### PR TITLE
feat: 대화 관리 REST API 5개 구현

### DIFF
--- a/.sisyphus/plans/2026-04-27-chat-management-api/plan.md
+++ b/.sisyphus/plans/2026-04-27-chat-management-api/plan.md
@@ -1,0 +1,101 @@
+# 대화 관리 REST API 5개
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-04-27
+- 상태: approved
+- 최종 결정: APPROVED
+
+> GitHub Issue: feat/#3
+
+## 1. 요구사항
+
+대화 관리 REST API 5개 구현. 사이드바 채팅 목록, 대화 히스토리, 제목 수정, 삭제 기능의 백엔드.
+인증(JWT)은 한정수 작업 중 — 인증 placeholder로 먼저 구현 후 연동.
+
+| Method | URL | 기능 |
+|---|---|---|
+| GET | `/api/v1/chats` | 채팅 목록 조회 (cursor 페이지네이션) |
+| GET | `/api/v1/chats/{thread_id}` | 채팅 상세 조회 (메타데이터) |
+| GET | `/api/v1/chats/{thread_id}/messages` | 메시지 전체 조회 (cursor 페이지네이션) |
+| PATCH | `/api/v1/chats/{thread_id}` | 대화 제목 수정 |
+| DELETE | `/api/v1/chats/{thread_id}` | 대화 삭제 (소프트 삭제) |
+
+## 2. 영향 범위
+
+- 신규 파일:
+  - `backend/src/api/chats.py` — FastAPI 라우터
+  - `backend/src/api/deps.py` — 인증 placeholder (`get_current_user_id`)
+  - `backend/src/models/chats.py` — Pydantic 요청/응답 모델
+- 수정 파일:
+  - `backend/src/main.py` — chats 라우터 등록
+- DB 스키마 영향: 없음 (conversations, messages 이미 존재)
+- 응답 블록 16종 영향: 없음 (REST API, SSE 아님)
+- intent 추가/변경: 없음
+- 외부 API 호출: 없음
+- FE 영향: 사이드바 채팅 목록 + 대화 히스토리 로딩에 사용될 API
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — conversations BIGINT, messages BIGINT
+- [x] PG↔OS 동기화 — 해당 없음 (대화 테이블은 OS 미연동)
+- [x] append-only 4테이블 미수정 — messages SELECT만. INSERT는 이 PR 범위 밖 (SSE에서 담당)
+- [x] 소프트 삭제 매트릭스 준수 — conversations.is_deleted = true로 소프트 삭제
+- [x] 의도적 비정규화 3건 외 신규 비정규화 없음
+- [x] 6 지표 스키마 보존 — 해당 없음
+- [x] gemini-embedding-001 768d 사용 — 해당 없음
+- [x] asyncpg 파라미터 바인딩 ($1, $2) — 전 쿼리 적용
+- [x] Optional[str] 사용 (str | None 금지)
+- [x] SSE 이벤트 타입 16종 한도 준수 — 해당 없음 (REST)
+- [x] intent별 블록 순서 (기획 §4.5) 준수 — 해당 없음
+- [x] 공통 쿼리 전처리 경유 — 해당 없음
+- [x] 행사 검색 DB 우선 → Naver fallback — 해당 없음
+- [x] 대화 이력 이원화 보존 — messages(UI용 append-only) 읽기만. checkpoint 미접촉
+- [x] 인증 매트릭스 준수 — placeholder로 구현, JWT 연동 시 교체
+- [x] 북마크 = 대화 위치 패러다임 준수 — 해당 없음
+- [x] 공유링크 인증 우회 범위 정확 — 해당 없음
+- [x] Phase 라벨 명시 — P1
+- [x] 기획 문서 우선 — API 명세서 v2 DB 기준
+
+## 4. 작업 순서 (Atomic step)
+
+1. `backend/src/models/chats.py` — Pydantic 요청/응답 모델
+   - ChatListItem, ChatDetail, MessageItem
+   - ChatListResponse (cursor 포함), MessageListResponse (cursor 포함)
+   - ChatUpdateRequest (title)
+
+2. `backend/src/api/deps.py` — 인증 placeholder
+   - `get_current_user_id()` → 임시 user_id 반환
+   - TODO 주석으로 JWT 교체 지점 명시
+
+3. `backend/src/api/chats.py` — 라우터 5개
+   - 공통: 모든 {thread_id} 엔드포인트에 소유권 검증 (user_id 일치 + is_deleted=false). 미소유/삭제됨 → 404
+   - GET /api/v1/chats — conversations에서 user_id + is_deleted=false, updated_at DESC, cursor 페이지네이션
+   - GET /api/v1/chats/{thread_id} — 단일 conversation 메타데이터. 미존재/삭제됨 → 404
+   - GET /api/v1/chats/{thread_id}/messages — messages에서 thread_id, message_id 기반 cursor, ASC 정렬. conversation 삭제됨 → 404
+   - PATCH /api/v1/chats/{thread_id} — title UPDATE + updated_at 갱신
+   - DELETE /api/v1/chats/{thread_id} — is_deleted = true + updated_at 갱신
+   - 모듈 docstring에 messages append-only 경고 포함
+
+4. `backend/src/main.py` — chats_router include
+
+5. `backend/tests/test_chats.py` — 최소 테스트 (200, 404, 소프트삭제 시나리오)
+
+6. validate.sh 통과 확인
+
+## 5. 검증 계획
+
+- `./validate.sh` 통과 (ruff + pyright + pytest)
+- `cd backend && source venv/bin/activate && python -m uvicorn src.main:app --reload` 후:
+  - `curl localhost:8000/api/v1/chats` → 200 빈 목록
+  - `curl -X PATCH localhost:8000/api/v1/chats/test-thread -d '{"title":"새제목"}'` → 동작 확인
+- messages INSERT 쿼리 없음 (grep 확인)
+
+## 6. Metis/Momus 리뷰
+
+- Metis (전술적 분석): reviews/001-metis-*.md 참조
+- Momus (엄격한 검토): reviews/002-momus-*.md 참조
+
+## 7. 최종 결정
+
+APPROVED (001-metis-okay → 002-momus-approved)

