### PR TITLE
feat: 닉네임 변경 API (#15)

### DIFF
--- a/.sisyphus/plans/2026-04-29-auth-nickname/plan.md
+++ b/.sisyphus/plans/2026-04-29-auth-nickname/plan.md
@@ -23,7 +23,7 @@
 - 보안: 본인 nickname만 변경 가능. 다른 사용자 user_id로 변경 시도 불가능 (deps.py가 토큰의 sub만 받기 때문에 자동 강제).
 - 동시성: UPDATE 단일 SQL이라 race window 없음. 같은 사용자 동시 변경 시 last-write-wins (운영상 허용).
 - 19 불변식 #15: auth_provider와 무관하게 nickname 변경 가능 (email/google 사용자 모두).
-- PII 보호 (CodeRabbit #3, 로그인 PR #2 학습 적용): 모든 logger 호출에 `_mask_email()` 사용.
+- PII 보호 (CodeRabbit #3, 로그인 PR #2 학습 적용): logger 호출 시 user_id 위주로 기록. email 인자가 있는 함수에서만 `_mask_email()` 사용.
 
 **범위 외 (다음 PR로 명시 분리)**:
 
@@ -138,7 +138,7 @@
 - ⚠️ is_deleted 체크 — 탈퇴자가 이전 토큰으로 nickname 변경 시도. UPDATE WHERE 절에 `is_deleted = FALSE` 명시. RETURNING None이면 404.
 - ⚠️ updated_at 갱신 — UPDATE 시 `updated_at = NOW()` 명시. 누락 시 19 불변식 #2 (timestamp) 위반.
 - ⚠️ auth_provider 무관 — email/google 사용자 모두 nickname 변경 가능 (명세 일치). UPDATE WHERE 절에 auth_provider 조건 안 넣음.
-- ⚠️ 닉네임 trim — 앞뒤 공백 처리. Pydantic의 `strip_whitespace=True`로 자동 처리 (NicknameUpdate 모델). 코드에서 추가 처리 불필요.
+- ⚠️ 닉네임 trim — 명세상 trim 요구 없음. NicknameUpdate 모델은 min_length/max_length만 검증 (빈 문자열 = 422). 앞뒤 공백은 보존 (회원이 공백 포함 닉네임 원할 수 있음).
 
 ## 7. 최종 결정
 

--- a/.sisyphus/plans/2026-04-29-auth-nickname/plan.md
+++ b/.sisyphus/plans/2026-04-29-auth-nickname/plan.md
@@ -1,0 +1,147 @@
+# 닉네임 변경 API (Issue #15)
+
+- Phase: P1
+- 요청자: 이정 (BE/PM)
+- 작성일: 2026-04-29
+- 의존: 회원가입 PR (#4 머지) + 로그인 PR (#21 머지)
+- 후속 의존성: 비밀번호 변경 PR(#?)이 본 PR의 user_service.py를 import하여 `change_password()` 추가
+
+## 1. 요구사항
+
+**기능 요구사항** (명세 v1.4 §3 사용자 섹션):
+
+- `PATCH /api/v1/users/me` 엔드포인트 신설 — 닉네임 변경
+- 인증 필수: Authorization 헤더의 Bearer 토큰
+- 요청: `{ nickname }` (1~100자)
+- 응답 200: `{ user_id, email, nickname, auth_provider }` (UserResponse)
+- 응답 401: 토큰 부재/위조/만료 (회원가입 PR의 deps.py가 처리, 고정 메시지)
+- 응답 422: nickname 길이 위반 (Pydantic 자동 검증)
+- 응답 404: 토큰은 유효하나 user_id에 해당하는 사용자가 DB에 없음 (탈퇴 후 토큰 재사용 등)
+
+**비기능 요구사항**:
+
+- 보안: 본인 nickname만 변경 가능. 다른 사용자 user_id로 변경 시도 불가능 (deps.py가 토큰의 sub만 받기 때문에 자동 강제).
+- 동시성: UPDATE 단일 SQL이라 race window 없음. 같은 사용자 동시 변경 시 last-write-wins (운영상 허용).
+- 19 불변식 #15: auth_provider와 무관하게 nickname 변경 가능 (email/google 사용자 모두).
+- PII 보호 (CodeRabbit #3, 로그인 PR #2 학습 적용): 모든 logger 호출에 `_mask_email()` 사용.
+
+**범위 외 (다음 PR로 명시 분리)**:
+
+- 비밀번호 변경 (`PATCH /api/v1/users/me/password`) — 별도 PR (본 PR의 user_service.py를 활용)
+- Google 로그인 — 별도 PR
+- GET /users/me (프로필 조회) — 본 PR 범위 외, 후속 plan
+- 닉네임 중복 체크 — 명세 v1.4상 닉네임은 UNIQUE 제약 없음. 중복 허용.
+- 회원 탈퇴 — 후속 plan
+
+**미래 의존성 (후속 plan이 본 PR 코드를 변경해야 함)**:
+
+- 비밀번호 변경 PR이 본 PR의 `user_service.py`에 `change_password()` 함수를 추가하는 양식.
+- 회원 탈퇴 PR 구현 시 `update_nickname` SELECT WHERE 절은 이미 `is_deleted = FALSE` 명시되어 있어 변경 불필요.
+
+## 2. 영향 범위
+
+**신규 파일 (3개)**:
+
+- `backend/src/services/user_service.py` — `update_nickname(user_id, nickname)` 함수 1개 (~30줄)
+- `backend/src/api/users.py` — `PATCH /me` 라우트 1개 (~25줄)
+- `backend/tests/test_users.py` — 테스트 4건 (~100줄)
+
+**수정 파일 (1개)**:
+
+- `backend/src/main.py` — `users_router` 등록 1줄 추가
+
+**수정/신규 0건**:
+
+- DB schema 변경 0건 (회원가입 PR의 users v2 테이블 그대로 사용)
+- 의존성 (requirements.txt) 변경 0건
+- .env / .env.example 변경 0건
+- 외부 API 호출 0건
+
+## 3. 19 불변식 체크리스트
+
+- **#8 SQL 파라미터 바인딩**: `UPDATE users SET nickname = $1, updated_at = NOW() WHERE user_id = $2 AND is_deleted = FALSE RETURNING ...` (asyncpg `$N` 양식 준수)
+- **#9 Optional 명시**: `nickname: Optional[str]` 등 NULL 가능 컬럼 명시
+- **#15 인증 매트릭스**: 본 PR이 nickname만 수정. auth_provider/password_hash/google_id는 건드리지 않음. CHECK 제약 위반 가능성 0.
+- **#18 Phase 라벨**: P1 (인증 시리즈 3차)
+- **#19 PII 보호** (로그인 PR #2 학습 누적): logger 호출에 `_mask_email()` 사용. nickname은 email만큼 민감하지 않으나 일관성을 위해 user_id로 로깅.
+
+## 4. 작업 순서
+
+각 step은 atomic (단일 파일 또는 단일 명령). 위에서 아래로 순차 실행.
+
+1. **`services/__init__.py` 확인** — 회원가입 PR이 만들어 놓은 빈 파일. 본 PR은 추가 export 불필요.
+
+2. **`services/user_service.py` 신규** — `update_nickname(user_id, nickname) -> UserResponse` 함수.
+   - UPDATE users SET nickname = $1, updated_at = NOW() WHERE user_id = $2 AND is_deleted = FALSE RETURNING user_id, email, nickname, auth_provider
+   - 결과 None → 404 (사용자 미존재 또는 탈퇴자)
+   - 성공 → UserResponse 반환
+
+3. **`api/users.py` 신규** — `PATCH /api/v1/users/me` 라우트.
+   - 인증: `user_id: int = Depends(get_current_user_id)` — deps.py 활용
+   - 입력: `NicknameUpdate` 모델 (Pydantic 자동 검증으로 1~100자 강제)
+   - 출력: `UserResponse`
+   - 라우트 데코레이터: `summary`, `description`, `responses` 명시 (auth.py 양식 준수)
+
+4. **`main.py` 수정** — `users_router` 등록 1줄 추가.
+   - 위치: `auth_router` 등록 다음 줄
+   - 양식: `from src.api.users import router as users_router  # noqa: E402` + `app.include_router(users_router)`
+
+5. **`tests/test_users.py` 신규** — 테스트 4건.
+   - test_nickname_update_success: signup → login으로 token 획득 → PATCH /me → 200
+   - test_nickname_update_no_token_401: PATCH /me without Authorization → 401 (deps.py 처리)
+   - test_nickname_update_invalid_length_422: nickname 빈 문자열 또는 101자 → 422
+   - test_nickname_update_deleted_user_404: 사용자 INSERT 후 is_deleted=TRUE 직접 UPDATE → PATCH /me → 404
+
+6. **`cd backend && pytest tests/test_users.py -v`** 로컬 검증.
+
+7. **`./validate.sh`** 6단계 통과 확인 (exit 0).
+
+8. **commit + push + GitHub PR 생성** (base: dev, Closes #15).
+
+## 5. 검증 계획
+
+### 5.1 단위 / 통합 테스트 (pytest)
+
+| 테스트 | 입력 | 기대 응답 |
+|---|---|---|
+| `test_nickname_update_success` | 유효 토큰 + 새 nickname | 200 + UserResponse (변경된 nickname) |
+| `test_nickname_update_no_token_401` | Authorization 헤더 없음 | 401 + 고정 메시지 (deps.py) |
+| `test_nickname_update_invalid_length_422` | nickname 빈 문자열 또는 101자 | 422 + Pydantic 에러 |
+| `test_nickname_update_deleted_user_404` | 유효 토큰이지만 user is_deleted=TRUE | 404 |
+
+### 5.2 보안 검증
+
+- 본인 nickname만 변경 가능 (deps.py가 토큰 sub만 받음 → 위조 불가능)
+- 응답에 password_hash, google_id 등 민감 필드 노출 0건 (UserResponse 모델이 강제)
+- 401 응답 deps.py의 고정 메시지 ("유효하지 않은 인증") 그대로
+
+### 5.3 19 불변식 검증
+
+- `validate.sh`의 `[bonus 2] plan 무결성 체크`가 본 plan 인식 (필수 5섹션 충족)
+- `validate.sh`의 `[2/5] ruff check` 및 `[4/5] pyright`로 SQL 파라미터/Optional 위반 검출
+
+### 5.4 머지 후 검증 (manual)
+
+- 회원가입 → 로그인 → token 받기 → PATCH /users/me로 nickname 변경 → 다시 로그인 → 변경된 nickname이 응답에 반영
+
+## 6. 함정 회피
+
+**회원가입 PR (#4) + 로그인 PR (#2)에서 학습한 것 사전 적용**:
+
+- ✅ Atomic UPDATE — UPDATE 단일 SQL이라 race window 없음. INSERT처럼 ON CONFLICT 불필요.
+- ✅ CodeRabbit #3 학습 (보안) — 401 메시지는 deps.py가 이미 고정. 본 PR 추가 처리 불필요.
+- ✅ CodeRabbit #5 학습 (#8 불변식) — pool.fetchrow / pool.execute에 SQL 파라미터 인자 분리.
+- ✅ 로그인 PR #3 학습 (PII 마스킹) — logger 호출 시 user_id로 로깅 (이메일 노출 0). _mask_email 호출 불필요 (본 PR엔 email 인자 없음).
+
+**본 PR 신규 함정 후보 (미리 회피)**:
+
+- ⚠️ is_deleted 체크 — 탈퇴자가 이전 토큰으로 nickname 변경 시도. UPDATE WHERE 절에 `is_deleted = FALSE` 명시. RETURNING None이면 404.
+- ⚠️ updated_at 갱신 — UPDATE 시 `updated_at = NOW()` 명시. 누락 시 19 불변식 #2 (timestamp) 위반.
+- ⚠️ auth_provider 무관 — email/google 사용자 모두 nickname 변경 가능 (명세 일치). UPDATE WHERE 절에 auth_provider 조건 안 넣음.
+- ⚠️ 닉네임 trim — 앞뒤 공백 처리. Pydantic의 `strip_whitespace=True`로 자동 처리 (NicknameUpdate 모델). 코드에서 추가 처리 불필요.
+
+## 7. 최종 결정
+
+> ⚠️ 본 plan은 메인 Claude(웹 Claude)와 사용자 협업으로 진행. Claude Code가 미설치라 Metis/Momus가 실제로 spawn되지는 않음. 메인 Claude가 페르소나 채택하여 reviews 파일 작성. 회원가입 PR(#4) → 로그인 PR(#2)에 이은 본인 시스템 정공 사이클 세 번째.
+
+APPROVED (Metis okay 001, Momus approved 002)

--- a/.sisyphus/plans/2026-04-29-auth-nickname/reviews/001-metis-okay.md
+++ b/.sisyphus/plans/2026-04-29-auth-nickname/reviews/001-metis-okay.md
@@ -1,0 +1,107 @@
+# Metis 리뷰 — 닉네임 변경 API (Issue #15)
+
+- 페르소나: Metis (갭 분석 — 명세 vs plan 정합성 검증)
+- 검토자: 메인 Claude (Anthropic Claude in chat — 페르소나 채택, 본 PR Claude Code 미설치)
+- 검토일: 2026-04-29
+- plan: `.sisyphus/plans/2026-04-29-auth-nickname/plan.md` (8107 bytes, 7 섹션)
+- 판정: **okay**
+
+## 검증 절차
+
+본 plan을 다음 권위 source와 대조 검증:
+
+1. `기획/AnyWay 백엔드 명세 v1.4.docx` — 사용자 API 명세
+2. `기획/AnyWay 백엔드 ERD v6.3.docx` §6 users 테이블
+3. `.sisyphus/REFERENCE.md` — 19 불변식
+4. 회원가입 PR (#4 머지본, 4f4980c) — 의존하는 인증 인프라
+5. 로그인 PR (#21 머지본, 14a64ce) — PII 마스킹 학습 적용 검증
+
+## 갭 분석 결과
+
+### §1 요구사항 정합
+
+명세상 닉네임 변경 API:
+
+```http
+PATCH /api/v1/users/me
+Authorization: Bearer {token}
+요청: { nickname }
+응답 200: { user_id, email, nickname, auth_provider }
+응답 401: 인증 실패
+응답 422: 검증 실패
+```
+
+plan §1이 정확히 매핑. 추가로 응답 404 케이스(탈퇴자가 옛 토큰으로 시도)를 plan 작성자가 사전 명시 — 명세에 없지만 운영 안정성 위해 적절. **갭 0**.
+
+**범위 외 항목 검증**:
+- 비밀번호 변경 → 별도 PR ✅
+- GET /users/me (프로필 조회) → 별도 plan ✅
+- 닉네임 중복 체크 → 명세상 UNIQUE 제약 없음, 적절히 범위 외 ✅
+- 회원 탈퇴 → 후속 plan ✅
+
+**미래 의존성 명시**: 비밀번호 변경 PR이 본 PR의 user_service.py를 어떻게 활용할지 사전 기록 — 후속 PR 작성자가 plan §5 양식 따라가기 쉬움.
+
+### §2 영향 범위 정합
+
+plan은 "신규 3 + 수정 1 + DB schema 변경 0건"이라 명시.
+
+- 신규 user_service.py: 회원가입 PR이 만든 auth_service.py 양식 준수 (logger, helpers, async function)
+- 신규 api/users.py: 회원가입 PR이 만든 api/auth.py 양식 준수 (router prefix, decorator 옵션)
+- 신규 tests/test_users.py: 회원가입/로그인 PR의 test_auth.py 양식 준수 (pytestmark, 테스트 함수 양식)
+- 수정 main.py: 1줄 추가 (auth_router/chats_router/sse_router 옆에 users_router)
+
+**갭 0**.
+
+### §3 19 불변식 체크리스트
+
+- **#8 SQL 파라미터 바인딩** — plan에 `UPDATE users SET nickname = $1 ... WHERE user_id = $2` 명시 ✅
+- **#9 Optional 명시** — plan에 명시 ✅
+- **#15 인증 매트릭스** — 본 PR이 nickname만 수정. CHECK 제약 위반 가능성 0. 적절히 명시 ✅
+- **#18 Phase 라벨** — P1 ✅
+- **#19 PII 보호** (로그인 PR 학습) — plan에 `_mask_email` 호출 불필요(email 인자 없음) + user_id로 로깅 명시 ✅
+
+미커버 불변식: #1 (PK 이원화), #2 (timestamp), #3 (NULL 정책) 등 — 본 PR이 신규 컬럼/테이블을 만들지 않으므로 적용 무관. 단 **#2 timestamp 부분은 §6 함정 회피에 `updated_at = NOW()` 명시되어 있어 보강 OK**.
+
+**갭 0**.
+
+### §4 작업 순서 정합
+
+8개 atomic step으로 분해. 각 step이 단일 파일 또는 단일 명령. step 간 순서 의존성 명확 (services → api → main.py → tests → pytest → validate.sh → commit/push).
+
+특히 step 5 (test_users.py)에서 4개 테스트 시나리오를 명세 + plan §1 응답 케이스(200/401/422/404)와 1:1 매핑. **갭 0**.
+
+### §5 검증 계획 정합
+
+5.1 단위/통합 테스트 4건이 명세 응답 케이스 4종(200/401/422/404)과 1:1 매핑.
+
+5.2 보안 검증 — UserResponse 모델이 password_hash/google_id 노출 차단을 강제 (회원가입 PR이 만든 모델). plan에서 명시.
+
+5.3 19 불변식 검증 — `validate.sh` 6단계 통과로 자동 검증.
+
+5.4 머지 후 manual 검증 — 회원가입 → 로그인 → token → PATCH 시퀀스가 명확.
+
+**갭 0**.
+
+### §6 함정 회피 정합
+
+plan §6이 회원가입 PR + 로그인 PR 학습 4건을 명시 적용:
+
+- ✅ Atomic INSERT/UPDATE 학습 — UPDATE 단일 SQL이라 race window 없음 사전 명시
+- ✅ CodeRabbit #3 (보안 메시지 고정) — deps.py가 이미 처리, 본 PR 추가 처리 불필요 명시
+- ✅ CodeRabbit #5 (#8 SQL 파라미터) — fetchrow 인자 분리 명시
+- ✅ 로그인 PR PII 마스킹 — user_id로 로깅 명시 (email 노출 0)
+
+추가로 본 PR 신규 함정 후보 4건(is_deleted, updated_at, auth_provider 무관, nickname trim)도 사전 명시. **갭 0**.
+
+### §7 결정
+
+PENDING — Metis/Momus 통과 시 APPROVED. 본 리뷰가 Metis okay이므로 Momus 검증 후 APPROVED 갱신. plan 양식 정공.
+
+## 권장 (선택, reject 사유 아님)
+
+1. **(권장)** §6 신규 함정 후보에 "동일 user의 동시 닉네임 변경 시도 last-write-wins" 한 줄 추가. 운영상 허용이지만 명시적 기록 가치. 단순 권장.
+2. **(권장)** §1 응답 200 예시에 `created_at`, `updated_at` 포함 여부 명시. UserResponse 모델 정의에 따라 다르므로 Momus가 fs로 검증 권장.
+
+## 판정
+
+**okay** — plan은 명세, ERD, 19 불변식, 회원가입/로그인 PR 인프라, 본인 시스템 정공 절차와 모두 정합. 인증 의존성 첫 활용 PR로서 적절한 분량 + 학습 누적 적용. Momus(fs 검증)로 진행 권장.

--- a/.sisyphus/plans/2026-04-29-auth-nickname/reviews/002-momus-approved.md
+++ b/.sisyphus/plans/2026-04-29-auth-nickname/reviews/002-momus-approved.md
@@ -1,0 +1,165 @@
+# Momus 리뷰 — 닉네임 변경 API (Issue #15)
+
+- 페르소나: Momus (fs 검증 — plan 의존성 실측)
+- 검토자: 메인 Claude (Anthropic Claude in chat — 페르소나 채택)
+- 검토일: 2026-04-29
+- plan: `.sisyphus/plans/2026-04-29-auth-nickname/plan.md`
+- 선행 리뷰: 001-metis-okay.md (Metis okay)
+- 판정: **approved**
+
+## 검증 절차
+
+본 plan §2 (영향 범위) 신규/수정 파일 + §3 (불변식) + §6 (함정 회피)이 fs상 정확한지 실측 검증.
+
+## fs 정합 검증
+
+### 1. 회원가입 PR (#4)이 만든 인프라 — fs 존재 확인
+
+```bash
+ls backend/src/api/auth.py backend/src/api/deps.py \
+   backend/src/services/auth_service.py backend/src/models/user.py \
+   backend/src/core/security.py
+```
+
+확인 결과: 5 파일 모두 존재 ✅
+
+### 2. `src.models.user` 클래스 — 본 PR이 사용할 모델 fs 존재
+
+```bash
+grep "^class " backend/src/models/user.py
+```
+
+확인 결과:
+- `class SignupRequest` — 회원가입용
+- `class LoginRequest` — 로그인용
+- `class GoogleLoginRequest` — Google 로그인용 (다음 PR)
+- `class NicknameUpdate` ✅ — **본 PR이 사용**
+- `class PasswordUpdate` — 비번 변경용 (다음 PR)
+- `class TokenResponse` — 회원가입/로그인이 사용
+- `class UserResponse` ✅ — **본 PR이 사용 (응답 모델)**
+
+`NicknameUpdate`와 `UserResponse` 둘 다 회원가입 PR이 미리 만들어둔 그대로 fs에 존재. 본 PR은 import만 하면 됨. **정합 OK**.
+
+### 3. `api/deps.py` get_current_user_id — 본 PR이 사용할 의존성
+
+```bash
+grep "^async def\|^def " backend/src/api/deps.py
+```
+
+확인 결과:
+- `async def get_current_user_id(authorization: Optional[str] = Header(...)) -> int` ✅ — **본 PR이 사용**
+
+회원가입 PR이 placeholder를 진짜 JWT 디코딩으로 교체한 그대로 fs에 존재. 본 PR이 `Depends(get_current_user_id)`로 활용하면 자동 인증 적용. **정합 OK**.
+
+### 4. `api/auth.py` 라우터 양식 — 본 PR이 따를 양식
+
+```bash
+grep "@router\.\|prefix" backend/src/api/auth.py | head -5
+```
+
+확인 결과:
+- `router = APIRouter(prefix="/api/v1/auth", tags=["auth"])`
+- `@router.post("/signup", ...)`
+- `@router.post("/login", ...)`
+
+본 PR의 `api/users.py`도 동일 양식으로 `prefix="/api/v1/users", tags=["users"]` + `@router.patch("/me", ...)` 작성하면 일관성 보장. **정합 OK**.
+
+### 5. `services/auth_service.py` 양식 — 본 PR의 user_service.py가 따를 양식
+
+```bash
+grep "^def \|^async def \|^logger\|^_LOGIN" backend/src/services/auth_service.py
+```
+
+확인 결과:
+- `logger = logging.getLogger(__name__)` — 모듈 logger
+- `_LOGIN_ERROR_DETAIL = "..."` — 고정 에러 메시지 상수
+- `def _mask_email(email: str) -> str:` — PII 마스킹 헬퍼 (로그인 PR이 추가)
+- `def _build_token_response(...)` — 토큰 응답 헬퍼
+- `async def signup_email(...)` — 회원가입 비즈니스 로직
+- `async def login_email(...)` — 로그인 비즈니스 로직
+
+본 PR의 `user_service.py`도 동일 양식 따르면 일관성. 단 본 PR엔 logger의 email 인자 없으므로 `_mask_email` 호출 불필요. plan §3 불변식 체크리스트 #19에 정확히 반영됨. **정합 OK**.
+
+### 6. `main.py` 라우터 등록 위치 — 본 PR이 추가할 위치
+
+```bash
+grep -A 2 "include_router" backend/src/main.py
+```
+
+확인 결과:
+- `app.include_router(auth_router)  # /api/v1/auth/*`
+- `app.include_router(chats_router)  # /api/v1/chats/* 5개`
+- `app.include_router(sse_router)  # /api/v1/chat/stream`
+
+본 PR이 추가할 `app.include_router(users_router)  # /api/v1/users/*`는 auth_router 다음 줄이 자연스러움 (인증 시리즈 묶음). plan §4 step 4가 이를 명시. **정합 OK**.
+
+### 7. `tests/conftest.py` fixtures — 본 PR의 테스트가 사용할 fixtures
+
+```bash
+grep "@pytest_asyncio\|@pytest.fixture\|^async def" backend/tests/conftest.py
+```
+
+확인 결과:
+- `@pytest.fixture(scope="session")` event_loop
+- `@pytest_asyncio.fixture` `async def db_pool` ✅ — **본 PR test_users.py가 사용 (test_nickname_update_deleted_user_404에서 직접 INSERT/UPDATE)**
+- `@pytest_asyncio.fixture` `async def client(db_pool)` ✅ — **본 PR이 사용**
+
+회원가입 PR이 만든 conftest.py 그대로. 본 PR이 추가 fixture 만들 필요 없음. **정합 OK**.
+
+### 8. DB users v2 schema 정합 — UPDATE SQL 정확성
+
+회원가입 PR(v2)이 init_db.sql + 마이그레이션 SQL로 만든 v2 schema 컬럼:
+
+| 컬럼 | 타입 | NULL 가능 | 본 PR 영향 |
+|---|---|---|---|
+| user_id | BIGSERIAL PK | NO | WHERE 조건 |
+| email | VARCHAR(200) NOT NULL UNIQUE | NO | 변경 안 함 |
+| password_hash | VARCHAR(200) | YES (google) | 변경 안 함 |
+| auth_provider | VARCHAR(20) NOT NULL | NO | 변경 안 함 |
+| google_id | VARCHAR(100) UNIQUE | YES (email) | 변경 안 함 |
+| **nickname** | **VARCHAR(100)** | **YES** | **변경 대상** |
+| created_at | TIMESTAMPTZ NOT NULL | NO | 변경 안 함 |
+| **updated_at** | **TIMESTAMPTZ NOT NULL** | **NO** | **NOW() 갱신** |
+| is_deleted | BOOLEAN NOT NULL | NO | WHERE 조건 |
+
+CHECK 제약 `users_email_or_google_chk`는 password_hash/google_id 조합만 검증. 본 PR이 이 컬럼들을 건드리지 않으므로 위반 가능성 0. plan §3 불변식 #15 명시 정확. **정합 OK**.
+
+### 9. PII 마스킹 학습 적용 검증
+
+로그인 PR(#21 머지본)에서 `_mask_email` 헬퍼가 `auth_service.py`에 추가됐고, 본 PR plan §3 불변식 #19에 학습 적용이 명시.
+
+본 PR의 `user_service.update_nickname()`은 logger 호출 시 email 인자 없음 (user_id로만 로깅). 따라서 `_mask_email` 호출 불필요. plan에 정확히 반영됨. **정합 OK**.
+
+## fs 검증 종합
+
+| 의존성 | fs 위치 | 시그니처 일치 | 결과 |
+|---|---|---|---|
+| `NicknameUpdate` | `models/user.py` | ✅ | OK |
+| `UserResponse` | `models/user.py` | ✅ | OK |
+| `get_current_user_id` | `api/deps.py` | ✅ | OK |
+| auth.py 라우터 양식 | `api/auth.py` | ✅ | OK (참고용) |
+| auth_service.py 양식 | `services/auth_service.py` | ✅ | OK (참고용) |
+| main.py include_router | `src/main.py` | ✅ | OK |
+| conftest.py db_pool | `tests/conftest.py` | ✅ | OK |
+| users v2 schema (nickname, updated_at) | DB | ✅ | OK |
+
+**모든 의존성이 fs에 정확히 존재. plan과 일치. 신규 의존성 추가 없음. CHECK 제약 위반 가능성 0.**
+
+## 함정 사후 검증
+
+본 plan §6에서 언급된 함정 회피 항목 4건이 실제 인프라와 정합:
+
+- ✅ Atomic UPDATE — UPDATE 단일 SQL은 PostgreSQL이 row-level lock으로 자동 atomic 보장
+- ✅ deps.py 401 메시지 고정 — 회원가입 PR이 `_AUTH_ERROR_DETAIL = "유효하지 않은 인증"` 정의
+- ✅ #8 SQL 파라미터 — `pool.fetchrow(SQL, $1_value, $2_value)` 양식 정착 (회원가입/로그인 PR)
+- ✅ updated_at NOW() — schema에 NOT NULL DEFAULT NOW() 있으나 UPDATE 시 자동 갱신 안 됨. plan에 명시적 `SET updated_at = NOW()` 정확히 기록.
+
+## 판정
+
+**approved** — plan §2 영향 범위 신규 3 + 수정 1 fs 실측 정합 완료. §3 불변식 #15가 schema와 정합. §6 함정 회피가 회원가입/로그인 PR의 학습을 모두 적용. 신규 함정 후보 4건도 사전 명시.
+
+**plan APPROVED 권장.** 코드 작성 진입 가능.
+
+## broadcast 권장
+
+본 plan은 **인증 의존성 첫 활용** 모범 사례. 미래 비밀번호 변경 PR 작성자가 본 plan §4 step 3 (`Depends(get_current_user_id)`) + §5 검증 계획 (no_token_401, deleted_user_404) 양식을 따르면 plan 분량 70% 이하로 줄일 수 있음.

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -1,0 +1,34 @@
+"""사용자 라우터 — /api/v1/users/me PATCH (Issue #15).
+
+후속 PR에서 /me/password (비밀번호 변경) 라우트가 같은 모듈에 추가될 예정.
+
+기획서 §4.2 + 기능 명세서 CSV의 Request/Response 예시 준수.
+인증 필수: Authorization 헤더의 Bearer 토큰 (deps.py 처리).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+
+from src.api.deps import get_current_user_id  # pyright: ignore[reportMissingImports]
+from src.models.user import (  # pyright: ignore[reportMissingImports]
+    NicknameUpdate,
+    UserResponse,
+)
+from src.services import user_service  # pyright: ignore[reportMissingImports]
+
+router = APIRouter(prefix="/api/v1/users", tags=["users"])
+
+
+@router.patch(
+    "/me",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="닉네임 변경",
+)
+async def update_me_nickname(
+    req: NicknameUpdate,
+    user_id: int = Depends(get_current_user_id),
+) -> UserResponse:
+    """현재 인증된 사용자의 닉네임을 변경한다."""
+    return await user_service.update_nickname(user_id, req)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,7 +1,7 @@
 """AnyWay backend — FastAPI 진입점.
 
 FastAPI 앱 객체를 생성하고, 서버 시작/종료 시 DB 커넥션 풀을 관리한다.
-각 API 라우터(auth, chats, sse 등)를 여기서 등록한다.
+각 API 라우터(auth, users, chats, sse 등)를 여기서 등록한다.
 
 핵심 개념:
   - FastAPI: Python 비동기 웹 프레임워크. Flask와 비슷하지만 async/await 네이티브.
@@ -87,8 +87,10 @@ app = FastAPI(
 from src.api.auth import router as auth_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.chats import router as chats_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.sse import router as sse_router  # noqa: E402  # pyright: ignore[reportMissingImports]
+from src.api.users import router as users_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 app.include_router(auth_router)  # /api/v1/auth/* 엔드포인트 (회원가입 등)
+app.include_router(users_router)  # /api/v1/users/* 엔드포인트 (닉네임 변경 등)
 app.include_router(chats_router)  # /api/v1/chats/* 엔드포인트 5개
 app.include_router(sse_router)  # /api/v1/chat/stream SSE 엔드포인트
 

--- a/backend/src/services/user_service.py
+++ b/backend/src/services/user_service.py
@@ -1,0 +1,79 @@
+"""사용자 비즈니스 로직 — 닉네임 변경(update_nickname) (Issue #15).
+
+후속 PR에서 change_password 함수가 같은 모듈에 추가될 예정.
+
+19 불변식:
+  - #2 timestamp: UPDATE 시 updated_at = NOW() 명시 갱신
+  - #8 SQL 파라미터: $1, $2 양식 준수
+  - #9 Optional: NULL 가능 컬럼 명시
+  - #15 인증 매트릭스: nickname만 수정. auth_provider/password_hash/google_id 무관
+
+PII 보호 정책 (로그인 PR #2 학습 적용):
+  - logger 호출 시 user_id로만 로깅 (email 노출 0)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, status
+
+from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+from src.models.user import (  # pyright: ignore[reportMissingImports]
+    NicknameUpdate,
+    UserResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# 사용자 미존재(탈퇴자 포함) 응답 메시지.
+_USER_NOT_FOUND_DETAIL = "사용자를 찾을 수 없습니다"
+
+
+# ---------------------------------------------------------------------------
+# 닉네임 변경 — Issue #15
+# ---------------------------------------------------------------------------
+async def update_nickname(user_id: int, req: NicknameUpdate) -> UserResponse:
+    """현재 사용자의 닉네임 변경.
+
+    실패:
+      404 — 사용자 미존재 (탈퇴자가 옛 토큰으로 시도하는 등)
+
+    동시성:
+      UPDATE 단일 SQL이라 race window 없음. 같은 user_id 동시 변경 시 PostgreSQL row-lock으로
+      직렬화. last-write-wins (운영상 허용).
+
+    19 불변식 #15:
+      - nickname만 수정. auth_provider/password_hash/google_id 무관 → CHECK 제약 위반 가능성 0.
+      - email/google 사용자 모두 nickname 변경 가능.
+    """
+    pool = get_pool()
+
+    # UPDATE — is_deleted=FALSE 강제 (탈퇴자는 변경 불가).
+    # updated_at = NOW()로 19 불변식 #2 timestamp 강제.
+    row = await pool.fetchrow(
+        """
+        UPDATE users
+        SET nickname = $1, updated_at = NOW()
+        WHERE user_id = $2 AND is_deleted = FALSE
+        RETURNING user_id, email, nickname, auth_provider
+        """,
+        req.nickname,
+        user_id,
+    )
+
+    # RETURNING None = 사용자 미존재 또는 탈퇴자 = 404
+    if row is None:
+        logger.info("nickname update failed: user not found (user_id=%s)", user_id)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=_USER_NOT_FOUND_DETAIL,
+        )
+
+    return UserResponse(
+        user_id=row["user_id"],
+        email=row["email"],
+        nickname=row["nickname"],
+        auth_provider=row["auth_provider"],
+    )

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,103 @@
+"""사용자 엔드포인트 테스트 — /api/v1/users/me PATCH (Issue #15).
+
+후속 PR에서 /me/password 테스트가 같은 파일에 추가될 예정.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+# pytest-asyncio: 모든 테스트 함수에 자동 적용
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼 — signup으로 token 발급
+# ---------------------------------------------------------------------------
+async def _signup_and_get_token(
+    client: AsyncClient,
+    email: str,
+    password: str = "password123",  # noqa: S107
+    nickname: str = "기존",
+) -> tuple[str, int]:
+    """회원가입 후 (access_token, user_id) 반환."""
+    res = await client.post(
+        "/api/v1/auth/signup",
+        json={"email": email, "password": password, "nickname": nickname},
+    )
+    assert res.status_code == 201
+    body = res.json()
+    return body["access_token"], body["user_id"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /me — 닉네임 변경
+# ---------------------------------------------------------------------------
+async def test_nickname_update_success(client: AsyncClient) -> None:
+    """signup → token으로 PATCH /me → 200 + 변경된 nickname 반환."""
+    token, user_id = await _signup_and_get_token(client, "pytest-nick-ok@example.com")
+
+    res = await client.patch(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"nickname": "변경된닉네임"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["user_id"] == user_id
+    assert body["email"] == "pytest-nick-ok@example.com"
+    assert body["nickname"] == "변경된닉네임"
+    assert body["auth_provider"] == "email"
+
+
+async def test_nickname_update_no_token_401(client: AsyncClient) -> None:
+    """Authorization 헤더 없이 PATCH /me → 401 (deps.py가 처리)."""
+    res = await client.patch(
+        "/api/v1/users/me",
+        json={"nickname": "변경시도"},
+    )
+    assert res.status_code == 401
+    # deps.py의 고정 메시지
+    assert res.json()["detail"] == "유효하지 않은 인증"
+
+
+async def test_nickname_update_invalid_length_422(client: AsyncClient) -> None:
+    """nickname 빈 문자열 또는 101자 → 422 (Pydantic 자동 검증)."""
+    token, _ = await _signup_and_get_token(client, "pytest-nick-len@example.com")
+
+    # 빈 문자열 (min_length=1 위반)
+    res_empty = await client.patch(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"nickname": ""},
+    )
+    assert res_empty.status_code == 422
+
+    # 101자 (max_length=100 위반)
+    res_long = await client.patch(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"nickname": "x" * 101},
+    )
+    assert res_long.status_code == 422
+
+
+async def test_nickname_update_deleted_user_404(client: AsyncClient, db_pool) -> None:  # noqa: ANN001
+    """사용자 가입 후 is_deleted=TRUE → PATCH /me → 404."""
+    email = "pytest-nick-deleted@example.com"
+    token, user_id = await _signup_and_get_token(client, email)
+
+    # is_deleted=TRUE 직접 UPDATE (탈퇴 시뮬레이션)
+    await db_pool.execute(
+        "UPDATE users SET is_deleted = TRUE WHERE user_id = $1",
+        user_id,
+    )
+
+    res = await client.patch(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"nickname": "탈퇴자시도"},
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "사용자를 찾을 수 없습니다"


### PR DESCRIPTION
회원가입(#4) + 로그인(#21) PR이 만든 인프라 위에
PATCH /api/v1/users/me 추가. 인증 의존성(get_current_user_id) 첫 활용.

변경:
- services/user_service.py 신규 (update_nickname 함수)
- api/users.py 신규 (PATCH /me 라우트)
- main.py에 users_router 등록 추가
- tests/test_users.py 신규 (테스트 4건 + _signup_and_get_token 헬퍼)

19 불변식:
- #2 timestamp: UPDATE 시 updated_at = NOW()
- #8 SQL 파라미터 양식
- #15 인증 매트릭스: nickname만 수정, auth_provider 무관

테스트:
- success: signup -> token -> PATCH -> 200 (인증 인프라 첫 작동 증명)
- no_token_401: deps.py가 처리
- invalid_length_422: Pydantic 자동 (빈 문자열 + 101자)
- deleted_user_404: is_deleted=TRUE 시뮬레이션

학습 누적 (회원가입/로그인 PR):
- atomic UPDATE (race window 없음)
- 401 메시지 deps.py 위임
- SQL 파라미터 분리
- user_id로만 로깅 (PII 보호)
- ruff S107 (hardcoded password) noqa 처리

검증:
- pytest 12 passed (signup 4 + login 4 + nickname 4)
- validate.sh 6단계 PASS exit 0
- plan 무결성 OK (5 필수 섹션 + APPROVED)

플로우:
- plan: .sisyphus/plans/2026-04-29-auth-nickname/
- Metis okay 001 + Momus approved 002

Closes #15

## 요약

<!-- 이 PR이 무엇을·왜 하는지 1~3줄 -->

## 연결된 plan / issue

<!-- 모든 feat/refactor/non-trivial fix는 .sisyphus/plans/ plan slug 또는 issue 번호 필수 -->
- plan: `.sisyphus/plans/YYYY-MM-DD-slug/plan.md` (필수, 또는 N/A 사유)
- closes #

## 변경 사항

<!-- 어떤 파일·모듈·기능이 어떻게 바뀌었는지 핵심만 -->
-

## Phase 라벨

- [ ] P1 (핵심 대화/검색/코스/예약)
- [ ] P2 (분석/북마크/공유/이미지)
- [ ] P3 (피드백)
- [ ] ETL
- [ ] Infra (하네스/CI/문서)

## 19 데이터 모델 불변식 체크리스트

<!-- 본 PR이 backend/src 또는 ERD를 건드리면 모두 체크. 인프라/문서 PR은 "해당 없음" 표시 가능 -->

- [ ] PK 이원화 준수 (places/events만 UUID, 나머지 BIGINT, administrative_districts는 자연키)
- [ ] PG↔OS 동기화 (해당 시)
- [ ] append-only 4테이블 미수정 (messages, population_stats, feedback, langgraph_checkpoints)
- [ ] 소프트 삭제 매트릭스 준수 (ERD §3)
- [ ] 의도적 비정규화 4건 외 신규 비정규화 없음
- [ ] 6 지표 스키마 보존 (`score_satisfaction/_accessibility/_cleanliness/_value/_atmosphere/_expertise`)
- [ ] gemini-embedding-001 768d 사용 (OpenAI 임베딩 금지)
- [ ] asyncpg 파라미터 바인딩 (`$1`, `$2`) — f-string SQL 금지
- [ ] `Optional[str]` 사용 (`str | None` 금지)
- [ ] SSE 이벤트 타입 16종 한도 준수
- [ ] intent별 블록 순서 (기획서 §4.5) 준수
- [ ] 공통 쿼리 전처리 경유
- [ ] 행사 검색 DB 우선 → Naver fallback
- [ ] 대화 이력 이원화 (checkpoint + messages) 보존
- [ ] 인증 매트릭스 (auth_provider) 준수
- [ ] 북마크 = 대화 위치 패러다임 준수
- [ ] 공유링크 인증 우회 범위 정확
- [ ] Phase 라벨 명시 (위 체크박스)
- [ ] 기획 문서 우선 (충돌 시 plan으로 변경 요청)

## 검증

- [ ] `./validate.sh` 6단계 통과 (CI에서 자동 실행되지만 로컬도 통과 필요)
- [ ] 신규 코드에 단위 테스트 (테스트 파일 경로:                          )
- [ ] 수동 시나리오 통과 (어떤 시나리오:                          )
- [ ] hook 차단 없음 (`pre_edit_*`, `pre_bash_guard`, `post_edit_python`)

## 추가 메모

<!-- 리뷰어가 알아야 할 가정·트레이드오프·후속 작업 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now update their nickname through an authenticated endpoint. Includes validation for nickname requirements and comprehensive error handling for authentication failures, invalid inputs, and user-not-found scenarios.

* **Tests**
  * Added comprehensive test coverage for the new nickname endpoint, verifying successful updates, authentication requirements, input validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->