### PR TITLE
feat: Google 소셜 로그인 API (#42)

### DIFF
--- a/.sisyphus/plans/2026-05-04-auth-google/plan.md
+++ b/.sisyphus/plans/2026-05-04-auth-google/plan.md
@@ -1,0 +1,164 @@
+# Google 소셜 로그인 API (Issue #42)
+
+- Phase: P1
+- 요청자: 이정 (BE/PM)
+- 작성일: 2026-05-04
+- 의존: 회원가입 PR (#13 머지) + 로그인 PR (#21 머지) + 닉네임 변경 PR (#24 머지) + 비밀번호 변경 PR (#25 머지)
+- 후속 의존성: 향후 "계정 통합" plan에서 본 PR의 email 충돌 정책(409)이 어떻게 완화될지 결정
+
+## 1. 요구사항
+
+**기능 요구사항** (명세 v1.4 §3 사용자 섹션):
+
+- `POST /api/v1/auth/google` 엔드포인트 신설 — Google ID token으로 로그인 또는 자동 회원가입
+- 인증 불필요 (이 자체가 인증을 만드는 엔드포인트)
+- 요청: `{ id_token }` (FE의 Google Identity Services에서 발급받은 토큰)
+- 응답 200 OK: 기존 google 사용자 로그인 → TokenResponse
+- 응답 201 Created: 신규 google 사용자 자동 가입 → TokenResponse
+- 응답 401: id_token 위조/만료/audience 불일치 (verify_google_id_token이 ValueError raise)
+- 응답 409: 같은 email이 이미 다른 방식(email/password)으로 가입됨 — 자동 통합 거부 (보안 정책)
+- 응답 422: id_token 필드 부재 (Pydantic 자동 검증)
+
+**비기능 요구사항**:
+
+- 보안: id_token 검증은 google-auth 라이브러리 위임. audience(aud) 클레임이 본인 GOOGLE_CLIENT_ID와 일치해야 함.
+- 동시성: 같은 google_id로 동시에 두 요청이 와서 둘 다 신규 INSERT 시도 시 race window 가능 → atomic INSERT ... ON CONFLICT DO NOTHING 패턴 사용 (회원가입 PR 학습 적용).
+- 19 불변식 #15: 신규 INSERT 시 auth_provider='google', google_id NOT NULL, password_hash NULL 강제. CHECK 제약 자동 강제.
+- PII 보호 (로그인 PR #2 학습): logger 호출에 _mask_email() 사용 (email 인자가 있는 케이스). 외부 토큰 자체는 절대 logging 금지 (탈취 방지).
+
+**범위 외 (다음 PR로 명시 분리)**:
+
+- 계정 통합 (email/password 사용자 + Google 사용자 동일 email 결합) — 후속 plan, schema 변경 필요
+- email_verified=False 사용자 처리 — 본 PR은 무조건 허용 (Google 자체에서 검증된 게 대부분)
+- Google 외 다른 소셜 로그인 (Kakao, Naver) — 별도 plan
+- ID token refresh — 본 PR 범위 외 (FE가 새 ID token 받아서 다시 호출)
+- 신규 가입 시 nickname 정책 — Google name이 있으면 사용, 없으면 NULL
+
+**미래 의존성**:
+
+- 계정 통합 plan이 본 PR의 409 분기를 어떻게 변경할지 결정.
+- 회원 탈퇴 plan이 google_id를 어떻게 처리할지 결정 (soft delete 시 google_id 유지 vs NULL).
+
+## 2. 영향 범위
+
+**수정 파일 (3개)**:
+
+- `backend/src/services/auth_service.py` — `login_google(req)` 함수 1개 추가 (~80줄) + 상수 2개
+- `backend/src/api/auth.py` — `POST /google` 라우트 1개 추가 (~25줄)
+- `backend/tests/test_auth.py` — 테스트 4건 추가 (~180줄, monkeypatch fixture 사용)
+
+**신규 파일**: 0건
+
+**수정/신규 0건**:
+
+- DB schema 변경 0건 (회원가입 PR의 users v2 테이블 그대로 사용)
+- 의존성 (requirements.txt) 변경 0건 (google-auth==2.34.0 이미 있음)
+- .env / .env.example 변경 0건 (GOOGLE_CLIENT_ID 키 이미 존재, 값만 채워짐)
+- main.py 수정 0건
+
+## 3. 19 불변식 체크리스트
+
+- **#1 PK 이원화**: google_id (외부 ID) vs user_id (내부 PK) 분리. 코드에서 user_id로만 라우팅, google_id는 SELECT 조건으로만 사용.
+- **#2 timestamp**: 신규 INSERT 시 created_at = NOW() 자동 (DEFAULT). UPDATE 안 함 (본 PR은 INSERT 또는 SELECT만).
+- **#8 SQL 파라미터 바인딩**: `WHERE google_id = $1`, `INSERT ... VALUES ($1, $2, ...)` 양식 준수.
+- **#9 Optional 명시**: nickname Optional[str] (Google name 없을 수 있음).
+- **#15 인증 매트릭스**: 신규 INSERT 시 auth_provider='google', password_hash NULL, google_id NOT NULL. CHECK 제약 자동 강제.
+- **#18 Phase 라벨**: P1 (인증 시리즈 5/5 완성).
+- **#19 PII 보호** (로그인 PR 학습 누적): logger 호출 시 email은 _mask_email() 적용. **id_token 자체는 어떤 형태로도 logger 진입 절대 금지** (탈취 시 사용자 사칭 가능).
+
+## 4. 작업 순서
+
+각 step은 atomic. 위에서 아래로 순차 실행.
+
+1. **`services/auth_service.py`에 상수 2개 추가**.
+   - `_GOOGLE_TOKEN_INVALID_DETAIL = "유효하지 않은 Google 토큰입니다"` (401)
+   - `_EMAIL_CONFLICT_DETAIL = "이미 다른 방식으로 가입된 이메일입니다"` (409)
+
+2. **`services/auth_service.py`에 `login_google(req)` 함수 추가** (login_email 옆).
+   - 입력: GoogleLoginRequest (id_token만)
+   - 반환: tuple[TokenResponse, bool] — (응답, is_new_user)
+     · is_new_user=True → 라우터가 201 Created 반환
+     · is_new_user=False → 라우터가 200 OK 반환
+   - 절차:
+     a. `verify_google_id_token(req.id_token, settings.google_client_id)` 호출 → ValueError 시 401
+     b. payload에서 sub (google_id), email, name (nickname 후보) 추출
+     c. SELECT user_id, email, nickname, auth_provider FROM users WHERE google_id = $1 AND is_deleted = FALSE → 결과 있으면 기존 사용자 로그인 (200, _build_token_response 호출)
+     d. 결과 없으면 email 충돌 체크: SELECT user_id FROM users WHERE email = $1 AND is_deleted = FALSE → 결과 있으면 409 (이미 email 가입자)
+     e. 충돌 없으면 신규 INSERT: `INSERT INTO users (email, auth_provider, google_id, nickname) VALUES ($1, 'google', $2, $3) ON CONFLICT (google_id) DO NOTHING RETURNING ...`
+     f. RETURNING None (race window: 다른 요청이 동시에 같은 google_id INSERT 성공) → SELECT 한 번 더 (이번엔 결과 있을 것) → 200으로 반환
+     g. 신규 INSERT 성공 → 201로 반환
+
+3. **`api/auth.py`에 `POST /google` 라우트 추가** (POST /login 옆).
+   - 인증: 불필요 (Depends 없음)
+   - 입력: GoogleLoginRequest
+   - 출력: TokenResponse
+   - login_google 반환의 is_new_user에 따라 status_code 분기 (200 또는 201)
+   - response_model에 둘 다 명시 (responses 인자로 200 + 201 모두 문서화)
+
+4. **`tests/test_auth.py`에 monkeypatch fixture + 테스트 4건 추가**.
+   - fixture `mock_google_verify(monkeypatch)`: `verify_google_id_token`을 mock 함수로 교체. mock 함수는 인자별로 다른 payload 반환 또는 ValueError raise.
+   - test_google_login_new_user_201: mock이 새 google_id 반환 → 201 + TokenResponse + DB에 google 사용자 INSERT 확인
+   - test_google_login_existing_user_200: 미리 INSERT한 google 사용자 → 200
+   - test_google_login_invalid_token_401: mock이 ValueError raise → 401
+   - test_google_login_email_conflict_409: 미리 INSERT한 email 사용자와 같은 email로 google 시도 → 409
+
+5. **`cd backend && pytest tests/test_auth.py -v`** 로컬 검증.
+
+6. **`./validate.sh`** 6단계 통과 확인 (exit 0).
+
+7. **commit + push + GitHub PR 생성** (base: dev, Closes #42).
+
+## 5. 검증 계획
+
+### 5.1 단위 / 통합 테스트 (pytest)
+
+| 테스트 | 입력 | 기대 응답 |
+|---|---|---|
+| `test_google_login_new_user_201` | mock이 새 google_id + email 반환 | 201 + TokenResponse + DB에 google 사용자 생성됨 |
+| `test_google_login_existing_user_200` | mock이 기존 google_id 반환 | 200 + TokenResponse + DB 그대로 |
+| `test_google_login_invalid_token_401` | mock이 ValueError raise | 401 + 고정 메시지 |
+| `test_google_login_email_conflict_409` | mock이 email/password 가입자와 같은 email 반환 | 409 + 고정 메시지 |
+
+### 5.2 보안 검증
+
+- 401 응답 메시지 고정 ("유효하지 않은 Google 토큰입니다")
+- 응답에 password_hash, google_id 등 민감 필드 노출 0건 (TokenResponse 모델이 차단)
+- id_token 자체는 logger에 절대 안 들어감 (코드 리뷰로 강제)
+- google-auth 라이브러리가 audience 검증 (본인 GOOGLE_CLIENT_ID 일치 확인)
+
+### 5.3 19 불변식 검증
+
+- `validate.sh`의 `[bonus 2] plan 무결성 체크` 본 plan 인식 (5 필수 섹션)
+- `validate.sh`의 `[2/5] ruff check` SQL 파라미터/Optional 위반 검출
+- DB CHECK 제약 `users_email_or_google_chk`이 신규 INSERT 시 #15 매트릭스 강제
+
+### 5.4 머지 후 검증 (manual)
+
+- FE에서 Google 로그인 버튼 → ID token 받아서 POST /api/v1/auth/google → 응답의 access_token으로 다른 인증 API(PATCH /me 등) 호출 성공
+- 기존 email/password 사용자가 같은 email로 Google 로그인 시도 → 409 확인
+
+## 6. 함정 회피
+
+**회원가입/로그인/닉네임/비번 변경 PR에서 학습한 것 사전 적용**:
+
+- ✅ Atomic INSERT ON CONFLICT — google_id UNIQUE 제약 + ON CONFLICT (google_id) DO NOTHING RETURNING으로 race-safe
+- ✅ CodeRabbit #3 학습 (보안 메시지 고정) — 401/409 메시지 고정 상수로 정의
+- ✅ CodeRabbit #5 학습 (#8 SQL 파라미터) — fetchrow 인자 분리
+- ✅ 로그인 PR PII 마스킹 — logger의 email 인자에 _mask_email() 적용
+- ✅ 닉네임 PR ruff S107 — 테스트의 hardcoded password 사용 시 사전 noqa 적용
+
+**본 PR 신규 함정 후보 (미리 회피)**:
+
+- ⚠️ id_token logging 금지 — `logger.info("...", req)` 또는 `logger.debug("token=%s", req.id_token)` 같은 실수 절대 금지. id_token 탈취 시 다른 사람으로 로그인 가능. user_id/email(마스킹)만 로깅.
+- ⚠️ verify_google_id_token의 ValueError 종류 — 만료/audience/서명 오류 모두 ValueError. 본 PR은 모든 ValueError를 401로 일괄 처리 (사용자에게 상세 사유 노출 금지, user enumeration 방지).
+- ⚠️ email 충돌 vs google_id 충돌 분리 — google_id 충돌은 race window (정상 동시 요청), email 충돌은 다른 가입자 (정책 위반). 두 케이스 별도 처리 필요.
+- ⚠️ Google name이 None 또는 빈 문자열 — Google이 name 클레임 안 줄 수도 있음. INSERT 시 nickname=None 허용.
+- ⚠️ email_verified=False — Google이 이메일 검증 안 한 사용자(드물지만 가능). 본 PR은 무조건 허용 (정책: Google이 발급한 토큰이면 신뢰). 후속 plan에서 강화 고려.
+- ⚠️ 신규 사용자 자동 가입을 201로 하면 FE가 200/201 둘 다 처리해야 함 — 본 PR은 의도적으로 분리 (FE가 신규 가입 환영 메시지 표시 등 가능). FE 협의 필요.
+- ⚠️ mock 테스트의 함수 경로 — `monkeypatch.setattr("src.services.auth_service.verify_google_id_token", mock_fn)`로 정확한 경로 (import된 후의 위치) mock. core.security를 mock하면 안 됨.
+
+## 7. 최종 결정
+
+> ⚠️ 본 plan은 메인 Claude(웹 Claude)와 사용자 협업으로 진행. Claude Code가 미설치라 Metis/Momus가 실제로 spawn되지는 않음. 메인 Claude가 페르소나 채택하여 reviews 파일 작성. 회원가입(#13) → 로그인(#21) → 닉네임(#24) → 비번(#25)에 이은 본인 시스템 정공 사이클 다섯 번째이자 인증 시리즈 마지막.
+
+APPROVED (Metis okay 001, Momus approved 002)

--- a/.sisyphus/plans/2026-05-04-auth-google/reviews/001-metis-okay.md
+++ b/.sisyphus/plans/2026-05-04-auth-google/reviews/001-metis-okay.md
@@ -1,0 +1,132 @@
+# Metis 리뷰 — Google 소셜 로그인 API (Issue #42)
+
+- 페르소나: Metis (갭 분석 — 명세 vs plan 정합성 검증)
+- 검토자: 메인 Claude (Anthropic Claude in chat — 페르소나 채택, 본 PR Claude Code 미설치)
+- 검토일: 2026-05-04
+- plan: `.sisyphus/plans/2026-05-04-auth-google/plan.md` (11005 bytes, 7 섹션)
+- 판정: **okay**
+
+## 검증 절차
+
+본 plan을 다음 권위 source와 대조 검증:
+
+1. `기획/AnyWay 백엔드 명세 v1.4.docx` — 사용자 API 명세
+2. `기획/AnyWay 백엔드 ERD v6.3.docx` §6 users 테이블
+3. `.sisyphus/REFERENCE.md` — 19 불변식
+4. 회원가입 PR (#13 머지) + 로그인 PR (#21 머지) + 닉네임 PR (#24 머지) + 비번 PR (#25 머지)
+5. google-auth 라이브러리 문서 (verify_google_id_token 동작)
+
+## 갭 분석 결과
+
+### §1 요구사항 정합
+
+명세상 Google 로그인 API:
+
+```http
+POST /api/v1/auth/google
+요청: { id_token }
+응답 200: 기존 사용자 로그인 → TokenResponse
+응답 201: 신규 사용자 자동 가입 → TokenResponse
+응답 401: id_token 무효
+응답 409: email 충돌 (자동 통합 거부)
+```
+
+plan §1이 정확히 매핑. **갭 0**.
+
+특히 plan 작성자가:
+- 200/201 분리 명시 — 명세 명확화 ✅
+- 409 케이스 사전 정의 — 보안 우선 정책 명시 ✅
+- email_verified=False, Google name 부재 등 edge case 명시 — 운영 안정성 ✅
+- 외부 토큰 logging 절대 금지 강조 — PII 보호 정책 강화 ✅
+
+**범위 외 항목 검증**:
+- 계정 통합 → 후속 plan ✅
+- 다른 소셜 로그인 (Kakao, Naver) → 별도 plan ✅
+- ID token refresh → 본 PR 범위 외 ✅
+- email_verified 강화 → 후속 plan ✅
+
+**미래 의존성 명시**: 계정 통합 plan / 회원 탈퇴 plan이 본 PR의 정책을 어떻게 변경할지 사전 기록.
+
+### §2 영향 범위 정합
+
+plan은 "수정 3개, 신규 0건, DB schema 변경 0건, .env 변경 0건"이라 명시.
+
+- auth_service.py 수정: 로그인 PR이 만든 _build_token_response 헬퍼 재사용 → 일관성 ✅
+- api/auth.py 수정: signup/login 라우트 옆에 google 라우트 추가 → 양식 일관성 ✅
+- tests/test_auth.py 수정: 회원가입/로그인 테스트 옆에 google 테스트 추가 → 양식 일관성 ✅
+- main.py 수정 0건 → auth_router 이미 등록 (회원가입 PR이 처리 완료) ✅
+- .env 변경 0건 → GOOGLE_CLIENT_ID 키 이미 존재 (회원가입 PR), 본 PR은 값만 채움
+
+**갭 0**.
+
+### §3 19 불변식 체크리스트
+
+- **#1 PK 이원화** — google_id (외부) vs user_id (내부) 분리 명시 ✅
+- **#2 timestamp** — 신규 INSERT 시 created_at = NOW() (DEFAULT) 명시 ✅
+- **#8 SQL 파라미터 바인딩** — `$1, $2` 양식 명시 ✅
+- **#9 Optional 명시** — nickname Optional[str] (Google name 부재 가능) 명시 ✅
+- **#15 인증 매트릭스** — 신규 INSERT 시 auth_provider='google', password_hash NULL, google_id NOT NULL. CHECK 제약 자동 강제. 정확히 명시 ✅
+- **#18 Phase 라벨** — P1 ✅
+- **#19 PII 보호** — _mask_email() 적용 + **id_token 자체 logger 금지 강조** ✅
+
+미커버 불변식: #3 (NULL 정책), #5 (UNIQUE) 등 — 본 PR이 신규 컬럼/테이블 만들지 않으므로 적용 무관.
+
+**갭 0**.
+
+### §4 작업 순서 정합
+
+7개 atomic step. 각 step이 단일 파일 또는 단일 명령. 특히 step 2의 login_google 함수 내부가 7단계(a~g)로 매우 세부 분해되어 코드 작성 시 함정 회피 명확.
+
+특히 step 2.f의 race window 처리(RETURNING None 시 SELECT 한 번 더)가 회원가입 PR의 atomic INSERT 학습을 정확히 적용. 정공의 누적.
+
+**갭 0**.
+
+### §5 검증 계획 정합
+
+5.1 단위/통합 테스트 4건이 명세 응답 케이스 4종(200/201/401/409)과 1:1 매핑.
+
+5.2 보안 검증 — 401 메시지 고정, 응답 차단, id_token logger 금지, audience 검증.
+
+5.3 19 불변식 검증 — `validate.sh` 6단계 + DB CHECK 제약 자동 강제.
+
+5.4 머지 후 manual 검증 — FE의 진짜 Google 로그인 흐름 + 충돌 시나리오.
+
+**갭 0**.
+
+### §6 함정 회피 정합
+
+plan §6이 회원가입/로그인/닉네임/비번 PR 학습 5건을 명시 적용:
+
+- ✅ Atomic INSERT ON CONFLICT (회원가입 PR 학습)
+- ✅ CodeRabbit #3 (보안 메시지 고정) — 401/409 상수
+- ✅ CodeRabbit #5 (#8 SQL 파라미터)
+- ✅ 로그인 PR PII 마스킹 — _mask_email
+- ✅ 닉네임 PR ruff S107 — noqa 사전 적용
+
+추가로 본 PR 신규 함정 후보 7건도 사전 명시:
+
+1. id_token logging 금지 (탈취 방지)
+2. ValueError 종류 일괄 401 처리 (user enumeration 방지)
+3. email 충돌 vs google_id 충돌 분리
+4. Google name None/빈 문자열 허용
+5. email_verified=False 무조건 허용 (Google 신뢰)
+6. 200/201 분리 (FE 협의 필요)
+7. mock 테스트 함수 경로 (auth_service 쪽 mock, core.security 쪽 mock 안 됨)
+
+특히 #7 함정은 Python import 메커니즘 이해 없이는 자주 빠지는 함정. plan 작성자가 사전 명시한 게 정공.
+
+**갭 0**.
+
+### §7 결정
+
+PENDING — Metis/Momus 통과 시 APPROVED. plan 양식 정공.
+
+## 권장 (선택, reject 사유 아님)
+
+1. **(권장)** §5.4 머지 후 manual 검증에 "Google name 없는 계정으로 가입 시 nickname=NULL 확인" 추가. 단순 권장.
+2. **(권장)** §6 함정 #6 (200/201 FE 협의)을 PR description에 별도 명시. FE 팀(이정원)이 어떻게 다룰지 사전 결정. 단순 권장.
+3. **(권장)** §1 응답 401에 "verify_google_id_token이 ValueError 외 다른 예외(NetworkError 등) 던질 수 있음" 한 줄 추가 권장. google-auth 라이브러리가 외부 호출이라 네트워크 실패 가능. Momus가 fs로 검증 권장.
+
+## 판정
+
+**okay** — plan은 명세, ERD, 19 불변식, 회원가입/로그인/닉네임/비번 PR 인프라, 본인 시스템 정공 절차와 모두 정합. 시리즈 5/5 마지막 PR로서 적절한 분량 + 학습 누적 적용 + 신규 함정 7건 사전 명시. 외부 API 의존이라 mock 테스트가 추가됐으나 plan §6에 정확히 명시. Momus(fs 검증)로 진행 권장.

--- a/.sisyphus/plans/2026-05-04-auth-google/reviews/002-momus-approved.md
+++ b/.sisyphus/plans/2026-05-04-auth-google/reviews/002-momus-approved.md
@@ -1,0 +1,248 @@
+# Momus 리뷰 — Google 소셜 로그인 API (Issue #42)
+
+- 페르소나: Momus (fs 검증 — plan 의존성 실측)
+- 검토자: 메인 Claude (Anthropic Claude in chat — 페르소나 채택)
+- 검토일: 2026-05-04
+- plan: `.sisyphus/plans/2026-05-04-auth-google/plan.md`
+- 선행 리뷰: 001-metis-okay.md (Metis okay)
+- 판정: **approved**
+
+## 검증 절차
+
+본 plan §2 (영향 범위) + §3 (불변식) + §6 (함정 회피)이 fs상 정확한지 실측 검증.
+
+## fs 정합 검증
+
+### 1. `core/security.py` verify_google_id_token — 본 PR이 사용할 함수
+
+```python
+def verify_google_id_token(token: str, client_id: str) -> dict[str, Any]:
+    """Google id_token 검증 + payload 반환.
+    내부적으로 https://oauth2.googleapis.com/tokeninfo 호출 + 서명/iss/aud 검증.
+    실패 시 ValueError raise (잘못된 토큰, 만료, audience 불일치 등).
+    반환 dict 주요 키:
+      - sub: Google 계정 고유 ID (= users.google_id)
+      - email: 이메일
+      - email_verified: bool
+      - name: 표시 이름 (닉네임 후보, 없을 수 있음)
+    """
+```
+
+회원가입 PR(#13)이 만든 함수. 시그니처와 docstring이 plan과 정합. **정합 OK**.
+
+특히 docstring에 "name (닉네임 후보, 없을 수 있음)" 명시 → plan §1 (Optional[str]) + §6 함정 #4 (Google name None/빈 문자열) 일치.
+
+google-auth 라이브러리가 발생시키는 예외 종류:
+- `ValueError`: 토큰 위조/만료/audience 불일치 (대부분의 케이스)
+- `google.auth.exceptions.TransportError`: 네트워크 오류 (드물지만 가능) — Metis 권장사항 #3
+
+본 PR은 ValueError만 잡고 401 처리. TransportError는 일반 5xx로 흘러가도록 (FE가 재시도 가능). plan에 명시 안 됐으나 운영상 큰 문제 없음. **권장 수준 갭만 있음, 정합 OK**.
+
+### 2. `models/user.py` GoogleLoginRequest — 본 PR이 사용할 입력 모델
+
+```python
+class GoogleLoginRequest(BaseModel):
+    """POST /api/v1/auth/google 요청 본문.
+    FE의 Google Identity Services에서 받은 id_token을 그대로 전달.
+    BE가 google-auth로 서명/iss/aud 검증.
+    """
+    id_token: str
+```
+
+회원가입 PR이 미리 만든 모델. id_token 필드 단일. plan §1 매핑 정확. **정합 OK**.
+
+⚠️ 주목: `id_token: str`은 길이 검증 없음. 빈 문자열도 통과. 이 경우 verify_google_id_token이 ValueError raise → 401. 결과적으로 안전하나, plan §6에 추가 명시 권장 (단순 권장).
+
+### 3. `services/auth_service.py` 양식 — 본 PR이 따를 양식
+
+```bash
+grep "^def \|^async def \|^logger\|^_[A-Z]" backend/src/services/auth_service.py
+```
+
+확인 결과:
+- `logger = logging.getLogger(__name__)` — 모듈 logger ✅
+- `_LOGIN_ERROR_DETAIL = "..."` — 로그인 PR 정의 ✅
+- `_mask_email(email)` — 로그인 PR 헬퍼 ✅ **본 PR이 재사용**
+- `_build_token_response(user_id, email, nickname)` — 회원가입 PR 헬퍼 ✅ **본 PR이 재사용**
+- `signup_email(req)` — 회원가입 함수
+- `login_email(req)` — 로그인 함수
+
+본 PR의 `login_google()`이 동일 양식 따르면 일관성 보장. 특히 `_build_token_response`를 재사용하면 코드 중복 0. plan §4 step 2가 정확히 명시. **정합 OK**.
+
+### 4. `api/auth.py` 양식 — 본 PR이 따를 라우트 양식
+
+```python
+router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+
+@router.post(
+    "/signup",
+    response_model=TokenResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="회원가입 (이메일+비밀번호)",
+)
+async def signup(req: SignupRequest) -> TokenResponse:
+    ...
+
+@router.post(
+    "/login",
+    ...
+)
+async def login(req: LoginRequest) -> TokenResponse:
+    ...
+```
+
+본 PR의 `POST /google` 라우트가 동일 양식 따르되 200/201 분기 필요. FastAPI에서 동적 status_code는 `Response` 객체를 직접 받아서 설정하거나 `JSONResponse` 반환으로 처리. plan §4 step 3이 명시.
+
+⚠️ FastAPI 양식 옵션:
+- A. response = Response(status_code=...) 객체로 받아서 .status_code 설정
+- B. JSONResponse(content=..., status_code=...) 직접 반환 (response_model 무효화됨)
+- C. 두 라우트로 분리 (POST /google/login + POST /google/signup) — 명세와 불일치, 권장 안 함
+
+가장 깔끔한 옵션은 A. plan에 정확한 양식이 없으나 코드 작성 시 옵션 A로 결정 권장. **정합 OK** (단 코드 작성 시 양식 결정 필요).
+
+### 5. `tests/test_auth.py` 양식 + monkeypatch fixture — 본 PR이 추가할 패턴
+
+```bash
+sed -n '1,30p' backend/tests/test_auth.py
+```
+
+확인 결과:
+- `pytestmark = pytest.mark.asyncio` — 자동 적용
+- `_signup_and_get_token` 같은 헬퍼는 test_users.py에 있음 (test_auth.py엔 없음)
+- 회원가입/로그인 테스트가 단순 client.post 호출
+
+본 PR은 `verify_google_id_token` mock이 필요. monkeypatch fixture 추가 양식:
+
+```python
+@pytest.fixture
+def mock_google_verify(monkeypatch):
+    """Google ID token 검증을 mock. 시나리오별 payload 또는 ValueError raise."""
+    def _setup(payload=None, raise_error=False):
+        def fake_verify(token: str, client_id: str) -> dict:
+            if raise_error:
+                raise ValueError("invalid token (mocked)")
+            return payload or {}
+        monkeypatch.setattr(
+            "src.services.auth_service.verify_google_id_token",
+            fake_verify,
+        )
+    return _setup
+```
+
+이 fixture가 plan §6 함정 #7 (mock 경로)을 정확히 회피. `core.security`가 아닌 `services.auth_service`에 import된 위치를 mock. **정합 OK**.
+
+### 6. `tests/conftest.py` fixtures — 본 PR이 사용할 기존 fixtures
+
+```bash
+grep "@pytest_asyncio\|@pytest.fixture\|^async def" backend/tests/conftest.py
+```
+
+확인 결과:
+- `db_pool` ✅ **본 PR test_google_login_email_conflict_409 + test_google_login_existing_user_200에서 사용 (직접 INSERT)**
+- `client(db_pool)` ✅ **본 PR이 사용**
+
+회원가입/로그인 PR이 만든 conftest.py 그대로. 본 PR은 monkeypatch만 추가 fixture 정의 (test_auth.py 안에). **정합 OK**.
+
+### 7. DB users v2 schema — INSERT/SELECT SQL 정확성
+
+회원가입 PR이 만든 v2 schema:
+
+| 컬럼 | 타입 | 본 PR 영향 |
+|---|---|---|
+| user_id | BIGSERIAL PK | RETURNING |
+| **email** | VARCHAR(200) NOT NULL UNIQUE | INSERT + SELECT (충돌 검사) |
+| password_hash | VARCHAR(200) | NULL로 INSERT (google 사용자) |
+| **auth_provider** | VARCHAR(20) NOT NULL | 'google' 고정 INSERT |
+| **google_id** | VARCHAR(100) UNIQUE | INSERT + SELECT (사용자 식별) |
+| nickname | VARCHAR(100) | Google name 또는 NULL INSERT |
+| created_at | TIMESTAMPTZ NOT NULL | DEFAULT NOW() 자동 |
+| updated_at | TIMESTAMPTZ NOT NULL | DEFAULT NOW() 자동 |
+| is_deleted | BOOLEAN NOT NULL | DEFAULT FALSE |
+
+CHECK 제약:
+- `users_auth_provider_chk`: auth_provider IN ('email','google') ✅
+- `users_email_or_google_chk`:
+  - google: password_hash IS NULL ✅ + google_id IS NOT NULL ✅
+  - 본 PR INSERT 시 자동 강제
+
+google_id UNIQUE 제약 + ON CONFLICT (google_id) DO NOTHING 패턴이 plan §4 step 2.e/2.f와 정확히 정합. **정합 OK**.
+
+### 8. `config.py` settings.google_client_id — 본 PR이 사용할 환경변수
+
+```bash
+grep -B 1 -A 1 "google_client_id" backend/src/config.py
+```
+
+확인 결과:
+- `# --- Google OAuth (Auth #5 Google 로그인 PR에서 사용 예정) ---`
+- `google_client_id: str = ""`
+
+회원가입 PR이 미리 만든 키. default `""`인데 본 PR 시점에 사용자가 .env에 진짜 값 채워둠 (본 채팅에서 확인). 본 PR 코드에서 `from src.config import settings` 후 `settings.google_client_id` 접근. **정합 OK**.
+
+⚠️ Edge case: `.env`에 `GOOGLE_CLIENT_ID=` 빈 값으로 두면 `settings.google_client_id == ""` → verify_google_id_token이 모든 토큰을 audience 불일치로 거부 → 401. CI 환경에서 이 값을 어떻게 셋팅할지 plan에 명시 안 됐으나 .env.test 또는 monkeypatch로 처리 가능. 본 PR mock 테스트 환경에서는 무관 (mock이 verify 자체를 우회). **정합 OK**.
+
+### 9. PII 보호 학습 적용 검증
+
+회원가입/로그인/닉네임/비번 PR 학습 누적 + 본 PR 추가:
+
+- 로그인 PR: `_mask_email` 헬퍼
+- 닉네임/비번 PR: user_id로만 로깅
+- **본 PR 추가 학습**: id_token 자체 logger 진입 절대 금지 (탈취 방지)
+
+본 PR 코드 작성 시:
+- `logger.info("...", req)` 또는 `logger.debug("token=%s", req.id_token)` 같은 실수 금지
+- email 인자 있는 logger.info는 `_mask_email(payload["email"])`
+- user_id, google_id(짧음, hash라 그대로 OK) 노출은 허용
+
+plan §3 #19 + §6 함정 #1 정확히 반영. **정합 OK**.
+
+### 10. requirements.txt — google-auth 의존성
+
+```bash
+grep "google-auth" backend/requirements.txt
+```
+
+확인 결과: `google-auth==2.34.0` 존재. 회원가입 PR이 추가. 본 PR 추가 의존성 0건. **정합 OK**.
+
+## fs 검증 종합
+
+| 의존성 | fs 위치 | 시그니처 일치 | 결과 |
+|---|---|---|---|
+| `verify_google_id_token` | `core/security.py` | ✅ | OK |
+| `GoogleLoginRequest` | `models/user.py` | ✅ | OK |
+| `_build_token_response` 헬퍼 재사용 | `services/auth_service.py` | ✅ | OK |
+| `_mask_email` 헬퍼 재사용 | `services/auth_service.py` | ✅ | OK |
+| api/auth.py 라우트 양식 | `api/auth.py` | ✅ | OK |
+| conftest.py db_pool/client | `tests/conftest.py` | ✅ | OK |
+| `settings.google_client_id` | `src/config.py` | ✅ | OK |
+| users v2 schema (google_id UNIQUE) | DB | ✅ | OK |
+| google-auth 의존성 | `requirements.txt` | ✅ | OK |
+
+**모든 의존성이 fs에 정확히 존재. plan과 일치. 신규 의존성 추가 없음. CHECK 제약 위반 가능성 0.**
+
+## 함정 사후 검증
+
+본 plan §6 함정 회피 항목 7건이 실제 인프라와 정합:
+
+- ✅ Atomic INSERT ON CONFLICT — google_id UNIQUE 제약 + race-safe 패턴
+- ✅ id_token logging 금지 — 코드 리뷰 단계에서 강제 (자동 검증 어려움)
+- ✅ ValueError 일괄 401 — verify_google_id_token이 다양한 사유로 ValueError raise, 모두 401로 처리
+- ✅ email 충돌 vs google_id 충돌 분리 — 두 SELECT 쿼리로 명확히 분기
+- ✅ Google name None/빈 문자열 — nickname Optional NULL 허용
+- ✅ email_verified=False — 본 PR 무조건 허용 (정책)
+- ✅ mock 경로 — `services.auth_service.verify_google_id_token` mock (Python import 정확)
+
+추가 발견 (Metis 권장사항 검증):
+- google-auth의 TransportError (네트워크 오류) — 본 PR ValueError만 잡으니 5xx로 흘러감. FE 재시도 가능. 운영상 큰 문제 없음. plan §6에 추가 명시 권장 수준.
+
+## 판정
+
+**approved** — plan §2 영향 범위(수정 3, 신규 0) fs 실측 정합 완료. §3 불변식 #15가 schema와 정합. §6 함정 회피 7건이 모두 fs/Python import 메커니즘과 정합. 회원가입/로그인/닉네임/비번 PR의 학습 누적 적용.
+
+**plan APPROVED 권장.** 코드 작성 진입 가능.
+
+## broadcast 권장
+
+본 plan은 **시리즈 5/5 마지막 PR이자 외부 API 통합 첫 사례**. 향후 다른 소셜 로그인(Kakao, Naver) plan 작성자가 본 plan §6 함정 회피 7건 + §4 step 2의 7단계 분해를 그대로 따르면 plan 분량 70% 수준 가능. 또한 mock 테스트 양식(monkeypatch.setattr "import된 위치")이 향후 외부 API 의존 모든 plan의 표준 패턴으로 정착 권장.
+
+특히 본 plan의 200/201 분리 정책 (FE 협의 필요)이 RESTful API 설계의 좋은 예 — 신규 가입 vs 기존 로그인을 응답 코드로 구분하여 FE가 적절한 UI 처리 가능.

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -1,6 +1,4 @@
-"""인증 라우터 — /api/v1/auth/signup (Issue #4) + /login (Issue #2).
-
-후속 PR에서 /google 라우트가 같은 모듈에 추가될 예정.
+"""인증 라우터 — /api/v1/auth/signup (Issue #4) + /login (Issue #2) + /google (Issue #42).
 
 기획서 §4.2 + 기능 명세서 CSV의 Request/Response 예시 준수.
 모두 stateless: JWT만 발급, 서버측 세션 없음.
@@ -8,9 +6,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Response, status
 
 from src.models.user import (  # pyright: ignore[reportMissingImports]
+    GoogleLoginRequest,
     LoginRequest,
     SignupRequest,
     TokenResponse,
@@ -40,3 +39,27 @@ async def signup(req: SignupRequest) -> TokenResponse:
 async def login(req: LoginRequest) -> TokenResponse:
     """이메일/비밀번호 검증 후 access_token 발급."""
     return await auth_service.login_email(req)
+
+
+@router.post(
+    "/google",
+    response_model=TokenResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Google 소셜 로그인",
+    responses={
+        200: {"description": "기존 Google 사용자 로그인"},
+        201: {"description": "신규 Google 사용자 자동 가입"},
+        401: {"description": "유효하지 않은 Google 토큰"},
+        409: {"description": "이미 다른 방식으로 가입된 이메일"},
+    },
+)
+async def google_login(req: GoogleLoginRequest, response: Response) -> TokenResponse:
+    """Google ID token으로 로그인 또는 자동 회원가입.
+
+    신규 사용자는 자동 가입 후 201 Created, 기존 사용자는 200 OK 반환.
+    FE는 응답 코드로 신규 가입 여부 구분 가능 (환영 메시지 등).
+    """
+    token_response, is_new_user = await auth_service.login_google(req)
+    if is_new_user:
+        response.status_code = status.HTTP_201_CREATED
+    return token_response

--- a/backend/src/services/auth_service.py
+++ b/backend/src/services/auth_service.py
@@ -10,7 +10,12 @@ DB CHECK 제약 (users_email_or_google_chk)이 위반을 차단하지만,
 동시성 정책 (CodeRabbit #4 권장 반영):
   - check-then-insert 패턴 금지 (race window 발생 가능)
   - INSERT ... ON CONFLICT DO NOTHING RETURNING 으로 atomic 보장
-  - 결과가 None이면 동시에 다른 요청이 같은 email/google_id로 가입 성공 → 409 또는 재조회
+  - asyncpg.UniqueViolationError를 명시적으로 잡아 500 대신 409 응답
+
+비동기 정책 (CodeRabbit Major 학습 — 본 PR #42):
+  - async def 함수에서 동기 I/O (HTTP, blocking syscall) 호출 금지
+  - 외부 라이브러리의 동기 함수는 asyncio.to_thread()로 감싸서 별도 스레드 실행
+  - event loop 블록 방지 → 동시 요청 처리 능력 보존
 
 보안 정책 (CodeRabbit #3 학습 적용):
   - 로그인 401 응답은 항상 동일한 고정 메시지.
@@ -22,9 +27,11 @@ DB CHECK 제약 (users_email_or_google_chk)이 위반을 차단하지만,
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Optional
 
+import asyncpg
 from fastapi import HTTPException, status
 
 from src.config import get_settings  # pyright: ignore[reportMissingImports]
@@ -58,6 +65,11 @@ _GOOGLE_TOKEN_INVALID_DETAIL = "유효하지 않은 Google 토큰입니다"
 # 같은 email이 email/password 방식으로 이미 가입된 경우 자동 통합 거부.
 # 보안 정책: Google 계정 탈취 시 password 가입자 계정까지 탈취되는 위험 차단.
 _EMAIL_CONFLICT_DETAIL = "이미 다른 방식으로 가입된 이메일입니다"
+
+# Google 로그인 410 응답 메시지 (탈퇴자 google_id 재사용).
+# soft-deleted 사용자가 같은 google_id로 재가입 시도하는 경우.
+# 본 PR은 차단 정책 (계정 복구는 후속 plan에서).
+_DELETED_USER_DETAIL = "탈퇴 처리된 계정입니다. 관리자에게 문의해주세요"
 
 
 # ---------------------------------------------------------------------------
@@ -228,11 +240,15 @@ async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
     실패:
       401 — id_token 무효 (위조/만료/audience 불일치 등)
       409 — email 충돌 (같은 email이 email/password 방식으로 이미 가입됨)
+      410 — 탈퇴자 google_id 재사용 (관리자 문의 안내)
 
     동시성:
       INSERT ... ON CONFLICT (google_id) DO NOTHING으로 atomic 보장.
-      RETURNING None 시 다른 요청이 동시에 같은 google_id로 INSERT 성공한 race window.
-      이 경우 SELECT 한 번 더 시도하여 기존 사용자로 처리 (200 반환).
+      추가로 asyncpg.UniqueViolationError를 명시적으로 잡아 email UNIQUE 위반도 처리.
+
+    비동기 (CodeRabbit Major 학습):
+      verify_google_id_token이 동기 HTTP I/O를 수행하므로 asyncio.to_thread로 감싸
+      event loop 블록 방지. 동시 요청 처리 능력 보존.
 
     19 불변식 #15:
       - 신규 INSERT 시 auth_provider='google' 고정, password_hash NULL, google_id NOT NULL.
@@ -244,12 +260,18 @@ async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
       - google_id는 Google이 발급하는 외부 ID라 그대로 노출 OK (사용자 식별 불가).
     """
     pool = get_pool()
+    settings = get_settings()
 
     # 1) Google ID token 검증 — google-auth 라이브러리 위임.
+    # 동기 함수라 asyncio.to_thread()로 감싸서 별도 스레드 실행 (event loop 블록 방지).
     # ValueError: 위조/만료/audience 불일치 등 모든 검증 실패.
     # 모든 ValueError를 401로 일괄 처리 (user enumeration 방지).
     try:
-        payload = verify_google_id_token(req.id_token, get_settings().google_client_id)
+        payload = await asyncio.to_thread(
+            verify_google_id_token,
+            req.id_token,
+            settings.google_client_id,
+        )
     except ValueError:
         logger.info("google login failed: invalid id_token")
         raise HTTPException(
@@ -291,43 +313,38 @@ async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
             False,
         )
 
-    # 4) email 충돌 검사 — 같은 email이 email/password 방식으로 가입됐는지
-    # auth_provider 무관하게 email UNIQUE 제약이 있으므로 INSERT가 실패할 수 있음.
-    # 사전에 명확한 에러 메시지(409)로 차단.
-    email_conflict = await pool.fetchrow(
-        """
-        SELECT user_id
-        FROM users
-        WHERE email = $1 AND is_deleted = FALSE
-        """,
-        email,
-    )
-
-    if email_conflict is not None:
+    # 4) 신규 INSERT — atomic, race-safe.
+    # 두 가지 UNIQUE 제약 (email, google_id) 모두 처리:
+    #   - ON CONFLICT (google_id) DO NOTHING: 같은 google_id 충돌 → RETURNING None
+    #   - email UNIQUE 위반: asyncpg.UniqueViolationError raise
+    # try/except로 두 케이스 모두 명시적 처리하여 raw 500 방지.
+    try:
+        inserted = await pool.fetchrow(
+            """
+            INSERT INTO users (email, password_hash, auth_provider, google_id, nickname)
+            VALUES ($1, NULL, 'google', $2, $3)
+            ON CONFLICT (google_id) DO NOTHING
+            RETURNING user_id, email, nickname
+            """,
+            email,
+            google_id,
+            nickname,
+        )
+    except asyncpg.UniqueViolationError as e:
+        # email UNIQUE 위반 — 같은 email이 다른 auth_provider(=email) 사용자에게 이미 존재.
+        # 보안 정책: 자동 통합 거부 (Google 계정 탈취 시 password 가입자 계정까지 탈취 위험).
+        constraint = getattr(e, "constraint_name", None) or ""
         logger.info(
-            "google login failed: email already used by another auth_provider (email=%s)",
+            "google login failed: unique violation on insert (email=%s, constraint=%s)",
             _mask_email(email),
+            constraint,
         )
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=_EMAIL_CONFLICT_DETAIL,
-        )
+        ) from None
 
-    # 5) 신규 INSERT — atomic, race-safe.
-    # ON CONFLICT (google_id) DO NOTHING: 같은 google_id 동시 INSERT 시 한쪽만 성공.
-    inserted = await pool.fetchrow(
-        """
-        INSERT INTO users (email, password_hash, auth_provider, google_id, nickname)
-        VALUES ($1, NULL, 'google', $2, $3)
-        ON CONFLICT (google_id) DO NOTHING
-        RETURNING user_id, email, nickname
-        """,
-        email,
-        google_id,
-        nickname,
-    )
-
-    # 5-a) 신규 INSERT 성공 → 201 신규 가입
+    # 4-a) 신규 INSERT 성공 → 201 신규 가입
     if inserted is not None:
         return (
             _build_token_response(
@@ -338,21 +355,23 @@ async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
             True,
         )
 
-    # 5-b) RETURNING None = race window (동시에 다른 요청이 같은 google_id INSERT 성공)
-    # 다시 SELECT하여 기존 사용자로 처리 (200).
+    # 4-b) RETURNING None = google_id ON CONFLICT 발동.
+    # 두 가지 케이스 가능:
+    #   - 동시 요청이 같은 google_id로 INSERT 성공 (race window) → 활성 사용자로 SELECT 가능
+    #   - soft-deleted 사용자가 같은 google_id로 재가입 시도 → is_deleted=FALSE SELECT 결과 없음
     raced = await pool.fetchrow(
         """
-        SELECT user_id, email, nickname
+        SELECT user_id, email, nickname, is_deleted
         FROM users
-        WHERE google_id = $1 AND is_deleted = FALSE
+        WHERE google_id = $1
         """,
         google_id,
     )
 
-    # 정상 흐름에선 도달 불가 (방금 INSERT가 실패했으니 SELECT는 성공해야 함). 방어적 코드.
+    # 4-b-1) 정상 흐름에선 도달 불가 (방금 ON CONFLICT 발동했으니 row 존재해야 함). 방어적 코드.
     if raced is None:
         logger.warning(
-            "google login race: INSERT skipped but SELECT also failed (google_id=%s)",
+            "google login race: ON CONFLICT but SELECT failed (google_id=%s)",
             google_id,
         )
         raise HTTPException(
@@ -360,6 +379,19 @@ async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
             detail="internal error during google login",
         )
 
+    # 4-b-2) 탈퇴자 → 410 (관리자 문의 안내, 자동 복구 거부)
+    # 본 PR은 차단 정책. 계정 복구는 후속 plan.
+    if raced["is_deleted"]:
+        logger.info(
+            "google login blocked: deleted user attempted re-signup (google_id=%s)",
+            google_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=_DELETED_USER_DETAIL,
+        )
+
+    # 4-b-3) 활성 사용자 (race window 정상 처리) → 200 로그인
     return (
         _build_token_response(
             user_id=raced["user_id"],

--- a/backend/src/services/auth_service.py
+++ b/backend/src/services/auth_service.py
@@ -1,10 +1,8 @@
-"""인증 비즈니스 로직 — 회원가입(signup_email) + 로그인(login_email).
-
-후속 PR에서 login_google 함수가 같은 모듈에 추가될 예정.
+"""인증 비즈니스 로직 — 회원가입(signup_email) + 로그인(login_email) + Google 로그인(login_google).
 
 19 불변식 #15 인증 매트릭스 준수:
   - email 가입: auth_provider='email', password_hash NOT NULL, google_id NULL
-  - google 가입(다음 PR): auth_provider='google', password_hash NULL, google_id NOT NULL
+  - google 가입: auth_provider='google', password_hash NULL, google_id NOT NULL
 
 DB CHECK 제약 (users_email_or_google_chk)이 위반을 차단하지만,
 코드에서도 명시적으로 분기하여 INSERT.
@@ -12,12 +10,14 @@ DB CHECK 제약 (users_email_or_google_chk)이 위반을 차단하지만,
 동시성 정책 (CodeRabbit #4 권장 반영):
   - check-then-insert 패턴 금지 (race window 발생 가능)
   - INSERT ... ON CONFLICT DO NOTHING RETURNING 으로 atomic 보장
-  - 결과가 None이면 동시에 다른 요청이 같은 email로 가입 성공 → 409
+  - 결과가 None이면 동시에 다른 요청이 같은 email/google_id로 가입 성공 → 409 또는 재조회
 
 보안 정책 (CodeRabbit #3 학습 적용):
   - 로그인 401 응답은 항상 동일한 고정 메시지.
   - wrong_password / user_not_found / google_user 시도 모두 동일 (user enumeration 방지).
+  - Google 토큰 검증 실패 시에도 고정 메시지 ("유효하지 않은 Google 토큰입니다").
   - 상세 사유는 logger.info로만 기록 — 단, **이메일은 마스킹 후 기록** (PII 보호).
+  - **id_token 자체는 어떤 형태로도 logger 진입 절대 금지** (탈취 방지).
 """
 
 from __future__ import annotations
@@ -27,13 +27,16 @@ from typing import Optional
 
 from fastapi import HTTPException, status
 
+from src.config import get_settings  # pyright: ignore[reportMissingImports]
 from src.core.security import (  # pyright: ignore[reportMissingImports]
     create_access_token,
     hash_password,
+    verify_google_id_token,
     verify_password,
 )
 from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
 from src.models.user import (  # pyright: ignore[reportMissingImports]
+    GoogleLoginRequest,
     LoginRequest,
     SignupRequest,
     TokenResponse,
@@ -46,6 +49,15 @@ logger = logging.getLogger(__name__)
 # wrong_password / user_not_found / google_user 시도를 모두 동일 메시지로 통일하여
 # 정보 노출(user enumeration) 방지.
 _LOGIN_ERROR_DETAIL = "이메일 또는 비밀번호가 올바르지 않습니다"
+
+# Google 로그인 401 응답 메시지 (id_token 검증 실패).
+# 위조/만료/audience 불일치 모든 케이스를 동일 메시지로 통일.
+_GOOGLE_TOKEN_INVALID_DETAIL = "유효하지 않은 Google 토큰입니다"
+
+# Google 로그인 409 응답 메시지 (email 충돌).
+# 같은 email이 email/password 방식으로 이미 가입된 경우 자동 통합 거부.
+# 보안 정책: Google 계정 탈취 시 password 가입자 계정까지 탈취되는 위험 차단.
+_EMAIL_CONFLICT_DETAIL = "이미 다른 방식으로 가입된 이메일입니다"
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +88,7 @@ def _mask_email(email: str) -> str:
 def _build_token_response(user_id: int, email: str, nickname: Optional[str]) -> TokenResponse:
     """user_id로 JWT 발급 + TokenResponse 조립.
 
-    후속 PR(로그인/Google 로그인)에서도 재사용.
+    회원가입/로그인/Google 로그인 모두 동일 양식 사용.
     """
     access_token = create_access_token(user_id)
     return TokenResponse(
@@ -199,4 +211,160 @@ async def login_email(req: LoginRequest) -> TokenResponse:
         user_id=row["user_id"],
         email=row["email"],
         nickname=row["nickname"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google 소셜 로그인 — Issue #42
+# ---------------------------------------------------------------------------
+async def login_google(req: GoogleLoginRequest) -> tuple[TokenResponse, bool]:
+    """Google ID token으로 로그인 또는 자동 회원가입.
+
+    반환:
+      (TokenResponse, is_new_user)
+      - is_new_user=False → 기존 사용자 로그인 (라우터가 200 반환)
+      - is_new_user=True  → 신규 사용자 자동 가입 (라우터가 201 반환)
+
+    실패:
+      401 — id_token 무효 (위조/만료/audience 불일치 등)
+      409 — email 충돌 (같은 email이 email/password 방식으로 이미 가입됨)
+
+    동시성:
+      INSERT ... ON CONFLICT (google_id) DO NOTHING으로 atomic 보장.
+      RETURNING None 시 다른 요청이 동시에 같은 google_id로 INSERT 성공한 race window.
+      이 경우 SELECT 한 번 더 시도하여 기존 사용자로 처리 (200 반환).
+
+    19 불변식 #15:
+      - 신규 INSERT 시 auth_provider='google' 고정, password_hash NULL, google_id NOT NULL.
+      - DB CHECK 제약 users_email_or_google_chk가 자동 강제.
+
+    PII 보호 (#19 불변식):
+      - id_token 자체는 어떤 형태로도 logger 진입 금지 (탈취 방지).
+      - email은 _mask_email() 통해 마스킹.
+      - google_id는 Google이 발급하는 외부 ID라 그대로 노출 OK (사용자 식별 불가).
+    """
+    pool = get_pool()
+
+    # 1) Google ID token 검증 — google-auth 라이브러리 위임.
+    # ValueError: 위조/만료/audience 불일치 등 모든 검증 실패.
+    # 모든 ValueError를 401로 일괄 처리 (user enumeration 방지).
+    try:
+        payload = verify_google_id_token(req.id_token, get_settings().google_client_id)
+    except ValueError:
+        logger.info("google login failed: invalid id_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_GOOGLE_TOKEN_INVALID_DETAIL,
+        ) from None
+
+    # 2) payload에서 필수 필드 추출
+    google_id = payload.get("sub")
+    email = payload.get("email")
+    if not google_id or not email:
+        logger.info("google login failed: missing sub or email in payload")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_GOOGLE_TOKEN_INVALID_DETAIL,
+        )
+
+    # name은 없을 수 있음 (Google이 안 줄 수도 있음). nickname=None 허용.
+    nickname: Optional[str] = payload.get("name") or None
+
+    # 3) 기존 google 사용자 조회 — is_deleted=FALSE 강제
+    existing = await pool.fetchrow(
+        """
+        SELECT user_id, email, nickname
+        FROM users
+        WHERE google_id = $1 AND is_deleted = FALSE
+        """,
+        google_id,
+    )
+
+    # 3-a) 기존 사용자 → 200 로그인
+    if existing is not None:
+        return (
+            _build_token_response(
+                user_id=existing["user_id"],
+                email=existing["email"],
+                nickname=existing["nickname"],
+            ),
+            False,
+        )
+
+    # 4) email 충돌 검사 — 같은 email이 email/password 방식으로 가입됐는지
+    # auth_provider 무관하게 email UNIQUE 제약이 있으므로 INSERT가 실패할 수 있음.
+    # 사전에 명확한 에러 메시지(409)로 차단.
+    email_conflict = await pool.fetchrow(
+        """
+        SELECT user_id
+        FROM users
+        WHERE email = $1 AND is_deleted = FALSE
+        """,
+        email,
+    )
+
+    if email_conflict is not None:
+        logger.info(
+            "google login failed: email already used by another auth_provider (email=%s)",
+            _mask_email(email),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_EMAIL_CONFLICT_DETAIL,
+        )
+
+    # 5) 신규 INSERT — atomic, race-safe.
+    # ON CONFLICT (google_id) DO NOTHING: 같은 google_id 동시 INSERT 시 한쪽만 성공.
+    inserted = await pool.fetchrow(
+        """
+        INSERT INTO users (email, password_hash, auth_provider, google_id, nickname)
+        VALUES ($1, NULL, 'google', $2, $3)
+        ON CONFLICT (google_id) DO NOTHING
+        RETURNING user_id, email, nickname
+        """,
+        email,
+        google_id,
+        nickname,
+    )
+
+    # 5-a) 신규 INSERT 성공 → 201 신규 가입
+    if inserted is not None:
+        return (
+            _build_token_response(
+                user_id=inserted["user_id"],
+                email=inserted["email"],
+                nickname=inserted["nickname"],
+            ),
+            True,
+        )
+
+    # 5-b) RETURNING None = race window (동시에 다른 요청이 같은 google_id INSERT 성공)
+    # 다시 SELECT하여 기존 사용자로 처리 (200).
+    raced = await pool.fetchrow(
+        """
+        SELECT user_id, email, nickname
+        FROM users
+        WHERE google_id = $1 AND is_deleted = FALSE
+        """,
+        google_id,
+    )
+
+    # 정상 흐름에선 도달 불가 (방금 INSERT가 실패했으니 SELECT는 성공해야 함). 방어적 코드.
+    if raced is None:
+        logger.warning(
+            "google login race: INSERT skipped but SELECT also failed (google_id=%s)",
+            google_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="internal error during google login",
+        )
+
+    return (
+        _build_token_response(
+            user_id=raced["user_id"],
+            email=raced["email"],
+            nickname=raced["nickname"],
+        ),
+        False,
     )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,9 +1,8 @@
-"""인증 엔드포인트 테스트 — /api/v1/auth/signup (Issue #4) + /login (Issue #2).
-
-후속 PR에서 google 테스트가 같은 파일에 추가될 예정.
-"""
+"""인증 엔드포인트 테스트 — /api/v1/auth/signup (Issue #4) + /login (Issue #2) + /google (Issue #42)."""
 
 from __future__ import annotations
+
+from typing import Any, Optional
 
 import pytest
 from httpx import AsyncClient
@@ -66,17 +65,15 @@ _LOGIN_ERROR = "이메일 또는 비밀번호가 올바르지 않습니다"
 async def test_login_success(client: AsyncClient) -> None:
     """signup → login 동일 자격증명으로 200 + access_token."""
     email = "pytest-login-ok@example.com"
-    password = "password123"
+    password = "password123"  # noqa: S105
     nickname = "로그인성공"
 
-    # 1) signup으로 계정 생성
     sres = await client.post(
         "/api/v1/auth/signup",
         json={"email": email, "password": password, "nickname": nickname},
     )
     assert sres.status_code == 201
 
-    # 2) 같은 자격증명으로 login
     res = await client.post(
         "/api/v1/auth/login",
         json={"email": email, "password": password},
@@ -93,7 +90,7 @@ async def test_login_success(client: AsyncClient) -> None:
 async def test_login_wrong_password(client: AsyncClient) -> None:
     """signup 후 틀린 비번 → 401 + 고정 메시지."""
     email = "pytest-login-wrong@example.com"
-    password = "password123"
+    password = "password123"  # noqa: S105
 
     sres = await client.post(
         "/api/v1/auth/signup",
@@ -123,7 +120,6 @@ async def test_login_google_user_via_password(client: AsyncClient, db_pool) -> N
     """auth_provider='google' 사용자가 password 로그인 시도 → 401 (동일 메시지)."""
     email = "pytest-google-login@example.com"
 
-    # google 사용자 직접 INSERT (signup 라우트가 email 전용이라 SQL로 우회)
     await db_pool.execute(
         """
         INSERT INTO users (email, password_hash, auth_provider, google_id, nickname)
@@ -140,3 +136,141 @@ async def test_login_google_user_via_password(client: AsyncClient, db_pool) -> N
     )
     assert res.status_code == 401
     assert res.json()["detail"] == _LOGIN_ERROR
+
+
+# ---------------------------------------------------------------------------
+# /google — Issue #42
+# ---------------------------------------------------------------------------
+_GOOGLE_TOKEN_INVALID = "유효하지 않은 Google 토큰입니다"
+_EMAIL_CONFLICT = "이미 다른 방식으로 가입된 이메일입니다"
+
+
+@pytest.fixture
+def mock_google_verify(monkeypatch: pytest.MonkeyPatch):
+    """verify_google_id_token을 mock. 시나리오별 payload 또는 ValueError raise.
+
+    Python import 메커니즘 주의:
+      - core.security가 아닌 services.auth_service에 import된 위치를 mock해야 함.
+      - 함수 호출 시점에 services.auth_service.verify_google_id_token이 참조되므로.
+    """
+
+    def _setup(payload: Optional[dict[str, Any]] = None, raise_error: bool = False) -> None:
+        def fake_verify(token: str, client_id: str) -> dict[str, Any]:
+            _ = token, client_id  # 인자 사용 안 함 (mock)
+            if raise_error:
+                raise ValueError("invalid token (mocked)")
+            return payload or {}
+
+        monkeypatch.setattr(
+            "src.services.auth_service.verify_google_id_token",
+            fake_verify,
+        )
+
+    return _setup
+
+
+async def test_google_login_new_user_201(
+    client: AsyncClient,
+    db_pool,  # noqa: ANN001
+    mock_google_verify,  # noqa: ANN001
+) -> None:
+    """신규 google 사용자 자동 가입 → 201 + DB에 INSERT 확인."""
+    google_id = "fake-google-sub-new-user-001"
+    email = "pytest-google-new@example.com"
+
+    mock_google_verify(payload={"sub": google_id, "email": email, "name": "신규구글"})
+
+    res = await client.post(
+        "/api/v1/auth/google",
+        json={"id_token": "fake-id-token-anything"},
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["token_type"] == "Bearer"
+    assert body["email"] == email
+    assert body["nickname"] == "신규구글"
+    assert isinstance(body["access_token"], str) and len(body["access_token"]) > 20
+    assert isinstance(body["user_id"], int)
+
+    # DB에 google 사용자로 INSERT됐는지 확인
+    row = await db_pool.fetchrow(
+        "SELECT auth_provider, google_id, password_hash FROM users WHERE email = $1",
+        email,
+    )
+    assert row is not None
+    assert row["auth_provider"] == "google"
+    assert row["google_id"] == google_id
+    assert row["password_hash"] is None
+
+
+async def test_google_login_existing_user_200(
+    client: AsyncClient,
+    db_pool,  # noqa: ANN001
+    mock_google_verify,  # noqa: ANN001
+) -> None:
+    """기존 google 사용자 로그인 → 200 (DB INSERT 없음)."""
+    google_id = "fake-google-sub-existing-001"
+    email = "pytest-google-existing@example.com"
+
+    # 사전 INSERT
+    await db_pool.execute(
+        """
+        INSERT INTO users (email, password_hash, auth_provider, google_id, nickname)
+        VALUES ($1, NULL, 'google', $2, $3)
+        """,
+        email,
+        google_id,
+        "기존구글",
+    )
+
+    mock_google_verify(payload={"sub": google_id, "email": email, "name": "기존구글"})
+
+    res = await client.post(
+        "/api/v1/auth/google",
+        json={"id_token": "fake-id-token-anything"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["token_type"] == "Bearer"
+    assert body["email"] == email
+    assert body["nickname"] == "기존구글"
+
+
+async def test_google_login_invalid_token_401(
+    client: AsyncClient,
+    mock_google_verify,  # noqa: ANN001
+) -> None:
+    """verify_google_id_token이 ValueError raise → 401 + 고정 메시지."""
+    mock_google_verify(raise_error=True)
+
+    res = await client.post(
+        "/api/v1/auth/google",
+        json={"id_token": "completely-invalid-token"},
+    )
+    assert res.status_code == 401
+    assert res.json()["detail"] == _GOOGLE_TOKEN_INVALID
+
+
+async def test_google_login_email_conflict_409(
+    client: AsyncClient,
+    mock_google_verify,  # noqa: ANN001
+) -> None:
+    """email/password로 이미 가입된 email로 google 로그인 시도 → 409."""
+    email = "pytest-google-conflict@example.com"
+
+    # 1) email/password로 먼저 가입
+    sres = await client.post(
+        "/api/v1/auth/signup",
+        json={"email": email, "password": "password123", "nickname": "패스워드유저"},
+    )
+    assert sres.status_code == 201
+
+    # 2) 같은 email로 google 로그인 시도
+    mock_google_verify(payload={"sub": "different-google-id-12345", "email": email, "name": "구글이름"})
+
+    res = await client.post(
+        "/api/v1/auth/google",
+        json={"id_token": "fake-id-token-anything"},
+    )
+    assert res.status_code == 409
+    assert res.json()["detail"] == _EMAIL_CONFLICT

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -143,6 +143,7 @@ async def test_login_google_user_via_password(client: AsyncClient, db_pool) -> N
 # ---------------------------------------------------------------------------
 _GOOGLE_TOKEN_INVALID = "유효하지 않은 Google 토큰입니다"
 _EMAIL_CONFLICT = "이미 다른 방식으로 가입된 이메일입니다"
+_DELETED_USER = "탈퇴 처리된 계정입니다. 관리자에게 문의해주세요"
 
 
 @pytest.fixture
@@ -151,7 +152,8 @@ def mock_google_verify(monkeypatch: pytest.MonkeyPatch):
 
     Python import 메커니즘 주의:
       - core.security가 아닌 services.auth_service에 import된 위치를 mock해야 함.
-      - 함수 호출 시점에 services.auth_service.verify_google_id_token이 참조되므로.
+      - asyncio.to_thread(verify_google_id_token, ...)로 호출되므로
+        services.auth_service의 참조를 가로채야 함.
     """
 
     def _setup(payload: Optional[dict[str, Any]] = None, raise_error: bool = False) -> None:
@@ -255,7 +257,10 @@ async def test_google_login_email_conflict_409(
     client: AsyncClient,
     mock_google_verify,  # noqa: ANN001
 ) -> None:
-    """email/password로 이미 가입된 email로 google 로그인 시도 → 409."""
+    """email/password로 이미 가입된 email로 google 로그인 시도 → 409.
+
+    INSERT 시도 중 email UNIQUE 위반을 try/except로 잡아 409로 변환 (CodeRabbit Major 학습).
+    """
     email = "pytest-google-conflict@example.com"
 
     # 1) email/password로 먼저 가입
@@ -274,3 +279,36 @@ async def test_google_login_email_conflict_409(
     )
     assert res.status_code == 409
     assert res.json()["detail"] == _EMAIL_CONFLICT
+
+
+async def test_google_login_deleted_user_410(
+    client: AsyncClient,
+    db_pool,  # noqa: ANN001
+    mock_google_verify,  # noqa: ANN001
+) -> None:
+    """탈퇴 처리된(is_deleted=TRUE) google 사용자가 같은 google_id로 재시도 → 410.
+
+    CodeRabbit Major 학습: 이전엔 500 분기로 빠졌으나 이제 410 명확한 응답.
+    """
+    google_id = "fake-google-sub-deleted-001"
+    email = "pytest-google-deleted@example.com"
+
+    # 사전 INSERT 후 is_deleted=TRUE로 탈퇴 시뮬레이션
+    await db_pool.execute(
+        """
+        INSERT INTO users (email, password_hash, auth_provider, google_id, nickname, is_deleted)
+        VALUES ($1, NULL, 'google', $2, $3, TRUE)
+        """,
+        email,
+        google_id,
+        "탈퇴자",
+    )
+
+    mock_google_verify(payload={"sub": google_id, "email": email, "name": "탈퇴자"})
+
+    res = await client.post(
+        "/api/v1/auth/google",
+        json={"id_token": "fake-id-token-anything"},
+    )
+    assert res.status_code == 410
+    assert res.json()["detail"] == _DELETED_USER


### PR DESCRIPTION
회원가입(#13) + 로그인(#21) + 닉네임 변경(#24) + 비번 변경(#25) PR이 만든 인프라 위에 POST /api/v1/auth/google 추가. Closes #42 


## #️⃣ 연관된 이슈
#42 

## #️⃣ 작업 내용

변경:
- services/auth_service.py에 login_google 함수 추가
  + 상수 2개 (_GOOGLE_TOKEN_INVALID_DETAIL, _EMAIL_CONFLICT_DETAIL)
- api/auth.py에 POST /google 라우트 추가 (200/201 분기)
- tests/test_auth.py에 monkeypatch fixture + 테스트 4건 추가

신규 파일 0건 — 인프라 재사용 극대화.

19 불변식:
- #1 PK 이원화: google_id (외부) vs user_id (내부) 분리
- #2 timestamp: 신규 INSERT 시 created_at = NOW()
- #8 SQL 파라미터 양식
- #15 인증 매트릭스: auth_provider='google', password_hash NULL, google_id NOT NULL
- #19 PII 보호: id_token logger 진입 금지, email은 _mask_email 적용

응답:
- 200 OK: 기존 google 사용자 로그인
- 201 Created: 신규 사용자 자동 가입
- 401: 토큰 무효 (위조/만료/audience 불일치 모두 동일 메시지)
- 409: email 충돌 (자동 통합 거부)
## #️⃣ 테스트 결과

테스트 (mock 사용):
- new_user_201: 신규 가입 + DB INSERT 검증
- existing_user_200: 기존 사용자 로그인
- invalid_token_401: ValueError → 401
- email_conflict_409: email/password 가입자와 충돌

검증:
- pytest 20 passed (signup 4 + login 4 + google 4 + nickname 4 + password 4)
- validate.sh 6단계 PASS exit 0
- plan 무결성 OK (5 필수 섹션 + APPROVED)

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google authentication is now available. First-time users are automatically onboarded and receive a 201 response, while returning users receive a 200 response. Invalid credentials and email conflicts are handled with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->