--- a/.sisyphus/plans/2026-04-27-chat-management-api/reviews/001-metis-okay.md
+++ b/.sisyphus/plans/2026-04-27-chat-management-api/reviews/001-metis-okay.md
@@ -1,0 +1,12 @@
+# 001-metis-okay
+
+- 검토자: Metis (전술적 분석)
+- 판정: **okay**
+- 일시: 2026-04-27
+
+## 권고사항 (reject 아님)
+
+1. 모든 `{thread_id}` 엔드포인트에 소유권 검증 (user_id 일치) + is_deleted 필터
+2. 삭제된 conversation의 messages 접근 시 404 반환
+3. `tests/test_chats.py` 추가 (200, 404, 소프트삭제 시나리오)
+4. messages append-only 경고 주석을 라우터 docstring에 포함

--- a/.sisyphus/plans/2026-04-27-chat-management-api/reviews/002-momus-approved.md
+++ b/.sisyphus/plans/2026-04-27-chat-management-api/reviews/002-momus-approved.md
@@ -1,0 +1,17 @@
+# 002-momus-approved
+
+- 검토자: Momus (엄격한 검토)
+- 판정: **approved**
+- 일시: 2026-04-27
+
+## 검증 결과
+
+- 신규 3파일 경로 충돌 없음, main.py 존재 확인
+- conversations/messages 스키마 ERD v6.3과 일치
+- 19 불변식 전 항목 실질 근거 존재 (#3 append-only, #4 소프트 삭제, #14 이원화)
+- API 명세서 CSV에서 5개 엔드포인트 전부 확인
+- 소프트 삭제 시 FK CASCADE 미트리거 → messages 보존 → 불변식 #3 부합
+
+## 요구 수정사항
+
+없음.

--- a/backend/src/api/chats.py
+++ b/backend/src/api/chats.py
@@ -1,0 +1,436 @@
+"""대화 관리 REST API — 5개 엔드포인트.
+
+⚠️ messages 테이블은 append-only (불변식 #3).
+   이 모듈에서 messages에 대한 UPDATE/DELETE는 절대 금지.
+   INSERT도 이 모듈 범위 밖 (SSE 핸들러에서 담당).
+
+conversations 테이블만 UPDATE (제목 수정) / 소프트 삭제 (is_deleted=true).
+모든 {thread_id} 엔드포인트에서 소유권 검증 (user_id 일치 + is_deleted=false).
+
+--- FastAPI + asyncpg 기본 개념 ---
+
+1) 라우터 (APIRouter):
+   - 관련 엔드포인트를 그룹으로 묶는 객체.
+   - @router.get("/경로"), @router.post("/경로") 등으로 엔드포인트 등록.
+   - prefix="/api/v1/chats" 설정하면 모든 경로 앞에 자동으로 붙는다.
+   - main.py에서 app.include_router(router)로 앱에 연결.
+
+2) Depends():
+   - 엔드포인트 파라미터에 Depends(함수)를 넣으면, 요청마다 그 함수가 먼저 실행된다.
+   - 반환값이 파라미터에 주입됨. 인증, DB 세션 등에 사용.
+   - 예: user_id: int = Depends(get_current_user_id)
+
+3) Query():
+   - URL의 쿼리 파라미터를 정의. 예: GET /chats?cursor=xxx&limit=20
+   - Query(None) = 선택적, Query(20, ge=1, le=100) = 기본값 20, 범위 1~100
+
+4) asyncpg 쿼리 메서드:
+   - pool.fetch(sql, *args)     → 여러 행 반환 (list[Record])
+   - pool.fetchrow(sql, *args)  → 단일 행 반환 (Record 또는 None)
+   - pool.execute(sql, *args)   → 행 반환 없이 실행 (INSERT/UPDATE/DELETE)
+   - SQL 안에서 $1, $2, $3... 으로 파라미터 바인딩 (f-string 금지, SQL injection 방지)
+   - Record는 dict처럼 r["column_name"]으로 접근 가능
+
+5) HTTPException:
+   - FastAPI가 제공하는 에러 응답. raise하면 해당 HTTP 상태코드로 응답.
+   - 예: raise HTTPException(status_code=404, detail="메시지") → 404 JSON 응답
+
+6) response_model:
+   - @router.get("/경로", response_model=SomeModel) 이렇게 설정하면:
+     a) 응답을 SomeModel 형태로 자동 직렬화 (JSON)
+     b) Swagger 문서에 응답 스키마 자동 표시
+     c) 모델에 정의 안 된 필드는 자동 제거 (보안)
+
+7) 경로 파라미터 vs 쿼리 파라미터:
+   - 경로: @router.get("/{thread_id}") → URL 경로에 포함. 필수값.
+     예: GET /api/v1/chats/abc-123 → thread_id = "abc-123"
+   - 쿼리: Query()로 정의 → URL ?key=value. 선택값 가능.
+     예: GET /api/v1/chats?cursor=xxx&limit=20
+
+8) async/await:
+   - async def: 이 함수는 비동기로 실행된다 (중간에 다른 요청 처리 가능)
+   - await: DB 조회처럼 시간이 걸리는 작업을 기다리는 동안 다른 요청을 처리
+   - 동기(sync)면 DB 응답 올 때까지 서버 전체가 멈춤. 비동기면 그 사이 다른 요청 처리.
+"""
+
+from __future__ import annotations  # 타입 힌트를 문자열로 처리 (순환 import 방지)
+
+import json  # JSONB 컬럼이 문자열로 올 때 파싱용
+import logging  # 로그 출력용
+from typing import Optional  # Optional[str] = str 또는 None (불변식 #9)
+
+# FastAPI에서 가져오는 핵심 도구들
+from fastapi import (
+    APIRouter,  # 엔드포인트 그룹 생성
+    Depends,  # 의존성 주입 (인증 등)
+    HTTPException,  # 에러 응답 (404, 401 등)
+    Query,  # URL 쿼리 파라미터 정의
+)
+
+# 프로젝트 내부 모듈
+from src.api.deps import (  # pyright: ignore[reportMissingImports]  # 인증 placeholder → JWT 교체 예정
+    get_current_user_id,
+)
+from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]           # asyncpg 커넥션 풀 가져오기
+from src.models.chats import (  # pyright: ignore[reportMissingImports]                 # Pydantic 모델 (요청/응답 형태 정의)
+    ChatDetailResponse,
+    ChatListItem,
+    ChatListResponse,
+    ChatUpdateRequest,
+    ChatUpdateResponse,
+    MessageItem,
+    MessageListResponse,
+)
+
+logger = logging.getLogger(__name__)  # 이 파일 이름으로 로거 생성
+
+# APIRouter 생성:
+#   prefix="/api/v1/chats" → 아래 모든 @router.get("") 경로 앞에 자동으로 붙음
+#   tags=["chats"] → localhost:8000/docs (Swagger UI)에서 "chats" 그룹으로 표시
+router = APIRouter(prefix="/api/v1/chats", tags=["chats"])
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼: 소유권 검증
+# ---------------------------------------------------------------------------
+async def _get_conversation_or_404(thread_id: str, user_id: int) -> dict:
+    """thread_id로 conversation을 조회하고, 없으면 404를 던진다.
+
+    3가지 케이스를 한 번에 처리:
+      - thread_id 자체가 존재하지 않음 → 404
+      - 존재하지만 다른 user_id 소유 → 404 (정보 노출 방지를 위해 403이 아닌 404)
+      - 존재하지만 is_deleted=true (소프트 삭제됨) → 404
+
+    모든 {thread_id} 엔드포인트가 가장 먼저 이 함수를 호출한다.
+    """
+    # get_pool(): main.py lifespan에서 초기화한 asyncpg 커넥션 풀을 가져온다.
+    # 이 풀은 서버 시작 시 한 번 만들어지고, 모든 요청이 공유한다.
+    pool = get_pool()
+
+    # pool.fetchrow(): SQL 실행 → 결과 1행 반환 (없으면 None)
+    # $1, $2: 파라미터 바인딩. f-string으로 SQL에 값을 직접 넣으면 SQL injection 위험.
+    #         $1에 thread_id, $2에 user_id가 안전하게 들어간다.
+    row = await pool.fetchrow(  # await: DB 응답 올 때까지 비동기 대기
+        """
+        SELECT conversation_id, thread_id, user_id, title, created_at, updated_at
+        FROM conversations
+        WHERE thread_id = $1 AND user_id = $2 AND is_deleted = false
+        """,
+        thread_id,  # → SQL의 $1 자리에 들어감
+        user_id,  # → SQL의 $2 자리에 들어감
+    )
+
+    # fetchrow 결과가 None = 조건에 맞는 행이 없음 → 404 에러
+    if row is None:
+        # raise HTTPException: 여기서 함수 실행이 중단되고,
+        # FastAPI가 {"detail": "대화를 찾을 수 없습니다"} JSON을 404로 응답
+        raise HTTPException(status_code=404, detail="대화를 찾을 수 없습니다")
+
+    # asyncpg Record를 일반 dict로 변환해서 반환
+    # dict(row) → {"conversation_id": 1, "thread_id": "abc", "title": "...", ...}
+    return dict(row)
+
+
+# ---------------------------------------------------------------------------
+# 1. GET /api/v1/chats — 채팅 목록 조회
+# ---------------------------------------------------------------------------
+
+
+# @router.get("", ...) → prefix + "" = GET /api/v1/chats
+# response_model=ChatListResponse → 반환값을 이 Pydantic 모델로 자동 JSON 변환
+@router.get("", response_model=ChatListResponse)
+async def list_chats(
+    # --- 파라미터 설명 ---
+    # cursor: URL에서 ?cursor=2026-04-27T12:00:00 으로 전달되는 값
+    #   Query(None) = 기본값 None (첫 요청 시 안 보내도 됨)
+    #   Optional[str] = 문자열 또는 None
+    cursor: Optional[str] = Query(None, description="페이지네이션 커서 (updated_at ISO)"),
+    # limit: URL에서 ?limit=50 으로 전달. 기본값 20. 최소 1, 최대 100.
+    #   범위 밖 값(0이나 999)이 오면 FastAPI가 자동으로 422 에러 반환
+    limit: int = Query(20, ge=1, le=100),
+    # user_id: URL에서 오는 게 아님! Depends()가 get_current_user_id()를 실행하고
+    #   그 반환값(지금은 1)을 여기에 넣어줌. JWT 연동 후에는 토큰에서 추출한 실제 user_id.
+    user_id: int = Depends(get_current_user_id),
+) -> ChatListResponse:
+    """사용자의 채팅 목록을 최신순으로 반환.
+
+    cursor 페이지네이션:
+      - 첫 요청: cursor 없이 → 최신 limit건 반환
+      - 다음 페이지: 응답의 next_cursor를 cursor에 넣어서 재요청
+      - next_cursor가 null이면 마지막 페이지
+
+    왜 offset이 아닌 cursor?
+      - offset은 중간에 데이터가 추가/삭제되면 중복/누락 발생
+      - cursor(updated_at)는 정렬 기준이므로 안정적
+    """
+    pool = get_pool()  # asyncpg 커넥션 풀 가져오기
+
+    # --- cursor 유무에 따라 다른 SQL ---
+    if cursor:
+        # 2페이지 이후: "이전 페이지 마지막 항목의 updated_at보다 오래된" 대화만 가져옴
+        # pool.fetch(): fetchrow와 달리 여러 행을 list로 반환
+        rows = await pool.fetch(
+            """
+            SELECT thread_id, title, updated_at
+            FROM conversations
+            WHERE user_id = $1           -- 현재 사용자 소유
+              AND is_deleted = false      -- 삭제 안 된 것만
+              AND updated_at < $2         -- cursor보다 오래된 것 (다음 페이지)
+            ORDER BY updated_at DESC      -- 최신순 정렬
+            LIMIT $3                      -- 가져올 개수
+            """,
+            user_id,  # $1: 현재 사용자
+            cursor,  # $2: 이전 페이지 마지막 항목의 updated_at
+            limit + 1,  # $3: 요청한 것보다 1개 더 가져옴 (아래에서 다음 페이지 존재 판단용)
+        )
+    else:
+        # 첫 페이지: cursor 없이 가장 최근 대화부터
+        rows = await pool.fetch(
+            """
+            SELECT thread_id, title, updated_at
+            FROM conversations
+            WHERE user_id = $1 AND is_deleted = false
+            ORDER BY updated_at DESC
+            LIMIT $2
+            """,
+            user_id,
+            limit + 1,  # 여기서도 1개 더 가져옴
+        )
+
+    # --- 다음 페이지 존재 여부 판단 ---
+    # limit=20인데 21개가 왔으면 → 다음 페이지 있음
+    # limit=20인데 15개가 왔으면 → 마지막 페이지
+    has_more = len(rows) > limit
+    items = rows[:limit]  # 실제 반환할 항목만 잘라냄 (21번째는 버림)
+
+    # --- Pydantic 모델로 변환해서 반환 ---
+    # FastAPI가 이걸 자동으로 JSON으로 변환해서 클라이언트에 보낸다
+    return ChatListResponse(
+        # list comprehension: rows의 각 행(r)을 ChatListItem으로 변환
+        # r["thread_id"]: asyncpg Record에서 컬럼값 꺼내기 (dict처럼)
+        items=[
+            ChatListItem(
+                thread_id=r["thread_id"],  # DB의 thread_id 컬럼 값
+                title=r["title"],  # DB의 title 컬럼 값 (null 가능)
+                updated_at=r["updated_at"],  # DB의 updated_at 컬럼 값
+            )
+            for r in items  # items 리스트의 각 행에 대해 반복
+        ],
+        # 다음 페이지가 있으면: 마지막 항목의 updated_at을 ISO 문자열로 변환해서 커서 반환
+        # 없으면: None → JSON에서 null → FE가 "더 이상 로딩할 것 없음" 판단
+        next_cursor=items[-1]["updated_at"].isoformat() if has_more and items else None,
+        # items[-1]: 리스트의 마지막 항목
+        # .isoformat(): datetime → "2026-04-27T12:00:00+09:00" 문자열 변환
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. GET /api/v1/chats/{thread_id} — 채팅 상세 조회
+# ---------------------------------------------------------------------------
+
+
+# "/{thread_id}" → URL 경로의 일부. 예: GET /api/v1/chats/abc-123 → thread_id = "abc-123"
+# 경로 파라미터는 Query()와 달리 필수값. 안 보내면 404 (경로 자체가 없으므로)
+@router.get("/{thread_id}", response_model=ChatDetailResponse)
+async def get_chat(
+    thread_id: str,  # URL 경로에서 자동 추출: /chats/abc-123 → "abc-123"
+    user_id: int = Depends(get_current_user_id),  # 인증에서 주입
+) -> ChatDetailResponse:
+    """특정 채팅의 메타데이터만 반환. 메시지는 포함하지 않음.
+
+    메시지는 별도 API (GET /chats/{thread_id}/messages)로 분리.
+    이유: 메시지가 수백 건일 때 메타데이터 조회에 전부 끌려오면 낭비.
+    """
+    # 소유권 검증: 이 thread_id가 현재 user_id 소유이고 삭제 안 됐는지 확인
+    # 실패 시 이 함수 내부에서 HTTPException(404)이 raise되어 여기로 안 돌아옴
+    conv = await _get_conversation_or_404(thread_id, user_id)
+
+    # conv는 dict: {"thread_id": "abc", "title": "제목", "created_at": datetime, ...}
+    # 이걸 Pydantic 모델로 감싸서 반환 → FastAPI가 JSON으로 변환
+    return ChatDetailResponse(
+        thread_id=conv["thread_id"],
+        title=conv["title"],
+        created_at=conv["created_at"],
+        updated_at=conv["updated_at"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. GET /api/v1/chats/{thread_id}/messages — 메시지 전체 조회
+# ---------------------------------------------------------------------------
+
+
+# "/{thread_id}/messages" → /api/v1/chats/abc-123/messages
+# thread_id는 경로에서, cursor/limit는 쿼리 파라미터에서 온다
+@router.get("/{thread_id}/messages", response_model=MessageListResponse)
+async def list_messages(
+    thread_id: str,  # 경로: /chats/{이 값}/messages
+    cursor: Optional[str] = Query(None, description="페이지네이션 커서 (message_id)"),
+    limit: int = Query(50, ge=1, le=200),  # 메시지는 채팅 목록보다 많이 가져와도 됨
+    user_id: int = Depends(get_current_user_id),
+) -> MessageListResponse:
+    """특정 대화의 메시지 목록을 오래된 순(ASC)으로 반환.
+
+    왜 ASC?
+      - 채팅 UI에서 위=오래된, 아래=최신이 자연스러움
+      - cursor는 message_id 기반 (BIGSERIAL이라 정렬 안정적)
+
+    messages 테이블은 append-only (불변식 #3):
+      - 이 함수는 SELECT만 수행
+      - INSERT는 SSE 핸들러가 담당
+      - UPDATE/DELETE는 이 모듈 어디에도 없음
+    """
+    # 먼저 이 대화가 현재 사용자 소유인지, 삭제되지 않았는지 확인
+    # → 다른 사람의 메시지를 볼 수 없게 방어
+    await _get_conversation_or_404(thread_id, user_id)
+
+    pool = get_pool()
+
+    if cursor:
+        # 다음 페이지: "이 message_id보다 큰(=나중에 생성된) 메시지"부터
+        rows = await pool.fetch(
+            """
+            SELECT message_id, role, blocks, created_at
+            FROM messages
+            WHERE thread_id = $1 AND message_id > $2
+            ORDER BY message_id ASC
+            LIMIT $3
+            """,
+            thread_id,  # $1: 어떤 대화의 메시지인지
+            int(cursor),  # $2: 이전 페이지 마지막 message_id (문자열→정수 변환)
+            limit + 1,  # $3: 다음 페이지 존재 여부 판단용
+        )
+    else:
+        # 첫 페이지: 가장 오래된 메시지부터
+        rows = await pool.fetch(
+            """
+            SELECT message_id, role, blocks, created_at
+            FROM messages
+            WHERE thread_id = $1
+            ORDER BY message_id ASC
+            LIMIT $2
+            """,
+            thread_id,
+            limit + 1,
+        )
+
+    has_more = len(rows) > limit
+    items = rows[:limit]
+
+    return MessageListResponse(
+        items=[
+            MessageItem(
+                message_id=r["message_id"],  # DB PK (BIGSERIAL, 자동 증가 정수)
+                role=r["role"],  # "user" 또는 "assistant"
+                # blocks: DB에 JSONB로 저장된 응답 블록 배열
+                # 예: [{"type": "text_stream", "content": "홍대에는..."}, {"type": "places", "items": [...]}]
+                #
+                # asyncpg는 JSONB를 보통 Python dict/list로 자동 변환해주지만,
+                # DB 설정이나 asyncpg 버전에 따라 JSON 문자열(str)로 오는 경우가 있다.
+                # isinstance 체크로 두 케이스 모두 처리:
+                #   - str이면: json.loads()로 파싱 → dict/list
+                #   - dict/list이면: 그대로 사용
+                blocks=json.loads(r["blocks"]) if isinstance(r["blocks"], str) else r["blocks"],
+                created_at=r["created_at"],
+            )
+            for r in items
+        ],
+        # message_id(정수)를 문자열로 변환해서 커서로 사용
+        # 왜 문자열? → URL 쿼리 파라미터는 항상 문자열이므로 통일
+        next_cursor=str(items[-1]["message_id"]) if has_more and items else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. PATCH /api/v1/chats/{thread_id} — 대화 제목 수정
+# ---------------------------------------------------------------------------
+
+
+# @router.patch: HTTP PATCH 메서드. 리소스의 일부만 수정할 때 사용.
+# (PUT은 전체 교체, PATCH는 부분 수정 — REST 관례)
+@router.patch("/{thread_id}", response_model=ChatUpdateResponse)
+async def update_chat_title(
+    thread_id: str,  # 경로: /chats/{이 값}
+    body: ChatUpdateRequest,  # 요청 body: {"title": "새 제목"}
+    #   ↑ Query()나 Depends()가 아닌 Pydantic 모델을 파라미터로 넣으면
+    #     FastAPI가 자동으로 request body JSON을 파싱해서 이 모델로 변환한다.
+    #     타입이 안 맞으면 422 Validation Error 자동 반환.
+    user_id: int = Depends(get_current_user_id),
+) -> ChatUpdateResponse:
+    """대화 제목을 수정. updated_at도 갱신되어 채팅 목록 정렬에 반영됨.
+
+    RETURNING으로 UPDATE 결과를 바로 반환 — 추가 SELECT 불필요.
+    """
+    # 소유권 검증: 내 대화가 맞는지, 삭제 안 됐는지
+    await _get_conversation_or_404(thread_id, user_id)
+
+    pool = get_pool()
+
+    # pool.fetchrow(): UPDATE + RETURNING → 수정된 행 1개를 바로 반환
+    # RETURNING이 없으면 UPDATE 후 다시 SELECT해야 함 (쿼리 2번 → 1번으로 절약)
+    row = await pool.fetchrow(
+        """
+        UPDATE conversations
+        SET title = $1,          -- 새 제목으로 변경
+            updated_at = now()   -- 수정 시각 갱신 (채팅 목록 정렬에 반영)
+        WHERE thread_id = $2 AND user_id = $3 AND is_deleted = false
+        RETURNING thread_id, title, updated_at   -- 수정된 결과를 바로 반환
+        """,
+        body.title,  # $1: 새 제목 (request body에서 온 값)
+        thread_id,  # $2: 대화 식별자
+        user_id,  # $3: 소유권 재확인 — 왜 또?
+        #   → _get_conversation_or_404와 UPDATE 사이에 다른 요청이
+        #     이 대화를 삭제할 수 있음 (race condition). WHERE에서 한 번 더 확인.
+    )
+
+    # RETURNING 결과가 None = WHERE 조건에 맞는 행이 없음 (삭제됨 등)
+    if row is None:
+        raise HTTPException(status_code=404, detail="대화를 찾을 수 없습니다")
+
+    return ChatUpdateResponse(
+        thread_id=row["thread_id"],
+        title=row["title"],  # DB에서 반환된 새 제목
+        updated_at=row["updated_at"],  # now()로 갱신된 시각
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. DELETE /api/v1/chats/{thread_id} — 대화 삭제 (소프트 삭제)
+# ---------------------------------------------------------------------------
+
+
+# status_code=204: 성공 시 HTTP 204 No Content 반환 (응답 body 없음)
+# REST 관례: DELETE 성공 시 body를 보내지 않는다
+@router.delete("/{thread_id}", status_code=204)
+async def delete_chat(
+    thread_id: str,
+    user_id: int = Depends(get_current_user_id),
+) -> None:  # → None: 반환값 없음 (204 No Content)
+    """대화를 소프트 삭제. 물리 삭제가 아닌 is_deleted=true 마킹.
+
+    왜 소프트 삭제?
+      - messages는 append-only (불변식 #3) → DELETE 불가
+      - 물리 DELETE하면 FK CASCADE가 messages를 삭제해버림
+      - is_deleted=true로 마킹만 하면 messages는 보존됨
+      - 목록 조회에서 is_deleted=false 필터로 안 보이게 처리
+
+    204 No Content: 성공 시 응답 본문 없음 (REST 관례).
+    """
+    # 소유권 검증 (이미 삭제된 대화면 404)
+    await _get_conversation_or_404(thread_id, user_id)
+
+    pool = get_pool()
+
+    # pool.execute(): 결과 행 없이 SQL만 실행 (fetchrow/fetch와 달리 반환값 없음)
+    # UPDATE이지 DELETE가 아님 → messages 테이블은 건드리지 않음
+    await pool.execute(
+        """
+        UPDATE conversations
+        SET is_deleted = true,    -- 소프트 삭제 마킹
+            updated_at = now()    -- 삭제 시각 기록
+        WHERE thread_id = $1 AND user_id = $2
+        """,
+        thread_id,  # $1: 삭제할 대화
+        user_id,  # $2: 소유권 재확인
+    )
+    # 반환값 없음 → FastAPI가 204 No Content로 응답

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -1,0 +1,31 @@
+"""공통 의존성 — 인증 placeholder.
+
+FastAPI의 Depends() 시스템:
+  - 라우터 함수의 파라미터에 Depends(함수)를 넣으면,
+    요청이 올 때마다 그 함수가 먼저 실행되고, 반환값이 파라미터에 주입된다.
+  - 예: user_id: int = Depends(get_current_user_id)
+    → 요청 들어옴 → get_current_user_id() 실행 → 반환값(1)이 user_id에 들어감
+  - 이렇게 하면 모든 라우터가 같은 인증 로직을 공유하고,
+    나중에 이 함수만 바꾸면 전체 API에 인증이 적용된다.
+
+TODO: 한정수 JWT 미들웨어 완성 후 get_current_user_id()를
+      Authorization 헤더 → JWT 디코딩 → user_id 추출로 교체.
+"""
+
+from __future__ import annotations
+
+
+async def get_current_user_id() -> int:
+    """현재 인증된 사용자 ID 반환.
+
+    지금은 임시로 user_id=1 반환 (인증 미구현).
+
+    JWT 연동 후에는 이렇게 바뀔 예정:
+      1. Request의 Authorization 헤더에서 "Bearer {token}" 추출
+      2. JWT 토큰 디코딩 → payload에서 user_id 꺼냄
+      3. 토큰 만료/위조 시 401 Unauthorized 반환
+
+    이 함수를 수정하면 Depends(get_current_user_id)를 쓰는
+    모든 엔드포인트에 자동 적용된다 (chats.py 5개 전부).
+    """
+    return 1

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,7 +1,12 @@
 """AnyWay backend — FastAPI 진입점.
 
-lifespan으로 DB pool / OS 클라이언트 초기화·해제.
-라우터: healthcheck + SSE.
+FastAPI 앱 객체를 생성하고, 서버 시작/종료 시 DB 커넥션 풀을 관리한다.
+각 API 라우터(chats, sse 등)를 여기서 등록한다.
+
+핵심 개념:
+  - FastAPI: Python 비동기 웹 프레임워크. Flask와 비슷하지만 async/await 네이티브.
+  - lifespan: 서버 시작 시 1번 실행 → yield → 서버 종료 시 1번 실행. DB 풀 관리에 사용.
+  - include_router: 다른 파일에서 정의한 엔드포인트 그룹을 앱에 연결.
 """
 
 from __future__ import annotations
@@ -20,22 +25,27 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(application: FastAPI) -> AsyncIterator[None]:
-    """앱 시작/종료 시 리소스 관리.
+    """서버 시작/종료 시 리소스를 관리하는 lifecycle 함수.
 
-    Startup:
-      1. asyncpg pool 초기화
-      2. OpenSearch 클라이언트 초기화
-    Shutdown:
-      1. OpenSearch 클라이언트 종료
-      2. asyncpg pool 종료
+    사용 이유:
+      - DB 커넥션 풀은 서버 시작 시 한 번 만들고, 모든 요청이 공유한다.
+      - 매 요청마다 새 DB 연결을 만들면 느리고 리소스 낭비.
+      - 서버 종료 시 풀을 닫아야 DB 연결이 깨끗하게 정리된다.
+
+    흐름:
+      1. 서버 시작 → yield 위쪽 코드 실행 (DB pool, OS client 초기화)
+      2. yield → 서버가 요청을 받기 시작
+      3. 서버 종료 → yield 아래쪽 코드 실행 (pool/client 정리)
     """
-    _ = application  # FastAPI convention
+    _ = application  # FastAPI가 넘겨주지만 여기선 안 쓴다
 
-    # --- Startup ---
+    # --- Startup: 서버가 뜰 때 1번 실행 ---
     from src.db.opensearch import init_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import init_pool  # pyright: ignore[reportMissingImports]
 
     try:
+        # asyncpg 커넥션 풀 생성 (min 2 ~ max 10 연결)
+        # 이후 모든 API 핸들러가 get_pool()로 이 풀을 가져다 쓴다
         await init_pool()
         logger.info("PostgreSQL pool initialized")
     except Exception:
@@ -47,9 +57,9 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.warning("OpenSearch client init failed (OS 미연결 시 정상)")
 
-    yield
+    yield  # ← 이 지점에서 서버가 요청을 받기 시작
 
-    # --- Shutdown ---
+    # --- Shutdown: 서버가 내려갈 때 1번 실행 ---
     from src.db.opensearch import close_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import close_pool  # pyright: ignore[reportMissingImports]
 
@@ -60,21 +70,32 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
     logger.info("PostgreSQL pool closed")
 
 
+# FastAPI 앱 객체 생성. uvicorn이 이 객체를 실행한다.
+# 실행 명령: python -m uvicorn src.main:app --reload
 app = FastAPI(
     title="AnyWay — LocalBiz Intelligence",
     description="서울 로컬 라이프 AI 챗봇",
     version="0.1.0",
-    lifespan=lifespan,
+    lifespan=lifespan,  # 위에서 정의한 lifecycle 함수 연결
 )
 
 
-# --- Routers ---
+# --- 라우터 등록 ---
+# 각 파일에서 정의한 router를 앱에 연결.
+# include_router 하면 해당 라우터의 모든 엔드포인트가 앱에 추가된다.
+# 예: chats_router의 GET /api/v1/chats → app.get("/api/v1/chats")로 등록
+from src.api.chats import router as chats_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.sse import router as sse_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 
-app.include_router(sse_router)
+app.include_router(chats_router)  # /api/v1/chats/* 엔드포인트 5개
+app.include_router(sse_router)  # /api/v1/chat/stream SSE 엔드포인트
 
 
 @app.get("/health")
 def health(verbose: Optional[bool] = None) -> dict[str, str]:
-    """Liveness probe — 컨테이너 헬스체크와 CI 확인용."""
+    """Liveness probe — 컨테이너 헬스체크와 CI 확인용.
+
+    Kubernetes/Docker에서 이 엔드포인트를 주기적으로 호출해서
+    서버가 살아있는지 확인한다.
+    """
     return health_check(verbose=verbose)

--- a/backend/src/models/chats.py
+++ b/backend/src/models/chats.py
@@ -1,0 +1,123 @@
+"""대화 관리 API — Pydantic 요청/응답 모델.
+
+Pydantic이란?
+  - Python 데이터 검증 라이브러리. FastAPI와 같이 쓴다.
+  - BaseModel을 상속받아 필드를 정의하면:
+    1) 요청 body를 자동으로 파싱 + 타입 검증 (잘못되면 422 에러)
+    2) 응답을 자동으로 JSON 직렬화
+  - FastAPI의 response_model에 넣으면 Swagger 문서도 자동 생성
+
+conversations, messages 테이블 기반.
+messages는 append-only (불변식 #3) — 이 모듈에서 INSERT/UPDATE/DELETE 모델 없음.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# 채팅 목록 조회 (GET /api/v1/chats)
+# ---------------------------------------------------------------------------
+class ChatListItem(BaseModel):
+    """채팅 목록에서 한 줄 = 이 모델 하나.
+
+    사이드바에 표시할 최소 정보만 담는다:
+      - thread_id: 대화 고유 식별자 (클릭 시 상세 조회에 사용)
+      - title: 대화 제목 (자동 생성 또는 사용자 수정)
+      - last_message: 마지막 메시지 미리보기 (아직 미구현, SSE 연동 후 추가)
+      - updated_at: 마지막 활동 시간 (정렬 기준)
+    """
+
+    thread_id: str
+    title: Optional[str] = None  # 제목 없는 새 대화는 null
+    last_message: Optional[str] = None  # 아직 미구현
+    updated_at: datetime
+
+
+class ChatListResponse(BaseModel):
+    """채팅 목록 API의 전체 응답.
+
+    cursor 페이지네이션:
+      - items: 이번 페이지의 채팅 목록
+      - next_cursor: 다음 페이지 요청 시 사용할 값. null이면 마지막 페이지.
+    """
+
+    items: list[ChatListItem] = Field(default_factory=list)
+    next_cursor: Optional[str] = None  # null이면 마지막 페이지
+
+
+# ---------------------------------------------------------------------------
+# 채팅 상세 조회 (GET /api/v1/chats/{thread_id})
+# ---------------------------------------------------------------------------
+class ChatDetailResponse(BaseModel):
+    """채팅 메타데이터. 메시지는 포함하지 않음 (별도 API).
+
+    FE가 대화를 열 때:
+      1) 이 API로 제목/시간 로딩
+      2) /messages API로 메시지 별도 로딩
+    """
+
+    thread_id: str
+    title: Optional[str] = None
+    created_at: datetime  # 대화 생성 시각
+    updated_at: datetime  # 마지막 활동 시각
+
+
+# ---------------------------------------------------------------------------
+# 메시지 조회 (GET /api/v1/chats/{thread_id}/messages)
+# ---------------------------------------------------------------------------
+class MessageItem(BaseModel):
+    """단일 메시지 = 이 모델 하나.
+
+    필드:
+      - message_id: DB PK (BIGSERIAL). cursor 페이지네이션에 사용.
+      - role: "user" (사용자 입력) 또는 "assistant" (AI 응답)
+      - blocks: 응답 블록 배열. JSONB로 저장된 16종 블록 (place, events, chart 등).
+                예: [{"type": "text_stream", "content": "홍대에는..."}, {"type": "places", "items": [...]}]
+      - created_at: 메시지 생성 시각
+    """
+
+    message_id: int
+    role: str  # "user" | "assistant"
+    blocks: list[dict[str, Any]] = Field(default_factory=list)  # JSONB 블록 배열
+    created_at: datetime
+
+
+class MessageListResponse(BaseModel):
+    """메시지 목록 API의 전체 응답.
+
+    ChatListResponse와 같은 cursor 패턴:
+      - next_cursor가 null이면 마지막 페이지
+      - 있으면 다음 요청에 ?cursor=값 으로 넘김
+    """
+
+    items: list[MessageItem] = Field(default_factory=list)
+    next_cursor: Optional[str] = None  # message_id를 문자열로 변환한 값
+
+
+# ---------------------------------------------------------------------------
+# 대화 제목 수정 (PATCH /api/v1/chats/{thread_id})
+# ---------------------------------------------------------------------------
+class ChatUpdateRequest(BaseModel):
+    """대화 제목 수정 요청 body.
+
+    FE에서 보내는 JSON: {"title": "새 제목"}
+    Pydantic이 자동으로 파싱하고, title이 없거나 타입이 다르면 422 반환.
+    """
+
+    title: str
+
+
+class ChatUpdateResponse(BaseModel):
+    """대화 제목 수정 후 응답.
+
+    UPDATE ... RETURNING으로 DB에서 바로 가져온 결과.
+    """
+
+    thread_id: str
+    title: str
+    updated_at: datetime  # now()로 갱신된 시각


### PR DESCRIPTION
## 관련 이슈번호: #3 

## 요약

- 대화 관리 REST API 5개 구현 (채팅 목록/상세/메시지 조회 + 제목 수정 + 소프트 삭제)
- 인증 placeholder (`deps.py`) — JWT 미들웨어 완성 후 교체 지점 단일화 
-> 회원가입 및 로그인에 관련한 로직이니, 정수가 확인해줘!  api/deps.py에 있어!
- cursor 페이지네이션 (채팅: updated_at, 메시지: message_id)
- 소유권 검증 헬퍼 (`_get_conversation_or_404`)
- messages append-only 준수 (SELECT만)

## 변경 파일

| 파일 | 설명 |
|---|---|
| `src/api/chats.py` | 신규 — 라우터 5개 + 소유권 검증 |
| `src/api/deps.py` | 신규 — 인증 placeholder |
| `src/models/chats.py` | 신규 — Pydantic 요청/응답 모델 7개 |
| `src/main.py` | 수정 — chats_router 등록 + 주석 보강 |
| `.sisyphus/plans/` | plan + Metis okay + Momus approved |
