### PR TITLE
fix(ci): SSH host fingerprint 수정 (#44)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,7 +14,7 @@ jobs:
           host: ${{ secrets.GCE_HOST }}
           username: ${{ secrets.GCE_USER }}
           key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
-          fingerprint: "SHA256:WXR+ElhZhKHqJPfqJR/Y/d0JwXxfDDWFjz+YTIl6y3Y"
+          fingerprint: "SHA256:XvtjREpecV3gLUIul+W0Uudb/S9o8ueXbUojqjYKrFs"
           script: |
             set -euo pipefail
             cd ~/LocalBiz-Seoul


### PR DESCRIPTION
## Summary
- deploy-dev.yml의 SSH host fingerprint가 실제 GCE 호스트키와 불일치하여 배포 실패
- 올바른 fingerprint로 수정: `SHA256:XvtjREpecV3gLUIul+W0Uudb/S9o8ueXbUojqjYKrFs`

## Test plan
- [ ] dev 병합 후 GitHub Actions Deploy 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)