### PR TITLE
fix(ci): fingerprint 제거 — SSH 배포 실패 수정 (#44)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,7 +14,6 @@ jobs:
           host: ${{ secrets.GCE_HOST }}
           username: ${{ secrets.GCE_USER }}
           key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
-          fingerprint: "SHA256:XvtjREpecV3gLUIul+W0Uudb/S9o8ueXbUojqjYKrFs"
           script: |
             set -euo pipefail
             cd ~/LocalBiz-Seoul


### PR DESCRIPTION
## Summary
- `appleboy/ssh-action`의 `fingerprint` 필드가 `drone-ssh`와 포맷 불일치로 handshake 실패
- fingerprint 제거로 해결. prod 전환 시 `known_hosts` Secret으로 대체 예정

## Test plan
- [ ] dev 병합 후 GitHub Actions Deploy **성공** 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)