### PR TITLE
[FEAT] SSE 채팅 파이프라인 실제 구현 (기존 stub → 동작 코드)

### DIFF
--- a/.sisyphus/dependency-maps/2026-04-27-sse-end-to-end.md
+++ b/.sisyphus/dependency-maps/2026-04-27-sse-end-to-end.md
@@ -1,0 +1,36 @@
+# 의존성 맵: 2026-04-27-sse-end-to-end
+
+| 항목 | 값 |
+|---|---|
+| plan_slug | 2026-04-27-sse-end-to-end |
+| plan_path | `.sisyphus/plans/2026-04-27-sse-end-to-end/plan.md` |
+| 생성일 | 2026-04-28 |
+
+## 카테고리별 step 분류
+
+| id | description | category | depends_on | parallelizable_with |
+|---|---|---|---|---|
+| 1 | `general_node.py` 신규 — Gemini 호출, text_stream 블록 | langgraph-node | [] | [2, 3] |
+| 2 | `response_builder_node.py` 신규 — done 블록 + 블록순서 검증 | langgraph-node | [] | [1, 3] |
+| 3 | `intent_router_node.py` 수정 — Gemini JSON mode 13 intent 분류 | langgraph-node | [] | [1, 2] |
+| 4 | `real_builder.py` — stub → actual import 3건 교체 | quick | [1, 2, 3] | [] |
+| 5 | `sse.py` — astream() 연동 + seed user + conversations + messages INSERT | deep | [4] | [] |
+| 6 | validate.sh + curl 관통 테스트 | quick | [5] | [] |
+
+## 그룹 + 실행 순서
+
+```
+g1 (병렬: step 1,2,3 — 노드 구현 3종)
+  ↓
+g2 (step 4 — real_builder.py import 교체)
+  ↓
+g3 (step 5 — sse.py 관통 연동)
+  ↓
+g4 (step 6 — 검증)
+```
+
+## 비고
+
+- g1 3개 노드는 서로 import 없음 → 완전 병렬
+- step 5 (sse.py)가 plan 볼륨의 ~40-50% (seed user, conversations, messages x2, astream loop, disconnect)
+- checkpointer=None (불변식 #14 P1 예외)

--- a/.sisyphus/dependency-maps/2026-04-27-sse-end-to-end.md
+++ b/.sisyphus/dependency-maps/2026-04-27-sse-end-to-end.md
@@ -19,7 +19,7 @@
 
 ## 그룹 + 실행 순서
 
-```
+```text
 g1 (병렬: step 1,2,3 — 노드 구현 3종)
   ↓
 g2 (step 4 — real_builder.py import 교체)

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/plan.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/plan.md
@@ -1,0 +1,127 @@
+# SSE end-to-end 관통 — LangGraph astream + GENERAL intent
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-04-27
+- 상태: approved
+- 최종 결정: APPROVED
+
+> 팀원 병목 해소: 정조셉(노드 구현), 이정원(FE SSE 연동)이 이 작업 완료 후 시작 가능.
+
+## 1. 요구사항
+
+"안녕" → Gemini가 SSE로 토큰 단위 응답하는 최소 동작 파이프라인.
+모든 intent 노드의 기반이 되는 첫 번째 관통 테스트.
+
+흐름:
+```
+GET /api/v1/chat/stream?thread_id=xxx&query=안녕
+  → sse.py: conversations 없으면 auto-create + user 메시지 INSERT (role='user')
+  → LangGraph astream() 호출
+  → intent_router_node: GENERAL로 분류
+  → query_preprocessor_node: stub (빈 dict 반환, 그래프 토폴로지 유지)
+  → general_node: Gemini astream()으로 토큰 생성
+  → response_builder_node: done 블록 추가
+  → sse.py: event: intent → event: text_stream × N → event: done
+  → assistant 메시지 INSERT (role='assistant', blocks=응답 블록)
+```
+
+전제 조건:
+- messages.thread_id → conversations(thread_id) FK 존재
+- conversations가 없으면 INSERT 실패 → sse.py에서 auto-create 처리
+- user 메시지 + assistant 메시지 양쪽 모두 저장해야 대화 이력 성립
+
+## 2. 영향 범위
+
+- 신규 파일:
+  - `backend/src/graph/general_node.py` — GENERAL intent Gemini 스트리밍
+  - `backend/src/graph/response_builder_node.py` — 블록 순서 검증 + done
+- 수정 파일:
+  - `backend/src/api/sse.py` — stub → LangGraph astream() 실제 연동
+  - `backend/src/graph/real_builder.py` — stub 함수 → 실제 import 교체 (general, response_builder, intent_router)
+  - `backend/src/graph/intent_router_node.py` — stub → Gemini JSON mode 분류
+- DB 스키마 영향: 없음 (messages INSERT만, 테이블 이미 존재)
+- 응답 블록 16종 영향: intent, text_stream, done 3종 사용 (기존 모델 그대로)
+- intent 추가/변경: 없음 (13 intent 그대로, 분류 로직 구현)
+- 외부 API 호출: Gemini 2.5 Flash (intent 분류 + 대화 응답)
+- FE 영향: 이 작업 완료 후 SSE 수신 테스트 가능
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — messages BIGINT PK
+- [x] PG↔OS 동기화 — 해당 없음
+- [x] append-only 4테이블 미수정 — messages INSERT만. UPDATE/DELETE 없음
+- [x] 소프트 삭제 매트릭스 준수 — 해당 없음
+- [x] 의도적 비정규화 3건 외 신규 비정규화 없음
+- [x] 6 지표 스키마 보존 — 해당 없음
+- [x] gemini-embedding-001 768d 사용 — 해당 없음 (LLM 호출, 임베딩 아님)
+- [x] asyncpg 파라미터 바인딩 ($1, $2) — messages INSERT에 적용
+- [x] Optional[str] 사용 (str | None 금지)
+- [x] SSE 이벤트 타입 16종 한도 준수 — intent/text_stream/done 사용 (추가 없음)
+- [x] intent별 블록 순서 (기획 §4.5) 준수 — GENERAL: intent → text_stream → done
+- [x] 공통 쿼리 전처리 경유 — GENERAL은 전처리 불필요 (일반 대화)
+- [x] 행사 검색 DB 우선 → Naver fallback — 해당 없음
+- [ ] 대화 이력 이원화 보존 — **P1 범위 예외**: checkpointer=None으로 checkpoint 비활성. messages INSERT(UI용)만 동작. PostgresSaver 연동 시 해소 예정.
+- [x] 인증 매트릭스 준수 — deps.py placeholder 사용
+- [x] 북마크 = 대화 위치 패러다임 준수 — 해당 없음
+- [x] 공유링크 인증 우회 범위 정확 — 해당 없음
+- [x] Phase 라벨 명시 — P1
+- [x] 기획 문서 우선 — 기획서 §4.5 GENERAL 블록 순서 준수
+
+## 4. 작업 순서 (Atomic step)
+
+1. `backend/src/graph/general_node.py` — 신규
+   - Gemini 2.5 Flash 호출 (google-generativeai SDK)
+   - text_stream 블록을 response_blocks에 append
+   - 스트리밍이 아닌 단일 응답으로 먼저 구현 (토큰 스트리밍은 sse.py에서 처리)
+
+2. `backend/src/graph/response_builder_node.py` — 신규
+   - response_blocks에 done 블록 추가
+   - intent별 블록 순서 검증 (GENERAL: intent → text_stream → done)
+
+3. `backend/src/graph/intent_router_node.py` — 수정
+   - stub → Gemini JSON mode로 13 intent 분류
+   - 분류 결과를 state["intent"]에 저장
+   - 실패 시 GENERAL fallback
+
+4. `backend/src/graph/real_builder.py` — 수정
+   - _general_node stub → actual general_node import
+   - _response_builder_node stub → actual import
+   - _intent_router_node stub → actual import
+
+5. `backend/src/api/sse.py` — 수정
+   - stub done 전송 → LangGraph astream() 실제 호출
+   - seed user 보장: user_id=1이 users 테이블에 없으면 INSERT (개발용, 인증 연동 전까지)
+   - conversations auto-create: thread_id로 조회 → 없으면 INSERT (user_id + thread_id)
+   - user 메시지 INSERT: role='user', blocks=[{"type":"text","content":query}]
+   - 각 노드 출력을 SSE 이벤트로 변환하여 전송
+   - 완료 후 assistant 메시지 INSERT: role='assistant', blocks=response_blocks
+   - INSERT 실패 시 로그만, 재시도/수정 없음 (append-only 정책)
+   - request.is_disconnected() 체크
+   - checkpointer: P1 최소 동작에서는 None (LangGraph checkpoint 미사용). 이후 PostgresSaver 연동.
+
+6. validate.sh 통과 + curl 테스트
+
+범위 제한:
+- event_recommend/calendar conditional edges 누락은 기존 상태. 이 plan에서는 건드리지 않음.
+  intent_router가 해당 intent를 분류해도 GENERAL fallback으로 처리.
+- query_preprocessor는 stub 유지 (빈 dict 반환). GENERAL은 검색이 아니므로 전처리 불필요.
+
+## 5. 검증 계획
+
+- `./validate.sh` 통과
+- `curl "localhost:8000/api/v1/chat/stream?thread_id=test&query=안녕"` → SSE 이벤트 스트리밍 확인
+  - event: intent (type: GENERAL)
+  - event: text_stream × N (Gemini 응답)
+  - event: done
+- messages 테이블에 블록 저장 확인 (postgres MCP로 SELECT)
+- request disconnect 시 스트리밍 중단 확인
+
+## 6. Metis/Momus 리뷰
+
+- Metis (전술적 분석): reviews/001-metis-*.md 참조
+- Momus (엄격한 검토): reviews/002-momus-*.md 참조
+
+## 7. 최종 결정
+
+APPROVED (Metis 003-okay + Momus 005-approved, 2026-04-28)

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/001-metis-reject.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/001-metis-reject.md
@@ -1,0 +1,16 @@
+# 001-metis-reject
+
+- 검토자: Metis (전술적 분석)
+- 판정: **reject**
+- 일시: 2026-04-27
+
+## 필수 수정 2건
+
+1. **messages INSERT FK 전제조건**: conversations 레코드 없이 INSERT 불가. sse.py에 conversation auto-create 로직 포함 필요.
+2. **user 메시지 INSERT 누락**: role='user' 메시지도 저장해야 대화 이력 성립.
+
+## 권장 3건
+
+3. 흐름도에 query_preprocessor 노드 반영
+4. checkpointer 구성 방안 명시 (P1에서는 None)
+5. event_recommend/calendar conditional edges 누락 — "이 plan 범위 밖" 명시

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/002-momus-reject.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/002-momus-reject.md
@@ -1,0 +1,5 @@
+# 002-momus-reject
+
+- 검토자: Momus
+- 판정: **reject**
+- 사유: Metis okay/approved 미존재. 절차상 Metis 재검토 선행 필요.

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/003-metis-okay.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/003-metis-okay.md
@@ -1,0 +1,14 @@
+# 003-metis-okay
+
+- 검토자: Metis (재검토)
+- 판정: **okay**
+- 일시: 2026-04-27
+
+## 001-reject 5건 반영 확인
+
+전부 반영됨. 필수 수정 0건.
+
+## 권장 (구현 시 주의)
+
+1. sse.py에 `Depends(get_current_user_id)` 주입 — conversations auto-create 시 FK 충족
+2. EVENT_RECOMMEND/CALENDAR → GENERAL 클램핑 가드 — conditional_edges 누락 보호

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/004-momus-reject.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/004-momus-reject.md
@@ -1,0 +1,11 @@
+# 004-momus-reject
+
+- 검토자: Momus
+- 판정: **reject**
+- 일시: 2026-04-27
+
+## 필수 수정 3건 (1건 오탐)
+
+1. **[오탐] 파일 부재** — feat/#3 브랜치에 sse.py, real_builder.py, intent_router_node.py 존재. 검사 환경 문제.
+2. **[유효] users FK 해결** — users 0 row + conversations.user_id NOT NULL FK. seed user 필요.
+3. **[유효] 불변식 #14 예외 선언** — checkpointer=None이면 이원화 불성립. [x] → 예외 선언.

--- a/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/005-momus-approved.md
+++ b/.sisyphus/plans/2026-04-27-sse-end-to-end/reviews/005-momus-approved.md
@@ -1,0 +1,24 @@
+# 005-momus-approved
+
+- 검토자: Momus (재검토)
+- 판정: **approved**
+- 일시: 2026-04-28
+
+## 004-reject 3건 해소 확인
+
+| # | 지적 | 해소 여부 | 확인 방법 |
+|---|---|---|---|
+| 1 | [오탐] 파일 부재 | N/A | feat/#3 브랜치 소재. main에는 미반영 정상 |
+| 2 | [유효] users FK seed | PASS | plan.md L94: seed user INSERT 명시 |
+| 3 | [유효] 불변식 #14 예외 | PASS | plan.md L64: `[ ]` + P1 범위 예외 + checkpointer=None 설명 |
+
+## 19 불변식 전수 검증: PASS (18/19 준수, #14 예외 선언 적정)
+
+## 관찰 사항 (비차단)
+
+1. seed user의 email/password_hash 값 미명시 — 구현 시 `dev@localhost` 등 충돌 없는 값 사용 권장.
+2. 단위 테스트 부재 — 이 plan 범위에서는 합리적이나, 후속 plan에서 pytest 커버리지 확보 필요.
+
+## 다음 액션
+
+- plan.md 최종 결정을 `APPROVED`로 갱신할 자격 부여.

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -105,18 +105,16 @@ async def _ensure_seed_user(pool: Any) -> int:
 
 
 async def _ensure_conversation(pool: Any, thread_id: str, user_id: int) -> None:
-    """conversations 테이블에 thread_id가 없으면 auto-create."""
-    row = await pool.fetchrow("SELECT thread_id FROM conversations WHERE thread_id = $1", thread_id)
-    if row:
-        return
+    """conversations 테이블에 thread_id가 없으면 auto-create.
 
+    ON CONFLICT DO NOTHING으로 동시 요청 race condition 방지.
+    """
     await pool.execute(
-        "INSERT INTO conversations (thread_id, user_id, title) VALUES ($1, $2, $3)",
+        "INSERT INTO conversations (thread_id, user_id, title) VALUES ($1, $2, $3) ON CONFLICT (thread_id) DO NOTHING",
         thread_id,
         user_id,
         "새 대화",
     )
-    logger.info("Conversation auto-created: thread_id=%s", thread_id)
 
 
 async def _insert_message(
@@ -192,9 +190,9 @@ async def chat_stream(
         from src.graph.real_builder import build_graph  # pyright: ignore[reportMissingImports]
 
         logger.info(
-            "SSE stream started: thread_id=%s, query=%s",
+            "SSE stream started: thread_id=%s, query_len=%d",
             thread_id,
-            query[:100],
+            len(query),
         )
 
         try:

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -5,12 +5,15 @@ intent별 블록 순서 고정. SSE(Server-Sent Events) 기반.
 
 결정 근거: 기획/SSE_vs_WebSocket_결정.md
 
-Phase 1 본작업에서 구현할 항목:
-  1. JWT 인증 (@microsoft/fetch-event-source로 Bearer 헤더)
-  2. LangGraph astream() 실행
-  3. 블록 순서에 맞춘 SSE 이벤트 전송
-  4. 에러/disconnect 처리 (request.is_disconnected())
-  5. messages 테이블 append (불변식 #3: append-only)
+흐름:
+  1. seed user 보장 (개발용)
+  2. conversations auto-create
+  3. user 메시지 INSERT
+  4. LangGraph astream() 실행
+  5. 각 노드 출력 블록을 SSE 이벤트로 전송
+  6. text_stream 블록 → Gemini astream()으로 토큰 스트리밍
+  7. assistant 메시지 INSERT (블록 목록)
+  8. done 이벤트 전송
 """
 
 from __future__ import annotations
@@ -23,6 +26,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
+from src.config import get_settings  # pyright: ignore[reportMissingImports]
 from src.models.blocks import (  # pyright: ignore[reportMissingImports]
     DoneBlock,
     StatusFrame,
@@ -76,6 +80,95 @@ def format_done_event(
 
 
 # ---------------------------------------------------------------------------
+# DB 헬퍼 — seed user, conversations, messages
+# ---------------------------------------------------------------------------
+async def _ensure_seed_user(pool: Any) -> int:
+    """개발용 seed user 보장. user_id=1 없으면 INSERT.
+
+    Returns:
+        user_id (int).
+    """
+    row = await pool.fetchrow("SELECT user_id FROM users WHERE user_id = $1", 1)
+    if row:
+        return int(row["user_id"])
+
+    await pool.execute(
+        "INSERT INTO users (user_id, email, auth_provider, password_hash) "
+        "VALUES ($1, $2, $3, $4) ON CONFLICT (user_id) DO NOTHING",
+        1,
+        "dev@localhost",
+        "email",
+        "dev_placeholder_hash",
+    )
+    logger.info("Seed user created: user_id=1, email=dev@localhost")
+    return 1
+
+
+async def _ensure_conversation(pool: Any, thread_id: str, user_id: int) -> None:
+    """conversations 테이블에 thread_id가 없으면 auto-create."""
+    row = await pool.fetchrow("SELECT thread_id FROM conversations WHERE thread_id = $1", thread_id)
+    if row:
+        return
+
+    await pool.execute(
+        "INSERT INTO conversations (thread_id, user_id, title) VALUES ($1, $2, $3)",
+        thread_id,
+        user_id,
+        "새 대화",
+    )
+    logger.info("Conversation auto-created: thread_id=%s", thread_id)
+
+
+async def _insert_message(
+    pool: Any,
+    thread_id: str,
+    role: str,
+    blocks: list[dict[str, Any]],
+) -> None:
+    """messages 테이블에 INSERT (append-only, 불변식 #3).
+
+    message_id는 BIGSERIAL auto-increment (불변식 #1).
+    """
+    blocks_json = json.dumps(blocks, ensure_ascii=False)
+    await pool.execute(
+        "INSERT INTO messages (thread_id, role, blocks) VALUES ($1, $2, $3::jsonb)",
+        thread_id,
+        role,
+        blocks_json,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gemini 토큰 스트리밍
+# ---------------------------------------------------------------------------
+async def _stream_gemini(system_prompt: str, user_prompt: str) -> AsyncIterator[str]:
+    """Gemini 2.5 Flash로 토큰 단위 스트리밍.
+
+    Yields:
+        각 토큰 문자열 (delta).
+    """
+    from langchain_google_genai import ChatGoogleGenerativeAI  # pyright: ignore[reportMissingImports]
+
+    settings = get_settings()
+    llm = ChatGoogleGenerativeAI(
+        model="gemini-2.5-flash",
+        google_api_key=settings.gemini_llm_api_key,
+        temperature=0.7,
+        streaming=True,
+    )
+
+    messages: list[tuple[str, str]] = [
+        ("system", system_prompt),
+        ("human", user_prompt),
+    ]
+
+    async for chunk in llm.astream(messages):
+        content = chunk.content
+        if content:
+            yield str(content)
+
+
+# ---------------------------------------------------------------------------
 # SSE 엔드포인트
 # ---------------------------------------------------------------------------
 @router.get("/api/v1/chat/stream")
@@ -87,14 +180,6 @@ async def chat_stream(
 ) -> StreamingResponse:
     """메인 채팅 SSE 엔드포인트.
 
-    Phase 1 본작업에서 다음 흐름으로 교체:
-      1. JWT 검증 (Authorization 헤더 또는 token query param)
-      2. LangGraph astream({"query": ..., "thread_id": ...})
-      3. 각 노드 출력 블록을 intent별 순서에 맞춰 SSE 이벤트 전송
-      4. 완료 시 done 이벤트 전송
-      5. messages 테이블에 블록 목록 append (불변식 #3)
-      6. 클라이언트 disconnect 시 request.is_disconnected()로 감지하여 중단
-
     Args:
         request: FastAPI Request (disconnect 감지용).
         thread_id: 대화 스레드 ID.
@@ -103,17 +188,77 @@ async def chat_stream(
     """
 
     async def event_generator() -> AsyncIterator[str]:
+        from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+        from src.graph.real_builder import build_graph  # pyright: ignore[reportMissingImports]
+
         logger.info(
-            "SSE stream started: thread_id=%s, query=%s, token=%s",
+            "SSE stream started: thread_id=%s, query=%s",
             thread_id,
             query[:100],
-            "present" if token else "none",
         )
 
         try:
-            # TODO: LangGraph astream() 실행 + 블록 순서 전송
-            # 지금은 stub — done만 전송
-            yield format_done_event(status="done")
+            # 1. DB 준비 — seed user + conversation
+            pool = get_pool()
+            user_id = await _ensure_seed_user(pool)
+            await _ensure_conversation(pool, thread_id, user_id)
+
+            # 2. user 메시지 INSERT
+            user_blocks: list[dict[str, Any]] = [{"type": "text", "content": query}]
+            await _insert_message(pool, thread_id, "user", user_blocks)
+
+            # 3. LangGraph astream() 실행
+            graph = build_graph(checkpointer=None)
+            input_state: dict[str, Any] = {
+                "query": query,
+                "thread_id": thread_id,
+                "user_id": user_id,
+                "conversation_history": [],
+            }
+
+            assistant_blocks: list[dict[str, Any]] = []
+
+            async for event in graph.astream(input_state):
+                if await request.is_disconnected():
+                    logger.info("Client disconnected: thread_id=%s", thread_id)
+                    return
+
+                # event는 {node_name: node_output} 형태
+                for _node_name, node_output in event.items():
+                    if not isinstance(node_output, dict):
+                        continue
+
+                    blocks = node_output.get("response_blocks", [])
+                    for block in blocks:
+                        if not isinstance(block, dict):
+                            continue
+
+                        block_type = block.get("type", "")
+
+                        if block_type == "text_stream":
+                            # Gemini 토큰 스트리밍
+                            system_prompt = block.get("system", "")
+                            user_prompt = block.get("prompt", query)
+                            full_text = ""
+
+                            async for delta in _stream_gemini(system_prompt, user_prompt):
+                                if await request.is_disconnected():
+                                    return
+                                full_text += delta
+                                yield format_sse_event("text_stream", {"type": "text_stream", "delta": delta})
+
+                            # 저장용 블록은 완성된 텍스트로 교체
+                            assistant_blocks.append({"type": "text_stream", "content": full_text})
+                        else:
+                            # 다른 블록은 그대로 전송 + 저장
+                            yield format_sse_event(block_type, block)
+                            assistant_blocks.append(block)
+
+            # 4. assistant 메시지 INSERT
+            try:
+                await _insert_message(pool, thread_id, "assistant", assistant_blocks)
+            except Exception:
+                logger.exception("assistant message INSERT failed: thread_id=%s", thread_id)
 
         except Exception:
             logger.exception("SSE error: thread_id=%s", thread_id)

--- a/backend/src/graph/general_node.py
+++ b/backend/src/graph/general_node.py
@@ -1,0 +1,58 @@
+"""GENERAL intent 노드 — 일반 대화 Gemini 스트리밍.
+
+사용자 쿼리에 대해 text_stream 블록을 response_blocks에 추가.
+sse.py가 이 블록을 받아서 Gemini astream()으로 토큰 단위 스트리밍.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# 시스템 프롬프트 — GENERAL intent 전용
+_SYSTEM_PROMPT = (
+    "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
+    "서울의 맛집, 카페, 문화행사, 코스 추천 등 로컬 정보에 특화되어 있습니다. "
+    "친절하고 자연스럽게 한국어로 대화하세요. "
+    "장소/행사 검색이나 추천이 필요한 질문이면 해당 기능을 안내하세요."
+)
+
+
+async def general_node(state: dict[str, Any]) -> dict[str, Any]:
+    """GENERAL intent 노드 — text_stream 블록 생성.
+
+    text_stream 블록에 system/prompt를 담으면 sse.py에서
+    Gemini astream()으로 토큰 단위 스트리밍 처리.
+
+    Args:
+        state: AgentState dict.
+
+    Returns:
+        {"response_blocks": [text_stream_block]}.
+    """
+    query = state.get("query", "")
+    history = state.get("conversation_history", [])
+
+    # 대화 이력을 프롬프트에 포함
+    prompt_parts: list[str] = []
+    for msg in history[-10:]:  # 최근 10턴만
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        prompt_parts.append(f"{role}: {content}")
+    prompt_parts.append(f"user: {query}")
+
+    prompt = "\n".join(prompt_parts) if len(prompt_parts) > 1 else query
+
+    logger.info("general_node: query=%s", query[:100])
+
+    return {
+        "response_blocks": [
+            {
+                "type": "text_stream",
+                "system": _SYSTEM_PROMPT,
+                "prompt": prompt,
+            }
+        ],
+    }

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -6,11 +6,14 @@ Gemini 2.5 Flash JSON-mode로 분류 (Phase 1 본작업에서 구현).
 
 from __future__ import annotations
 
-from enum import StrEnum
+import logging
+from enum import StrEnum  # pyright: ignore[reportAttributeAccessIssue]
 from typing import Any, Optional
 
+logger = logging.getLogger(__name__)
 
-class IntentType(StrEnum):
+
+class IntentType(StrEnum):  # pyright: ignore[reportAttributeAccessIssue]
     """기획서 section 3.1 — 15 intent (14+1). 추가/변경 시 PM 합의 + 기획서 동기화."""
 
     # Phase 1
@@ -34,7 +37,7 @@ class IntentType(StrEnum):
 
 
 # Phase 1 intent만 활성 라우팅 대상
-PHASE1_INTENTS: frozenset[IntentType] = frozenset(
+PHASE1_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssignmentType]
     {
         IntentType.PLACE_SEARCH,
         IntentType.PLACE_RECOMMEND,
@@ -50,14 +53,40 @@ PHASE1_INTENTS: frozenset[IntentType] = frozenset(
 )
 
 
+_GENERAL_FALLBACK: IntentType = IntentType.GENERAL  # pyright: ignore[reportAssignmentType]
+
+
+_CLASSIFY_SYSTEM_PROMPT = """\
+You are an intent classifier for a Seoul local-life AI chatbot.
+Classify the user query into exactly ONE of these intents:
+
+Phase 1 (active):
+- PLACE_SEARCH: searching for specific places (restaurants, cafes, etc.)
+- PLACE_RECOMMEND: asking for place recommendations
+- EVENT_SEARCH: searching for cultural events, festivals, exhibitions
+- EVENT_RECOMMEND: asking for event recommendations
+- COURSE_PLAN: planning a course/itinerary with multiple stops
+- DETAIL_INQUIRY: asking detailed info about a specific place or event
+- BOOKING: requesting a reservation or booking link
+- CALENDAR: adding an event to calendar
+- FAVORITE: bookmarking or favoriting something
+- GENERAL: general conversation, greetings, or anything else
+
+Phase 2 (not yet active, classify as GENERAL for now):
+- REVIEW_COMPARE, ANALYSIS, COST_ESTIMATE, CROWDEDNESS, IMAGE_SEARCH
+
+Respond in JSON: {"intent": "INTENT_NAME", "confidence": 0.0-1.0}
+"""
+
+
 async def classify_intent(
     query: str,
     conversation_history: Optional[list[dict[str, str]]] = None,
 ) -> tuple[IntentType, float]:
     """사용자 쿼리 → (IntentType, confidence) 분류.
 
-    Phase 1 stub: 항상 (GENERAL, 1.0) 반환.
-    본작업에서 Gemini 2.5 Flash JSON-mode 호출로 교체.
+    Gemini 2.5 Flash JSON-mode로 15 intent 중 하나를 분류.
+    실패 시 (GENERAL, 0.0) fallback.
 
     Args:
         query: 사용자 원본 쿼리.
@@ -66,9 +95,67 @@ async def classify_intent(
     Returns:
         (intent, confidence) 튜플.
     """
-    _ = query
-    _ = conversation_history
-    return (IntentType.GENERAL, 1.0)
+    import json
+
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    from src.config import get_settings  # pyright: ignore[reportMissingImports]
+
+    settings = get_settings()
+    if not settings.gemini_llm_api_key:
+        logger.warning("classify_intent: GEMINI_LLM_API_KEY 미설정 → GENERAL fallback")
+        return (_GENERAL_FALLBACK, 0.0)
+
+    try:
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+
+        messages: list[tuple[str, str]] = [("system", _CLASSIFY_SYSTEM_PROMPT)]
+
+        # 대화 이력 포함 (최근 5턴)
+        if conversation_history:
+            for msg in conversation_history[-5:]:
+                role = msg.get("role", "user")
+                content = msg.get("content", "")
+                lc_role = "human" if role == "user" else "ai"
+                messages.append((lc_role, content))
+
+        messages.append(("human", query))
+
+        response = await llm.ainvoke(messages)
+        text = str(response.content).strip()
+
+        # JSON 파싱
+        # Gemini가 ```json ... ``` 래핑할 수 있음
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+        intent_str = result.get("intent", "GENERAL")
+        confidence = float(result.get("confidence", 0.0))
+
+        # Phase 2 intent → GENERAL fallback
+        try:
+            intent = IntentType(intent_str)
+        except ValueError:
+            logger.warning("classify_intent: 알 수 없는 intent=%s → GENERAL", intent_str)
+            return (_GENERAL_FALLBACK, 0.0)
+
+        if intent not in PHASE1_INTENTS:
+            logger.info("classify_intent: Phase 2 intent=%s → GENERAL", intent.value)
+            return (_GENERAL_FALLBACK, confidence)
+
+        return (intent, confidence)
+
+    except Exception:
+        logger.exception("classify_intent failed → GENERAL fallback")
+        return (_GENERAL_FALLBACK, 0.0)
 
 
 async def intent_router_node(state: dict[str, Any]) -> dict[str, Any]:

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -36,7 +36,7 @@ class IntentType(StrEnum):  # pyright: ignore[reportAttributeAccessIssue]
     GENERAL = "GENERAL"
 
 
-# Phase 1 intent만 활성 라우팅 대상
+# Phase 1 intent (기획서 기준 전체 목록)
 PHASE1_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssignmentType]
     {
         IntentType.PLACE_SEARCH,
@@ -48,6 +48,20 @@ PHASE1_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssi
         IntentType.BOOKING,
         IntentType.CALENDAR,
         IntentType.FAVORITE,
+        IntentType.GENERAL,
+    }
+)
+
+# 실제 그래프에 라우팅 가능한 intent (real_builder.py conditional_edges 기준)
+# 여기에 없는 Phase 1 intent는 GENERAL fallback 처리
+_ROUTABLE_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssignmentType]
+    {
+        IntentType.PLACE_SEARCH,
+        IntentType.PLACE_RECOMMEND,
+        IntentType.EVENT_SEARCH,
+        IntentType.COURSE_PLAN,
+        IntentType.DETAIL_INQUIRY,
+        IntentType.BOOKING,
         IntentType.GENERAL,
     }
 )
@@ -149,6 +163,11 @@ async def classify_intent(
 
         if intent not in PHASE1_INTENTS:
             logger.info("classify_intent: Phase 2 intent=%s → GENERAL", intent.value)
+            return (_GENERAL_FALLBACK, confidence)
+
+        # 라우팅 맵에 없는 intent는 GENERAL fallback (노드 미구현)
+        if intent not in _ROUTABLE_INTENTS:
+            logger.info("classify_intent: 라우팅 불가 intent=%s → GENERAL", intent.value)
             return (_GENERAL_FALLBACK, confidence)
 
         return (intent, confidence)

--- a/backend/src/graph/real_builder.py
+++ b/backend/src/graph/real_builder.py
@@ -1,4 +1,4 @@
-"""LangGraph 그래프 빌더 — 노드/엣지 인터페이스 스텁.
+"""LangGraph 그래프 빌더 — 노드/엣지 구성.
 
 StateGraph(AgentState)를 구성하고 compiled graph를 반환.
 각 노드의 실제 로직은 별도 *_node.py 파일에서 구현.
@@ -15,18 +15,15 @@ from typing import Any, Optional
 
 from langgraph.graph import END, StateGraph
 
-from src.graph.state import AgentState
+from src.graph.general_node import general_node  # pyright: ignore[reportMissingImports]
+from src.graph.intent_router_node import intent_router_node  # pyright: ignore[reportMissingImports]
+from src.graph.response_builder_node import response_builder_node  # pyright: ignore[reportMissingImports]
+from src.graph.state import AgentState  # pyright: ignore[reportMissingImports]
 
 
 # ---------------------------------------------------------------------------
-# 노드 함수 스텁 — 각 *_node.py에서 실제 구현 후 import 교체
+# 아직 실제 구현이 없는 노드 스텁
 # ---------------------------------------------------------------------------
-async def _intent_router_node(state: AgentState) -> dict[str, Any]:
-    """Intent 분류 노드 stub. 실제 구현: intent_router_node.py."""
-    # TODO: from src.graph.intent_router_node import classify_intent
-    return {"intent": "GENERAL"}
-
-
 async def _query_preprocessor_node(state: AgentState) -> dict[str, Any]:
     """공통 쿼리 전처리 노드 stub (불변식 #12).
 
@@ -62,11 +59,6 @@ async def _course_plan_node(state: AgentState) -> dict[str, Any]:
     return {"response_blocks": []}
 
 
-async def _general_node(state: AgentState) -> dict[str, Any]:
-    """일반 대화 노드 stub (Gemini 호출)."""
-    return {"response_blocks": []}
-
-
 async def _detail_inquiry_node(state: AgentState) -> dict[str, Any]:
     """상세 조회 노드 stub."""
     return {"response_blocks": []}
@@ -79,11 +71,6 @@ async def _booking_node(state: AgentState) -> dict[str, Any]:
 
 async def _calendar_node(state: AgentState) -> dict[str, Any]:
     """일정 추가 노드 stub (Google Calendar MCP)."""
-    return {"response_blocks": []}
-
-
-async def _response_builder_node(state: AgentState) -> dict[str, Any]:
-    """응답 빌더 노드 — intent별 블록 순서 검증 + done 블록 추가."""
     return {"response_blocks": []}
 
 
@@ -134,19 +121,19 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
     """
     graph = StateGraph(AgentState)
 
-    # 노드 등록
-    graph.add_node("intent_router", _intent_router_node)
+    # 노드 등록 — 실제 구현 3종 + 스텁 나머지
+    graph.add_node("intent_router", intent_router_node)
     graph.add_node("query_preprocessor", _query_preprocessor_node)
     graph.add_node("place_search", _place_search_node)
     graph.add_node("place_recommend", _place_recommend_node)
     graph.add_node("event_search", _event_search_node)
     graph.add_node("event_recommend", _event_recommend_node)
     graph.add_node("course_plan", _course_plan_node)
-    graph.add_node("general", _general_node)
+    graph.add_node("general", general_node)
     graph.add_node("detail_inquiry", _detail_inquiry_node)
     graph.add_node("booking", _booking_node)
     graph.add_node("calendar", _calendar_node)
-    graph.add_node("response_builder", _response_builder_node)
+    graph.add_node("response_builder", response_builder_node)
 
     # 엣지 설정
     graph.set_entry_point("intent_router")

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -1,0 +1,96 @@
+"""response_builder 노드 — done 블록 추가 + intent별 블록 순서 검증.
+
+LangGraph 그래프의 마지막 노드. 모든 intent 노드가 response_blocks에
+블록을 누적한 뒤, 이 노드가:
+  1. done 블록 추가 (에러 시 status="error")
+  2. intent별 블록 순서 검증 (불변식 #11, 기획서 section 4.5)
+  3. 검증 실패 시 logger.warning만 (블록 제거하지 않음)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# intent별 기대 블록 순서 (기획서 section 4.5)
+# ---------------------------------------------------------------------------
+# 현재 GENERAL만 확정. 나머지 intent는 각 노드 구현 완료 후 추가.
+# TODO: PLACE_SEARCH, PLACE_RECOMMEND, EVENT_SEARCH, EVENT_RECOMMEND,
+#       COURSE_PLAN, DETAIL_INQUIRY, BOOKING, CALENDAR
+_EXPECTED_BLOCK_ORDER: dict[str, list[str]] = {
+    "GENERAL": ["intent", "text_stream", "done"],
+}
+
+
+# ---------------------------------------------------------------------------
+# 블록 순서 검증 헬퍼
+# ---------------------------------------------------------------------------
+def _validate_block_order(
+    intent: Optional[str],
+    block_types: list[str],
+) -> Optional[str]:
+    """intent별 기대 순서와 실제 블록 type 시퀀스를 비교.
+
+    Args:
+        intent: 분류된 intent 문자열. None이면 검증 스킵.
+        block_types: response_blocks의 type 시퀀스 (done 포함).
+
+    Returns:
+        불일치 시 경고 메시지 문자열, 일치 시 None.
+    """
+    if intent is None:
+        return "intent가 None — 블록 순서 검증 스킵"
+
+    expected = _EXPECTED_BLOCK_ORDER.get(intent)
+    if expected is None:
+        # 아직 순서가 정의되지 않은 intent — 검증 스킵
+        return None
+
+    if block_types != expected:
+        return f"블록 순서 불일치 [{intent}]: expected={expected}, actual={block_types}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 노드 함수
+# ---------------------------------------------------------------------------
+async def response_builder_node(state: dict[str, Any]) -> dict[str, Any]:
+    """response_blocks에 done 블록 추가 + 블록 순서 검증.
+
+    Args:
+        state: AgentState dict. response_blocks / intent / error 참조.
+
+    Returns:
+        {"response_blocks": [done_block]}
+        Annotated[list, operator.add]에 의해 기존 블록 뒤에 append.
+    """
+    error: Optional[str] = state.get("error")
+
+    # 1) done 블록 생성
+    if error:
+        done_block: dict[str, Any] = {
+            "type": "done",
+            "status": "error",
+            "error_message": error,
+        }
+    else:
+        done_block = {
+            "type": "done",
+            "status": "done",
+        }
+
+    # 2) 블록 순서 검증 (done 포함한 최종 시퀀스)
+    existing_blocks: list[dict[str, Any]] = state.get("response_blocks", [])
+    block_types = [b.get("type", "") for b in existing_blocks]
+    block_types.append("done")  # done은 아직 append 전이므로 수동 추가
+
+    intent: Optional[str] = state.get("intent")
+    warning = _validate_block_order(intent, block_types)
+    if warning is not None:
+        logger.warning("response_builder: %s", warning)
+
+    return {"response_blocks": [done_block]}

--- a/validate.sh
+++ b/validate.sh
@@ -90,10 +90,12 @@ master_files = [
     "기획/AGENTS.md",
 ]
 # 기능/API 명세서는 노션 DB가 source of truth (CSV export는 보조)
-import glob as _glob
-if not _glob.glob("기획/기능 명세서 *.csv"):
+# macOS NFD 유니코드 정규화 대응: glob 대신 os.listdir + NFC 비교
+import unicodedata as _ud
+_plan_files = [_ud.normalize("NFC", f) for f in os.listdir("기획")]
+if not any(f.startswith("기능 명세서") and f.endswith(".csv") for f in _plan_files):
     errors.append("기획 권위 문서 누락: 기획/기능 명세서 *.csv")
-if not _glob.glob("기획/API 명세서 *.csv"):
+if not any(f.startswith("API 명세서") and f.endswith(".csv") for f in _plan_files):
     errors.append("기획 권위 문서 누락: 기획/API 명세서 *.csv")
 for m in master_files:
     if not os.path.exists(m):


### PR DESCRIPTION
## 요약

  `GET /api/v1/chat/stream`이 더미 코드(done만 반환)였는데, 이제 실제로 동작합니다.

  - Gemini 2.5 Flash로 intent 분류 (15종)
  - Gemini 2.5 Flash로 대화 응답 생성 (토큰 단위 SSE 스트리밍)
  - user/assistant 메시지 DB 저장 (append-only)

  ## 변경 파일

  | 파일 | 변경 |
  |---|---|
  | `general_node.py` **(신규)** | GENERAL intent 노드 — text_stream 블록 생성 |
  | `response_builder_node.py` **(신규)** | done 블록 추가 + 블록 순서 검증 |
  | `intent_router_node.py` | 더미 → Gemini JSON mode 15 intent 분류 |
  | `real_builder.py` | 더미 함수 3개 → 실제 모듈 import 교체 |
  | `sse.py` | 더미 → astream + DB 저장 + Gemini 토큰 스트리밍 |

  ## 동작 확인

  curl -N "http://localhost:8000/api/v1/chat/stream?thread_id=test&query=안녕"

  event: intent        → {"intent": "GENERAL", "confidence": 1.0}
  event: text_stream   → {"delta": "안녕하세요! ..."} × N
  event: done          → {"status": "done"}

  DB에 user 메시지 + assistant 메시지 정상 저장 확인.

  ## 팀원 참고

  **이제 시작할 수 있는 작업:**
  - **이정원 (FE):** SSE 수신 연동
  - **정조셉/한정수/강민서 (BE):** `general_node.py`를 참고해서 각자 노드 구현

  **새 노드 추가 방법:**
  1. `src/graph/{노드}_node.py` 생성 (`general_node.py` 복사 → 수정)
  2. `real_builder.py`에서 더미 함수 지우고 import 교체
  3. `response_builder_node.py`에 블록 순서 추가

  ## 아직 안 된 것

  - JWT 인증 (placeholder 유지)
  - LangGraph checkpoint (대화 기억 안 됨)
  - 다른 intent 노드들 (각자 구현 예정)
  - pytest 단위 테스트

## 첨부파일
[SSE_End-to-End_구현_보고서_2026-04-28.docx](https://github.com/user-attachments/files/27170868/SSE_End-to-End_._._2026-04-28.docx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented end-to-end chat streaming with automatic conversation creation and persistence.
  * Added real-time token-by-token response streaming for chat interactions.
  * Upgraded intent classification to use real AI-based analysis instead of defaults.
  * Complete user message and assistant response block storage in chat history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->