### PR TITLE
[FEAT] SSE: 코스 추천 (COURSE_PLAN)

### DIFF
--- a/.sisyphus/plans/2026-05-05-course-plan/plan.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/plan.md
@@ -1,0 +1,118 @@
+# COURSE_PLAN 노드 구현 — 카테고리별 병렬 검색 → Greedy NN → course + map_route
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-05-05
+- 상태: approved
+
+## 1. 요구사항
+
+API 명세서: `intent → text_stream → course → map_route → done`
+
+"홍대 카페+맛집 코스 추천해줘" 같은 요청에 카테고리별 장소를 병렬 검색 → 거리 기반 경로 최적화 → 코스 타임라인 + 지도 경로 응답.
+
+기능 명세서 정의: "카테고리별 병렬 검색 → ST_DWithin → Greedy NN → OSRM"
+
+> **Phase 1 단순화:** OSRM은 외부 서비스 의존이므로 Phase 1에서는 straight-line 직선 거리 기반 Greedy NN으로 구현. polyline.type="straight". Phase 2에서 OSRM road polyline으로 교체 (스키마 변경 없음, 기획서 api-course-quick-spec.md §Phase 1 vs Phase 2 참조).
+
+### 핵심 흐름
+
+```text
+processed_query (category[], district, neighborhood, keywords)
+  → ① 카테고리별 PG + OS 병렬 검색 (place_recommend 패턴 재활용)
+  → ② 후보 풀 병합 + 중복 제거
+  → ③ Greedy NN 경로 최적화 (직선 거리 기반 최근접 이웃)
+  → ④ LLM 코스 구성 (Gemini Flash — 시간대 배분 + 추천 사유)
+  → ⑤ 블록 생성: text_stream + course + map_route
+```
+
+### 코스 응답 스키마 (기획서 api-course-quick-spec.md 준수)
+
+- `course` 블록: stops[{order, place, duration_min, transit_to_next}], sections(시간대 그룹)
+- `map_route` 블록: markers + polyline(straight segments) + bounds/center
+- `course_id`로 두 블록 연결
+- 좌표: 단일점 {lat, lng}, 배열 [lng, lat] (GeoJSON)
+- 1-indexed order
+
+## 2. 영향 범위
+
+- 신규 파일: `backend/src/graph/course_plan_node.py`
+- 수정 파일: `backend/src/graph/real_builder.py` (stub → 실제 import 교체)
+- 수정 파일: `backend/src/graph/response_builder_node.py` (COURSE_PLAN 블록 순서 등록)
+- 수정 파일: `backend/src/models/blocks.py` (CourseStop/CourseBlock/MapRouteBlock를 api-course-quick-spec.md 스키마에 맞게 재정의)
+- DB 스키마 영향: 없음 (기존 places + places_vector 활용)
+- 응답 블록 16종 영향: 기존 course + map_route 블록 사용 (신규 타입 없음). blocks.py Pydantic 모델을 spec에 맞게 확장하되 CONTENT_BLOCK_TYPES 레지스트리 호환 유지.
+- intent 추가/변경: 없음 (COURSE_PLAN 이미 등록됨)
+- 외부 API 호출: Gemini 2.5 Flash (코스 구성 + text_stream용, 1회당 1호출, 입력 ~3K tokens — 후보 장소 메타 + 사용자 조건. RPM 한도 초과 시 Greedy NN 순서 그대로 반환하는 graceful degradation)
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — places는 UUID(VARCHAR(36))
+- [x] PG↔OS 동기화 — place_id == places_vector._id
+- [x] append-only 4테이블 미수정 — SELECT만 사용
+- [x] 소프트 삭제 매트릭스 준수 — is_deleted=false 필터 (places 테이블 검증 필요 — init_db.sql 갭 인지)
+- [x] 의도적 비정규화 3건 외 신규 비정규화 없음
+- [x] 6 지표 스키마 보존 — 미사용
+- [x] gemini-embedding-001 768d 사용 (OpenAI 임베딩 금지)
+- [x] asyncpg 파라미터 바인딩 ($1, $2)
+- [x] Optional[str] 사용 (str | None 금지)
+- [x] SSE 이벤트 타입 16종 한도 준수 — 기존 타입만 사용 (text_stream, course, map_route)
+- [x] intent별 블록 순서 (기획 §4.5) 준수 — text_stream → course → map_route → done. Phase 1에서 references 미포함 (리뷰 인용 불필요, Phase 2 확장). map_route는 optional.
+- [x] 공통 쿼리 전처리 경유 — query_preprocessor 결과 활용
+- [ ] 행사 검색 DB 우선 → Naver fallback — 해당 없음
+- [ ] 대화 이력 이원화 보존 — 해당 없음
+- [ ] 인증 매트릭스 준수 — 해당 없음
+- [ ] 북마크 = 대화 위치 패러다임 — 해당 없음
+- [ ] 공유링크 인증 우회 범위 — 해당 없음
+- [x] Phase 라벨 명시 — P1
+- [x] 기획 문서 우선 — api-course-quick-spec.md 스키마 준수
+
+## 4. 작업 순서 (Atomic step)
+
+1. **blocks.py CourseStop/CourseBlock/MapRouteBlock 재정의** (category: `deep`)
+   - CourseStop: order, arrival_time, duration_min, place{place_id, name, category, category_label, address, district, location{lat,lng}, rating(Optional), summary}, transit_to_next{mode, mode_ko, distance_m, duration_min}|null, recommendation_reason
+   - Phase 1 포함 place 필드: place_id, name, category, category_label, address, district, location, summary
+   - Phase 1 Optional place 필드: rating (DB 데이터 있으면 포함)
+   - Phase 1 생략 place 필드 (Optional 선언): photo_url, photo_attribution, business_hours_today, is_open_now, booking_url
+   - CourseBlock: type="course", course_id(UUID4), title, description, total_distance_m, total_duration_min, total_stay_min, total_transit_min, stops: list[CourseStop]. Phase 1 생략 필드: sections, emoji, actions, schema_version, photo_url/attribution/business_hours (Optional로 선언)
+   - MapRouteBlock: type="map_route", course_id, bounds{sw,ne}, center{lat,lng}, suggested_zoom, markers[{order, position{lat,lng}, label, category}], polyline{type:"straight", segments[{from_order, to_order, mode, coordinates[[lng,lat],...]}]}
+   - CONTENT_BLOCK_TYPES 레지스트리 호환 유지
+   - Pydantic 모델은 기존 blocks.py flat 패턴 유지 (spec의 `{type, schema_version, content:{...}}` wrapper는 적용하지 않음 — 기존 16종 블록 전부 flat 구조이며, FE가 flat 구조를 직접 소비)
+
+2. **course_plan_node.py 신규 작성** (category: `langgraph-node`)
+   - `_parse_course_categories()`: 쿼리에서 복수 카테고리 추출 ("카페+맛집" → ["카페", "맛집"])
+   - `_search_places_by_category()`: 카테고리별 PG+OS 병렬 검색 (place_recommend 패턴 재활용). `_embed_query_768d()` 복제 (3번째 — TODO: Phase 1 이후 공유 유틸 추출 검토).
+   - `_greedy_nn_route()`: 직선 거리 기반 Greedy Nearest Neighbor 경로 최적화. Haversine 거리 계산.
+   - `_llm_course_compose()`: Gemini Flash로 시간대 배분 + 체류시간 + 추천 사유 생성. 실패 시 균등 배분 fallback.
+   - `_build_course_blocks()`: course + map_route 블록 생성 (api-course-quick-spec.md 스키마). course_id는 UUID4 (spec은 ULID이나, 기존 프로젝트 PK 패턴과 일관성 유지 위해 UUID4 채택. spec api-course-quick-spec.md 갱신 예정: ULID→UUID4).
+   - `_build_text_stream_block()`: 코스 소개 프롬프트 생성.
+   - `course_plan_node()`: LangGraph 노드 엔트리 (state → response_blocks)
+
+3. **real_builder.py 수정** (category: `quick`)
+   - `_course_plan_node` stub 제거
+   - `from src.graph.course_plan_node import course_plan_node` 추가
+   - `graph.add_node("course_plan", course_plan_node)` 교체
+
+4. **response_builder_node.py 수정** (category: `quick`)
+   - `_EXPECTED_BLOCK_ORDER`에 COURSE_PLAN: `["intent", "text_stream", "course", "done"]` 등록
+   - `_OPTIONAL_BLOCKS`에 `map_route` 추가 (이미 `references`는 PLACE_RECOMMEND에서 추가됨)
+   - Phase 1에서 references 블록 미포함 (코스 추천은 리뷰 인용 불필요). spec의 `references`는 Phase 2 확장 시 추가.
+
+5. **단위 테스트 작성** (category: `deep`)
+   - `tests/test_course_plan_node.py`
+   - 케이스: 정상 3-stop 코스, 단일 카테고리, 후보 0건(빈 결과), Greedy NN 경로 순서 검증, LLM 실패 fallback, course/map_route 블록 스키마 검증
+
+## 5. 검증 계획
+
+- `validate.sh` 6단계 통과
+- 단위 테스트: `pytest tests/test_course_plan_node.py -v`
+- 수동 시나리오:
+  - "홍대 카페+맛집 코스" → course(stops 3-5개) + map_route(markers + straight polyline)
+  - "강남역 근처 데이트 코스" → district 필터 + 시간대 배분
+  - "카페 한 곳만" → 단일 stop 코스 (transit_to_next: null)
+- smoke: `python -c "from src.graph.real_builder import build_graph; build_graph()"`
+- course 블록 검증: stops order 1-indexed 연속, 마지막 transit_to_next null, markers.length == stops.length
+
+## 6. 최종 결정
+
+APPROVED (2026-05-05, Metis okay + Momus approved)

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/001-metis-reject.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/001-metis-reject.md
@@ -1,0 +1,42 @@
+# Review 001 — Metis
+
+## 검토자
+
+metis
+
+## 검토 일시
+
+2026-05-05
+
+## 검토 대상
+
+../plan.md (2026-05-05 draft)
+
+## 판정
+
+reject
+
+## 근거
+
+### Gap
+
+1. **blocks.py 스키마 불일치**: CourseBlock/CourseStop(7필드)과 MapRouteBlock(encoded string)이 api-course-quick-spec.md 스키마(40+ 필드, structured segments)와 구조적으로 다름. plan이 blocks.py를 영향 범위에 포함하지 않음.
+2. **블록 순서 미확정**: spec은 `text → course → map_route → references → done`인데 plan은 references 누락.
+3. **response_builder_node.py 등록 값 불확정**: 블록 순서가 미확정이므로 등록할 값도 미결정.
+
+### 숨은 의도
+
+Phase 1 단순화(OSRM 미사용)는 합리적. PG+OS 하이브리드 전환 의도 올바름.
+
+### AI Slop / 오버엔지니어링
+
+없음. `_embed_query_768d()` 3중 복제는 인지 권고 수준.
+
+## 요구 수정사항
+
+1. blocks.py를 수정 대상으로 추가 + Phase 1에서 구현할 필드 범위 명시
+2. 블록 순서 확정 (references 포함 여부)
+
+## 다음 액션
+
+reject → plan.md 수정 후 재리뷰

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/002-metis-okay.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/002-metis-okay.md
@@ -1,0 +1,12 @@
+# Review 002 — Metis
+
+## 검토자
+metis
+## 검토 일시
+2026-05-05
+## 판정
+okay
+## 근거
+이전 reject 2건 수정사항 모두 반영 확인. blocks.py 영향 범위 추가 + Phase 1 필드 범위 명시. 블록 순서 확정 (references Phase 2 확장 명시).
+## 다음 액션
+okay → Momus 검토

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/003-momus-reject.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/003-momus-reject.md
@@ -1,0 +1,14 @@
+# Review 003 — Momus
+
+## 검토자
+momus
+## 검토 일시
+2026-05-05
+## 판정
+reject
+## 요구 수정사항
+1. course_id 타입: ULID(spec) vs UUID4(plan) 편차 해명
+2. place 하위 필드 Phase 1/2 분류 완성 (category_label, rating, summary, is_open_now, booking_url)
+3. content wrapper vs flat 구조 설계 결정 1줄 기술
+## 다음 액션
+reject → 3건 수정 후 재리뷰

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/004-momus-approved.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/004-momus-approved.md
@@ -1,0 +1,16 @@
+# Review 004 — Momus
+
+## 검토자
+momus
+## 검토 일시
+2026-05-05
+## 판정
+approved
+## 근거
+이전 reject 3건 모두 반영 확인:
+1. course_id UUID4 채택 + spec 갱신 예정 명시
+2. place 하위 필드 3-tier 분류 (포함/Optional/생략) 완성
+3. flat 구조 유지 설계 결정 기술
+파일 참조, 19 불변식, 검증 계획 모두 PASS.
+## 다음 액션
+approved → APPROVED 갱신

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -65,7 +65,11 @@ async def _embed_query_768d(query: str, api_key: str) -> list[float]:
         resp.raise_for_status()
         data = resp.json()
 
-    return data.get("embedding", {}).get("values", [0.0] * 768)
+    values = data.get("embedding", {}).get("values")
+    if not values:
+        logger.warning("_embed_query_768d: API 응답에 embedding.values 없음 → zero vector fallback")
+        return [0.0] * 768
+    return values
 
 
 # ---------------------------------------------------------------------------
@@ -402,9 +406,19 @@ def _build_blocks(
     total_stay_min = 0
     total_transit_min = 0
 
+    # order 기준 dict lookup (LLM이 순서 바꿔 반환할 수 있음)
+    detail_by_order: dict[int, dict[str, Any]] = {}
+    for d in stop_details:
+        order = d.get("order")
+        if isinstance(order, int):
+            detail_by_order[order] = d
+    # order 키 없으면 index fallback
+    if not detail_by_order:
+        detail_by_order = {i + 1: d for i, d in enumerate(stop_details)}
+
     course_stops: list[dict[str, Any]] = []
     for i, place in enumerate(route):
-        detail = stop_details[i] if i < len(stop_details) else {}
+        detail = detail_by_order.get(i + 1, {})
 
         duration = detail.get("duration_min", _DEFAULT_DURATION_MIN)
         total_stay_min += duration

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -75,7 +75,7 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
     categories: list[str] = []
 
-    # query에서 +, &, 와/과 구분자로 분리
+    # query에서 +, &, 와/과 구분자로 분리 — 첫 매칭 구분자만 사용
     for sep in ["+", "&", "와 ", "과 ", ", "]:
         if sep in query:
             parts = [p.strip() for p in query.split(sep)]
@@ -83,6 +83,7 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
                 for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
                     if keyword in part and keyword not in categories:
                         categories.append(keyword)
+            break  # 첫 매칭 구분자로만 파싱
 
     if not categories and pq_category:
         categories = [pq_category]
@@ -191,7 +192,7 @@ async def _search_by_categories(
     seen: set[str] = set()
     merged: list[dict[str, Any]] = []
     for result in results:
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             logger.warning("Category search error: %s", result)
             continue
         for place in result:
@@ -441,8 +442,9 @@ def _build_blocks(
                 "category_label": place.get("category"),
                 "address": place.get("address"),
                 "district": place.get("district"),
-                "location": {"lat": place["lat"], "lng": place["lng"]} if place.get("lat") is not None else None,
-                "summary": place.get("name", ""),
+                "location": {"lat": place["lat"], "lng": place["lng"]}
+                if place.get("lat") is not None and place.get("lng") is not None
+                else None,
             },
             "transit_to_next": transit_to_next,
             "recommendation_reason": detail.get("recommendation_reason"),
@@ -466,7 +468,7 @@ def _build_blocks(
     # --- map_route 블록 ---
     markers: list[dict[str, Any]] = []
     for i, place in enumerate(route):
-        if place.get("lat") is not None:
+        if place.get("lat") is not None and place.get("lng") is not None:
             markers.append(
                 {
                     "order": i + 1,
@@ -567,7 +569,7 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
                     "system": _COURSE_SYSTEM_PROMPT,
                     "prompt": f"사용자 질문: {query}\n\n코스를 구성할 장소를 찾지 못했습니다. 다른 지역이나 카테고리로 다시 시도해보세요.",
                 },
-                {"type": "course", "stops": [], "total_duration_min": 0},
+                {"type": "course", "course_id": str(uuid.uuid4()), "stops": [], "total_duration_min": 0},
             ]
         }
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -79,15 +79,23 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
     categories: list[str] = []
 
+    _KNOWN_CATEGORIES = ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]
+
     # query에서 +, &, 와/과 구분자로 분리 — 첫 매칭 구분자만 사용
     for sep in ["+", "&", "와 ", "과 ", ", "]:
         if sep in query:
             parts = [p.strip() for p in query.split(sep)]
             for part in parts:
-                for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
+                for keyword in _KNOWN_CATEGORIES:
                     if keyword in part and keyword not in categories:
                         categories.append(keyword)
             break  # 첫 매칭 구분자로만 파싱
+
+    # 구분자 없는 단일 카테고리 쿼리 ("홍대 카페 코스") — whole-query 키워드 스캔
+    if not categories:
+        for keyword in _KNOWN_CATEGORIES:
+            if keyword in query and keyword not in categories:
+                categories.append(keyword)
 
     if not categories and pq_category:
         categories = [pq_category]
@@ -187,9 +195,9 @@ async def _search_by_categories(
 
     for cat in categories:
         tasks.append(_search_pg(pool, district, cat, neighborhood))
-
-    if os_client and api_key:
-        tasks.append(_search_os(os_client, expanded_query, api_key))
+        # 카테고리별 OS 검색 — 카테고리 키워드를 포함한 쿼리로 분리
+        if os_client and api_key:
+            tasks.append(_search_os(os_client, f"{expanded_query} {cat}", api_key))
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -330,9 +338,24 @@ async def _llm_course_compose(
             text = text.strip()
 
         result = json.loads(text)
+        if not isinstance(result, dict):
+            logger.warning("LLM course compose: 응답이 dict 아님 → fallback")
+            return None, None, []
+
         title = result.get("title")
         description = result.get("description")
-        stop_details = result.get("stops", [])
+        raw_stops = result.get("stops", [])
+
+        # stops 요소 검증 — dict가 아니거나 order 없으면 제외
+        stop_details: list[dict[str, Any]] = []
+        for s in raw_stops:
+            if not isinstance(s, dict):
+                continue
+            # duration_min 타입 정규화
+            dur = s.get("duration_min")
+            if isinstance(dur, str) and dur.isdigit():
+                s["duration_min"] = int(dur)
+            stop_details.append(s)
 
         return title, description, stop_details
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -1,0 +1,591 @@
+"""COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
+
+검색 흐름:
+  1. 쿼리에서 복수 카테고리 파싱 ("카페+맛집" → ["카페", "맛집"])
+  2. 카테고리별 PG + OS 병렬 검색 (place_recommend 패턴 재활용)
+  3. Greedy Nearest Neighbor 경로 최적화 (Haversine 직선 거리)
+  4. LLM 코스 구성 (Gemini Flash — 시간대 배분 + 추천 사유)
+  5. 블록: text_stream + course + map_route
+
+Phase 1 단순화: OSRM 미사용, polyline.type="straight". Phase 2에서 road polyline 교체.
+ST_DWithin 공간 필터는 AgentState에 user_location 추가 후 도입 예정.
+
+불변식 #2: place_id == places_vector._id
+불변식 #7: gemini-embedding-001 768d
+불변식 #8: asyncpg $1,$2 바인딩
+불변식 #11: intent → text_stream → course → map_route → done
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import uuid
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_COURSE_SYSTEM_PROMPT = (
+    "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
+    "사용자의 코스 추천 결과를 친절하게 소개해주세요. "
+    "각 장소의 추천 이유와 이동 동선을 자연스럽게 설명하고, "
+    "소요 시간과 팁도 포함해주세요."
+)
+
+_MAX_STOPS = 5
+_DEFAULT_DURATION_MIN = 60
+_OS_TOP_K = 10
+_OS_MIN_SCORE = 0.4
+_PG_LIMIT = 10
+
+
+# ---------------------------------------------------------------------------
+# Gemini 768d 임베딩 (place_search/place_recommend 동일 로직 복제)
+# TODO: Phase 1 이후 공유 유틸 추출 검토
+# ---------------------------------------------------------------------------
+async def _embed_query_768d(query: str, api_key: str) -> list[float]:
+    """Gemini embedding-001 768d 단건 임베딩. 불변식 #7."""
+    import httpx
+
+    url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent"
+    body = {
+        "model": "models/gemini-embedding-001",
+        "content": {"parts": [{"text": query[:2000]}]},
+        "outputDimensionality": 768,
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "x-goog-api-key": api_key,
+    }
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(url, json=body, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+    return data.get("embedding", {}).get("values", [0.0] * 768)
+
+
+# ---------------------------------------------------------------------------
+# ① 카테고리 파싱
+# ---------------------------------------------------------------------------
+def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
+    """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
+    categories: list[str] = []
+
+    # query에서 +, &, 와/과 구분자로 분리
+    for sep in ["+", "&", "와 ", "과 ", ", "]:
+        if sep in query:
+            parts = [p.strip() for p in query.split(sep)]
+            for part in parts:
+                for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
+                    if keyword in part and keyword not in categories:
+                        categories.append(keyword)
+
+    if not categories and pq_category:
+        categories = [pq_category]
+
+    if not categories:
+        categories = ["맛집"]
+
+    return categories[:3]  # 최대 3 카테고리
+
+
+# ---------------------------------------------------------------------------
+# ② 카테고리별 PG + OS 병렬 검색
+# ---------------------------------------------------------------------------
+async def _search_pg(
+    pool: Any,
+    district: Optional[str],
+    category: str,
+    neighborhood: Optional[str],
+) -> list[dict[str, Any]]:
+    """places 테이블 카테고리별 검색. 불변식 #8."""
+    sql = (
+        "SELECT place_id, name, category, address, district, "
+        "ST_Y(geom::geometry) AS lat, ST_X(geom::geometry) AS lng "
+        "FROM places WHERE is_deleted = false"
+    )
+    params: list[Any] = []
+
+    params.append(f"%{category}%")
+    sql += f" AND category ILIKE ${len(params)}"
+
+    if district:
+        params.append(district)
+        sql += f" AND district = ${len(params)}"
+
+    if neighborhood:
+        params.append(f"%{neighborhood}%")
+        sql += f" AND (address ILIKE ${len(params)} OR name ILIKE ${len(params)})"
+
+    params.append(_PG_LIMIT)
+    sql += f" LIMIT ${len(params)}"
+
+    try:
+        rows = await pool.fetch(sql, *params)
+        return [dict(r) for r in rows]
+    except Exception:
+        logger.exception("PG course search failed for category=%s", category)
+        return []
+
+
+async def _search_os(
+    os_client: Any,
+    query: str,
+    api_key: str,
+) -> list[dict[str, Any]]:
+    """places_vector k-NN 검색."""
+    try:
+        query_vector = await _embed_query_768d(query, api_key)
+
+        body: dict[str, Any] = {
+            "size": _OS_TOP_K,
+            "query": {"knn": {"embedding": {"vector": query_vector, "k": _OS_TOP_K}}},
+            "min_score": _OS_MIN_SCORE,
+        }
+
+        result = await os_client.search(index="places_vector", body=body)
+        hits = result.get("hits", {}).get("hits", [])
+
+        return [
+            {
+                "place_id": hit.get("_id", ""),
+                "name": hit.get("_source", {}).get("name", ""),
+                "category": hit.get("_source", {}).get("category", ""),
+                "address": hit.get("_source", {}).get("address", ""),
+                "district": hit.get("_source", {}).get("district", ""),
+                "lat": hit.get("_source", {}).get("lat"),
+                "lng": hit.get("_source", {}).get("lng"),
+                "score": hit.get("_score", 0),
+            }
+            for hit in hits
+        ]
+    except Exception:
+        logger.exception("OS course search failed")
+        return []
+
+
+async def _search_by_categories(
+    pool: Any,
+    os_client: Optional[Any],
+    categories: list[str],
+    district: Optional[str],
+    neighborhood: Optional[str],
+    expanded_query: str,
+    api_key: Optional[str],
+) -> list[dict[str, Any]]:
+    """카테고리별 PG + OS 병렬 검색 → 병합."""
+    tasks: list[Any] = []
+
+    for cat in categories:
+        tasks.append(_search_pg(pool, district, cat, neighborhood))
+
+    if os_client and api_key:
+        tasks.append(_search_os(os_client, expanded_query, api_key))
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    seen: set[str] = set()
+    merged: list[dict[str, Any]] = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.warning("Category search error: %s", result)
+            continue
+        for place in result:
+            pid = place.get("place_id", "")
+            if pid and pid not in seen:
+                seen.add(pid)
+                merged.append(place)
+
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# ③ Greedy Nearest Neighbor 경로 최적화
+# ---------------------------------------------------------------------------
+def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """두 좌표 간 Haversine 거리 (미터)."""
+    r = 6371000
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return r * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _greedy_nn_route(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Greedy Nearest Neighbor — 직선 거리 기반 최근접 이웃 순서 결정.
+
+    좌표 없는 후보는 뒤에 배치. 최대 _MAX_STOPS건.
+    """
+    with_coords = [c for c in candidates if c.get("lat") is not None and c.get("lng") is not None]
+    without_coords = [c for c in candidates if c.get("lat") is None or c.get("lng") is None]
+
+    if not with_coords:
+        return candidates[:_MAX_STOPS]
+
+    route: list[dict[str, Any]] = [with_coords[0]]
+    remaining = with_coords[1:]
+
+    while remaining and len(route) < _MAX_STOPS:
+        last = route[-1]
+        nearest_idx = 0
+        nearest_dist = float("inf")
+        for i, c in enumerate(remaining):
+            dist = _haversine_m(last["lat"], last["lng"], c["lat"], c["lng"])
+            if dist < nearest_dist:
+                nearest_dist = dist
+                nearest_idx = i
+        route.append(remaining.pop(nearest_idx))
+
+    # 좌표 없는 후보로 남은 슬롯 채우기
+    for c in without_coords:
+        if len(route) >= _MAX_STOPS:
+            break
+        route.append(c)
+
+    return route
+
+
+# ---------------------------------------------------------------------------
+# ④ LLM 코스 구성
+# ---------------------------------------------------------------------------
+_COURSE_COMPOSE_PROMPT = """\
+사용자의 코스 추천 요청에 맞춰 코스를 구성해주세요.
+장소 목록과 순서가 주어집니다. 각 장소에 대해:
+
+JSON으로만 응답하세요:
+{
+  "title": "코스 제목 (예: '홍대 카페+맛집 한나절 코스')",
+  "description": "코스 한줄 설명",
+  "stops": [
+    {
+      "order": 1,
+      "arrival_time": "HH:mm (예: 11:00)",
+      "duration_min": 체류시간(분),
+      "recommendation_reason": "추천 이유 한 줄",
+      "transit_mode": "walk|subway|bus|taxi (다음 장소까지 이동 수단)"
+    }
+  ]
+}
+
+시간대 배분 규칙:
+- 시작 시간은 11:00 기본
+- 각 장소 체류 30-90분
+- 이동 시간은 도보 기준 예상
+- 마지막 장소의 transit_mode는 null
+"""
+
+
+async def _llm_course_compose(
+    route: list[dict[str, Any]],
+    query: str,
+) -> tuple[Optional[str], Optional[str], list[dict[str, Any]]]:
+    """Gemini Flash로 코스 구성. 실패 시 균등 배분 fallback.
+
+    Returns:
+        (title, description, stop_details[{arrival_time, duration_min, recommendation_reason, transit_mode}])
+    """
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    from src.config import get_settings
+
+    settings = get_settings()
+    if not settings.gemini_llm_api_key or not route:
+        return None, None, []
+
+    place_lines = "\n".join(
+        f"- {i + 1}. {p.get('name', '')} ({p.get('category', '')}, {p.get('district', '')})"
+        for i, p in enumerate(route)
+    )
+
+    try:
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+
+        response = await llm.ainvoke(
+            [
+                ("system", _COURSE_COMPOSE_PROMPT),
+                ("human", f"사용자 요청: {query}\n\n경유 장소 (순서대로):\n{place_lines}"),
+            ]
+        )
+        text = str(response.content).strip()
+
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+        title = result.get("title")
+        description = result.get("description")
+        stop_details = result.get("stops", [])
+
+        return title, description, stop_details
+
+    except Exception:
+        logger.exception("LLM course compose failed → fallback")
+        return None, None, []
+
+
+def _apply_fallback_times(route: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """LLM 실패 시 균등 배분 fallback."""
+    details: list[dict[str, Any]] = []
+    hour = 11
+    minute = 0
+
+    for i in range(len(route)):
+        details.append(
+            {
+                "order": i + 1,
+                "arrival_time": f"{hour:02d}:{minute:02d}",
+                "duration_min": _DEFAULT_DURATION_MIN,
+                "recommendation_reason": None,
+                "transit_mode": "walk" if i < len(route) - 1 else None,
+            }
+        )
+        minute += _DEFAULT_DURATION_MIN + 15  # 체류 + 이동 15분
+        while minute >= 60:
+            hour += 1
+            minute -= 60
+
+    return details
+
+
+# ---------------------------------------------------------------------------
+# ⑤ 블록 생성
+# ---------------------------------------------------------------------------
+def _build_blocks(
+    query: str,
+    route: list[dict[str, Any]],
+    title: Optional[str],
+    description: Optional[str],
+    stop_details: list[dict[str, Any]],
+    course_id: str,
+) -> list[dict[str, Any]]:
+    """text_stream + course + map_route 블록 생성."""
+    blocks: list[dict[str, Any]] = []
+
+    # fallback 적용
+    if not stop_details:
+        stop_details = _apply_fallback_times(route)
+
+    if not title:
+        title = "추천 코스"
+    if not description:
+        description = f"{len(route)}곳을 둘러보는 코스"
+
+    # --- text_stream ---
+    stop_summary = "\n".join(
+        f"- {route[i].get('name', '')} ({route[i].get('category', '')})" for i in range(len(route))
+    )
+    prompt = (
+        f"사용자 질문: {query}\n\n"
+        f"코스 제목: {title}\n"
+        f"코스 설명: {description}\n\n"
+        f"경유 장소:\n{stop_summary}\n\n"
+        "위 코스를 친절하게 소개해주세요. 각 장소의 특징과 동선을 설명해주세요."
+    )
+    blocks.append({"type": "text_stream", "system": _COURSE_SYSTEM_PROMPT, "prompt": prompt})
+
+    # --- course 블록 ---
+    total_distance_m = 0
+    total_stay_min = 0
+    total_transit_min = 0
+
+    course_stops: list[dict[str, Any]] = []
+    for i, place in enumerate(route):
+        detail = stop_details[i] if i < len(stop_details) else {}
+
+        duration = detail.get("duration_min", _DEFAULT_DURATION_MIN)
+        total_stay_min += duration
+
+        transit_to_next: Optional[dict[str, Any]] = None
+        if i < len(route) - 1:
+            next_place = route[i + 1]
+            if place.get("lat") is not None and next_place.get("lat") is not None:
+                dist = int(_haversine_m(place["lat"], place["lng"], next_place["lat"], next_place["lng"]))
+                transit_min = max(1, dist // 80)  # 도보 약 80m/min
+            else:
+                dist = 0
+                transit_min = 10
+
+            total_distance_m += dist
+            total_transit_min += transit_min
+
+            mode = detail.get("transit_mode", "walk") or "walk"
+            mode_ko_map = {"walk": "도보", "subway": "지하철", "bus": "버스", "taxi": "택시"}
+            transit_to_next = {
+                "mode": mode,
+                "mode_ko": mode_ko_map.get(mode, "도보"),
+                "distance_m": dist,
+                "duration_min": transit_min,
+            }
+
+        stop: dict[str, Any] = {
+            "order": i + 1,
+            "arrival_time": detail.get("arrival_time"),
+            "duration_min": duration,
+            "place": {
+                "place_id": place.get("place_id", ""),
+                "name": place.get("name", ""),
+                "category": place.get("category"),
+                "category_label": place.get("category"),
+                "address": place.get("address"),
+                "district": place.get("district"),
+                "location": {"lat": place["lat"], "lng": place["lng"]} if place.get("lat") is not None else None,
+                "summary": place.get("name", ""),
+            },
+            "transit_to_next": transit_to_next,
+            "recommendation_reason": detail.get("recommendation_reason"),
+        }
+        course_stops.append(stop)
+
+    blocks.append(
+        {
+            "type": "course",
+            "course_id": course_id,
+            "title": title,
+            "description": description,
+            "total_distance_m": total_distance_m,
+            "total_duration_min": total_stay_min + total_transit_min,
+            "total_stay_min": total_stay_min,
+            "total_transit_min": total_transit_min,
+            "stops": course_stops,
+        }
+    )
+
+    # --- map_route 블록 ---
+    markers: list[dict[str, Any]] = []
+    for i, place in enumerate(route):
+        if place.get("lat") is not None:
+            markers.append(
+                {
+                    "order": i + 1,
+                    "position": {"lat": place["lat"], "lng": place["lng"]},
+                    "label": place.get("name", ""),
+                    "category": place.get("category"),
+                }
+            )
+
+    segments: list[dict[str, Any]] = []
+    for i in range(len(route) - 1):
+        p1 = route[i]
+        p2 = route[i + 1]
+        if p1.get("lat") is not None and p2.get("lat") is not None:
+            detail = stop_details[i] if i < len(stop_details) else {}
+            segments.append(
+                {
+                    "from_order": i + 1,
+                    "to_order": i + 2,
+                    "mode": detail.get("transit_mode", "walk") or "walk",
+                    "coordinates": [
+                        [p1["lng"], p1["lat"]],  # GeoJSON [lng, lat]
+                        [p2["lng"], p2["lat"]],
+                    ],
+                }
+            )
+
+    # bounds 계산
+    lats = [p["lat"] for p in route if p.get("lat") is not None]
+    lngs = [p["lng"] for p in route if p.get("lng") is not None]
+
+    if markers:
+        blocks.append(
+            {
+                "type": "map_route",
+                "course_id": course_id,
+                "bounds": {
+                    "sw": {"lat": min(lats), "lng": min(lngs)},
+                    "ne": {"lat": max(lats), "lng": max(lngs)},
+                },
+                "center": {"lat": sum(lats) / len(lats), "lng": sum(lngs) / len(lngs)},
+                "suggested_zoom": 14,
+                "markers": markers,
+                "polyline": {"type": "straight", "segments": segments},
+            }
+        )
+
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# LangGraph 노드
+# ---------------------------------------------------------------------------
+async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
+    """COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
+
+    Args:
+        state: AgentState dict.
+
+    Returns:
+        {"response_blocks": [text_stream, course, map_route]}.
+    """
+    from src.config import get_settings
+    from src.db.opensearch import get_os_client
+    from src.db.postgres import get_pool
+
+    query = state.get("query", "")
+    pq = state.get("processed_query") or {}
+
+    district = pq.get("district")
+    neighborhood = pq.get("neighborhood")
+    pq_category = pq.get("category")
+    expanded_query = pq.get("expanded_query") or query
+
+    settings = get_settings()
+    pool = get_pool()
+
+    # ① 카테고리 파싱
+    categories = _parse_categories(query, pq_category)
+
+    # ② 카테고리별 병렬 검색
+    os_client: Optional[Any] = None
+    api_key: Optional[str] = settings.gemini_llm_api_key
+    try:
+        os_client = get_os_client()
+    except RuntimeError:
+        logger.warning("OpenSearch client not initialized, skipping vector search")
+
+    candidates = await _search_by_categories(
+        pool, os_client, categories, district, neighborhood, expanded_query, api_key
+    )
+
+    if not candidates:
+        return {
+            "response_blocks": [
+                {
+                    "type": "text_stream",
+                    "system": _COURSE_SYSTEM_PROMPT,
+                    "prompt": f"사용자 질문: {query}\n\n코스를 구성할 장소를 찾지 못했습니다. 다른 지역이나 카테고리로 다시 시도해보세요.",
+                },
+                {"type": "course", "stops": [], "total_duration_min": 0},
+            ]
+        }
+
+    # ③ Greedy NN 경로 최적화
+    route = _greedy_nn_route(candidates)
+
+    # ④ LLM 코스 구성
+    title, description, stop_details = await _llm_course_compose(route, query)
+
+    # ⑤ 블록 생성
+    course_id = str(uuid.uuid4())
+    blocks = _build_blocks(query, route, title, description, stop_details, course_id)
+
+    logger.info(
+        "course_plan: categories=%s, candidates=%d, route=%d stops",
+        categories,
+        len(candidates),
+        len(route),
+    )
+
+    return {"response_blocks": blocks}

--- a/backend/src/graph/real_builder.py
+++ b/backend/src/graph/real_builder.py
@@ -17,6 +17,7 @@ from langgraph.graph import END, StateGraph
 
 from src.graph.booking_node import booking_node  # pyright: ignore[reportMissingImports]
 from src.graph.calendar_node import calendar_node  # pyright: ignore[reportMissingImports]
+from src.graph.course_plan_node import course_plan_node  # pyright: ignore[reportMissingImports]  # noqa: F401
 from src.graph.detail_inquiry_node import detail_inquiry_node  # pyright: ignore[reportMissingImports]  # noqa: F401
 from src.graph.general_node import general_node  # pyright: ignore[reportMissingImports]
 from src.graph.intent_router_node import intent_router_node  # pyright: ignore[reportMissingImports]
@@ -41,11 +42,6 @@ async def _event_search_node(state: AgentState) -> dict[str, Any]:
 
 async def _event_recommend_node(state: AgentState) -> dict[str, Any]:
     """행사 추천 노드 stub (events[] + references, EVENT_SEARCH 대칭)."""
-    return {"response_blocks": []}
-
-
-async def _course_plan_node(state: AgentState) -> dict[str, Any]:
-    """코스 계획 노드 stub."""
     return {"response_blocks": []}
 
 
@@ -104,7 +100,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
     graph.add_node("place_recommend", place_recommend_node)
     graph.add_node("event_search", _event_search_node)
     graph.add_node("event_recommend", _event_recommend_node)
-    graph.add_node("course_plan", _course_plan_node)
+    graph.add_node("course_plan", course_plan_node)
     graph.add_node("general", general_node)
     graph.add_node("detail_inquiry", detail_inquiry_node)
     graph.add_node("booking", booking_node)

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -26,11 +26,12 @@ _EXPECTED_BLOCK_ORDER: dict[str, list[str]] = {
     "GENERAL": ["intent", "text_stream", "done"],
     "PLACE_SEARCH": ["intent", "text_stream", "places", "done"],
     "PLACE_RECOMMEND": ["intent", "text_stream", "places", "done"],
+    "COURSE_PLAN": ["intent", "text_stream", "course", "done"],
     "DETAIL_INQUIRY": ["intent", "text_stream", "done"],
 }
 
 # 선택적 블록 — 있어도 되고 없어도 되는 블록 (순서 검증에서 제외)
-_OPTIONAL_BLOCKS: frozenset[str] = frozenset({"map_markers", "place", "references"})
+_OPTIONAL_BLOCKS: frozenset[str] = frozenset({"map_markers", "map_route", "place", "references"})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/models/blocks.py
+++ b/backend/src/models/blocks.py
@@ -107,27 +107,59 @@ class EventsBlock(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# 7. course — 코스 타임라인
+# 7. course — 코스 타임라인 (api-course-quick-spec.md 준수, flat 패턴)
 # ---------------------------------------------------------------------------
+class CoursePlaceInfo(BaseModel):
+    """코스 stop 내 장소 정보 — 자체 완결 (FE 추가 조회 불필요)."""
+
+    place_id: str
+    name: str = ""
+    category: Optional[str] = None
+    category_label: Optional[str] = None
+    address: Optional[str] = None
+    district: Optional[str] = None
+    location: Optional[dict[str, float]] = None  # {"lat": ..., "lng": ...}
+    rating: Optional[float] = None
+    summary: Optional[str] = None
+    photo_url: Optional[str] = None  # Phase 1 생략
+    photo_attribution: Optional[str] = None  # Phase 1 생략
+    business_hours_today: Optional[str] = None  # Phase 1 생략
+    is_open_now: Optional[bool] = None  # Phase 1 생략
+    booking_url: Optional[str] = None  # Phase 1 생략
+
+
+class CourseTransit(BaseModel):
+    """경유지 간 이동 정보."""
+
+    mode: str = "walk"  # walk | subway | bus | taxi
+    mode_ko: str = "도보"
+    distance_m: int = 0
+    duration_min: int = 0
+
+
 class CourseStop(BaseModel):
-    """코스 내 단일 정거장."""
+    """코스 내 단일 정거장 — 1-indexed order."""
 
     order: int
-    place_id: str  # UUID
-    name: str = ""
-    lat: Optional[float] = None
-    lng: Optional[float] = None
-    duration_minutes: Optional[int] = None  # 체류 시간
-    memo: Optional[str] = None  # LLM 추천 사유
+    arrival_time: Optional[str] = None  # "HH:mm"
+    duration_min: Optional[int] = None
+    place: CoursePlaceInfo
+    transit_to_next: Optional[CourseTransit] = None  # 마지막 stop은 None
+    recommendation_reason: Optional[str] = None
 
 
 class CourseBlock(BaseModel):
-    """코스 타임라인 (COURSE_PLAN intent)."""
+    """코스 타임라인 (COURSE_PLAN intent). flat 패턴 — content wrapper 미적용."""
 
     type: str = "course"
+    course_id: Optional[str] = None  # UUID4
     title: Optional[str] = None
+    description: Optional[str] = None
+    total_distance_m: Optional[int] = None
+    total_duration_min: Optional[int] = None
+    total_stay_min: Optional[int] = None
+    total_transit_min: Optional[int] = None
     stops: list[CourseStop] = Field(default_factory=list)
-    total_duration_minutes: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------
@@ -150,16 +182,38 @@ class MapMarkersBlock(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# 9. map_route — OSRM 폴리라인 (course 용)
+# 9. map_route — 코스 경로 시각화 (api-course-quick-spec.md 준수)
 # ---------------------------------------------------------------------------
+class RouteMarker(BaseModel):
+    """경로 마커 — course.stops[].order와 매칭."""
+
+    order: int
+    position: dict[str, float]  # {"lat": ..., "lng": ...}
+    label: str = ""
+    category: Optional[str] = None
+
+
+class RouteSegment(BaseModel):
+    """경로 구간 — straight(Phase 1) / road(Phase 2)."""
+
+    from_order: int
+    to_order: int
+    mode: str = "walk"
+    coordinates: list[list[float]] = Field(default_factory=list)  # [[lng, lat], ...] GeoJSON
+    distance_m: Optional[int] = None
+    duration_min: Optional[int] = None
+
+
 class MapRouteBlock(BaseModel):
-    """OSRM encoded polyline + 경유 좌표."""
+    """코스 경로 시각화. course_id로 CourseBlock과 연결."""
 
     type: str = "map_route"
-    polyline: Optional[str] = None
-    waypoints: Optional[list[dict[str, float]]] = None
-    distance_meters: Optional[int] = None
-    duration_seconds: Optional[int] = None
+    course_id: Optional[str] = None
+    bounds: Optional[dict[str, dict[str, float]]] = None  # {"sw": {lat,lng}, "ne": {lat,lng}}
+    center: Optional[dict[str, float]] = None  # {"lat": ..., "lng": ...}
+    suggested_zoom: Optional[int] = None
+    markers: list[RouteMarker] = Field(default_factory=list)
+    polyline: Optional[dict[str, Any]] = None  # {"type": "straight", "segments": [...]}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -234,4 +234,5 @@ async def test_llm_compose_api_error() -> None:
         title, desc, details = await _llm_course_compose(_PLACES, "테스트")
 
     assert title is None
+    assert desc is None
     assert details == []

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -1,0 +1,237 @@
+"""course_plan_node 단위 테스트.
+
+순수 함수 검증: _parse_categories / _greedy_nn_route / _build_blocks / _haversine_m.
+DB/OS/Gemini 의존성은 mock.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# 테스트 픽스처 데이터
+# ---------------------------------------------------------------------------
+_PLACES: list[dict[str, Any]] = [
+    {
+        "place_id": "p-001",
+        "name": "광장시장",
+        "category": "맛집",
+        "address": "서울 종로구 창경궁로 88",
+        "district": "종로구",
+        "lat": 37.5701,
+        "lng": 126.9996,
+    },
+    {
+        "place_id": "p-002",
+        "name": "익선동 한옥마을",
+        "category": "관광지",
+        "address": "서울 종로구 익선동",
+        "district": "종로구",
+        "lat": 37.5743,
+        "lng": 126.9912,
+    },
+    {
+        "place_id": "p-003",
+        "name": "경복궁",
+        "category": "관광지",
+        "address": "서울 종로구 사직로 161",
+        "district": "종로구",
+        "lat": 37.5796,
+        "lng": 126.977,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# _parse_categories 테스트
+# ---------------------------------------------------------------------------
+async def test_parse_categories_plus() -> None:
+    """+ 구분자로 카테고리 추출."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("홍대 카페+맛집 코스", None)
+    assert "카페" in result
+    assert "맛집" in result
+
+
+async def test_parse_categories_single() -> None:
+    """단일 카테고리 — processed_query에서 가져옴."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("강남 데이트 코스", "카페")
+    assert result == ["카페"]
+
+
+async def test_parse_categories_fallback() -> None:
+    """카테고리 없으면 맛집 기본값."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("좋은 곳 추천", None)
+    assert result == ["맛집"]
+
+
+# ---------------------------------------------------------------------------
+# _haversine_m 테스트
+# ---------------------------------------------------------------------------
+async def test_haversine_distance() -> None:
+    """광장시장 → 익선동 거리 계산 (약 800m)."""
+    from src.graph.course_plan_node import _haversine_m  # pyright: ignore[reportMissingImports]
+
+    dist = _haversine_m(37.5701, 126.9996, 37.5743, 126.9912)
+    assert 500 < dist < 1500
+
+
+# ---------------------------------------------------------------------------
+# _greedy_nn_route 테스트
+# ---------------------------------------------------------------------------
+async def test_greedy_nn_route_order() -> None:
+    """Greedy NN — 최근접 이웃 순서로 재배치."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    route = _greedy_nn_route(_PLACES)
+    assert len(route) == 3
+    # 첫 번째는 그대로, 나머지는 거리 기반
+    assert route[0]["place_id"] == "p-001"
+
+
+async def test_greedy_nn_max_stops() -> None:
+    """최대 5건으로 제한."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    many = [
+        {"place_id": f"p-{i}", "name": f"장소{i}", "lat": 37.5 + i * 0.01, "lng": 127.0 + i * 0.01} for i in range(10)
+    ]
+    route = _greedy_nn_route(many)
+    assert len(route) == 5
+
+
+async def test_greedy_nn_no_coords() -> None:
+    """좌표 없는 후보만 있을 때."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    no_coords = [{"place_id": f"p-{i}", "name": f"장소{i}", "lat": None, "lng": None} for i in range(3)]
+    route = _greedy_nn_route(no_coords)
+    assert len(route) == 3
+
+
+# ---------------------------------------------------------------------------
+# _build_blocks 테스트
+# ---------------------------------------------------------------------------
+async def test_build_blocks_normal() -> None:
+    """정상 3-stop 코스 → text_stream + course + map_route 블록."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    stop_details = [
+        {
+            "order": 1,
+            "arrival_time": "11:00",
+            "duration_min": 60,
+            "recommendation_reason": "전통시장",
+            "transit_mode": "walk",
+        },
+        {
+            "order": 2,
+            "arrival_time": "12:12",
+            "duration_min": 90,
+            "recommendation_reason": "한옥마을",
+            "transit_mode": "walk",
+        },
+        {
+            "order": 3,
+            "arrival_time": "14:00",
+            "duration_min": 60,
+            "recommendation_reason": "궁궐",
+            "transit_mode": None,
+        },
+    ]
+
+    blocks = _build_blocks("종로 코스", _PLACES, "도심 코스", "3곳 코스", stop_details, "test-uuid")
+    types = [b["type"] for b in blocks]
+
+    assert "text_stream" in types
+    assert "course" in types
+    assert "map_route" in types
+
+    # course 블록 검증
+    course = next(b for b in blocks if b["type"] == "course")
+    assert course["course_id"] == "test-uuid"
+    assert len(course["stops"]) == 3
+    assert course["stops"][0]["order"] == 1
+    assert course["stops"][2]["transit_to_next"] is None  # 마지막 stop
+    assert course["total_duration_min"] == course["total_stay_min"] + course["total_transit_min"]
+
+    # map_route 블록 검증
+    map_route = next(b for b in blocks if b["type"] == "map_route")
+    assert map_route["course_id"] == "test-uuid"
+    assert len(map_route["markers"]) == 3
+    assert map_route["markers"][0]["order"] == 1
+    assert len(map_route["polyline"]["segments"]) == 2  # 3 stops → 2 segments
+    # GeoJSON [lng, lat] 순서
+    assert map_route["polyline"]["segments"][0]["coordinates"][0][0] == _PLACES[0]["lng"]
+
+
+async def test_build_blocks_empty() -> None:
+    """빈 결과 → text_stream만 + 빈 course 블록."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    blocks = _build_blocks("없는 코스", [], None, None, [], "test-uuid")
+    types = [b["type"] for b in blocks]
+    assert "text_stream" in types
+    assert "course" in types
+
+
+async def test_build_blocks_single_stop() -> None:
+    """단일 stop → transit_to_next null, polyline segments 없음."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    single = [_PLACES[0]]
+    details = [
+        {"order": 1, "arrival_time": "11:00", "duration_min": 60, "recommendation_reason": "시장", "transit_mode": None}
+    ]
+
+    blocks = _build_blocks("시장 코스", single, "시장 코스", "1곳", details, "test-uuid")
+    course = next(b for b in blocks if b["type"] == "course")
+    assert len(course["stops"]) == 1
+    assert course["stops"][0]["transit_to_next"] is None
+
+    map_route = next(b for b in blocks if b["type"] == "map_route")
+    assert len(map_route["polyline"]["segments"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# _llm_course_compose fallback 테스트
+# ---------------------------------------------------------------------------
+async def test_llm_compose_fallback() -> None:
+    """Gemini 실패 시 None 반환 → _apply_fallback_times 적용."""
+    from src.graph.course_plan_node import _apply_fallback_times  # pyright: ignore[reportMissingImports]
+
+    details = _apply_fallback_times(_PLACES)
+    assert len(details) == 3
+    assert details[0]["arrival_time"] == "11:00"
+    assert details[0]["duration_min"] == 60
+    assert details[2]["transit_mode"] is None  # 마지막
+
+
+async def test_llm_compose_api_error() -> None:
+    """Gemini API 에러 → (None, None, []) 반환."""
+    from src.graph.course_plan_node import _llm_course_compose  # pyright: ignore[reportMissingImports]
+
+    mock_settings = type("Settings", (), {"gemini_llm_api_key": "fake-key"})()
+
+    with (
+        patch("src.config.get_settings", return_value=mock_settings),
+        patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_llm_cls,
+    ):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = Exception("API error")
+        mock_llm_cls.return_value = mock_llm
+
+        title, desc, details = await _llm_course_compose(_PLACES, "테스트")
+
+    assert title is None
+    assert details == []


### PR DESCRIPTION
## #️⃣  연관된 이슈                                                                                                                                                                                
                                                                                                                                                                                                   
  > #54                                                                                                                                                                                            
                                                                                                                                                                                                   
  ## #️⃣  작업 내용                                                                                                                                                                                  
                                                                                                                                                                                                   
  COURSE_PLAN intent 노드 구현. 카테고리별 병렬 검색 → Greedy NN 경로 최적화 → LLM 코스 구성.                                                                                                      
                                                                                                                                                                                                   
  **신규 파일:**                                                                                                                                                                                   
  - `src/graph/course_plan_node.py` — 핵심 노드 (검색 + Greedy NN + Gemini 코스 구성)                                                                                                              
  - `tests/test_course_plan_node.py` — 단위 테스트 12건                                                                                                                                            
                                                                                                                                                                                                   
  **수정 파일:**                                                                                                                                                                                   
  - `src/models/blocks.py` — CourseStop/CourseBlock/MapRouteBlock를 api-course-quick-spec.md 스키마에 맞게 재정의                                                                                  
  - `src/graph/real_builder.py` — stub 제거 → 실제 import                                                                                                                                          
  - `src/graph/response_builder_node.py` — COURSE_PLAN 블록 순서 + map_route optional 등록                                                                                                         
                                                                                                                                                                                                   
  **파이프라인:**                                                                                                                                                                                  
  쿼리 "홍대 카페+맛집 코스"                                                                                                                                                                       
  → 카테고리 파싱: ["카페", "맛집"]                                                                                                                                                                
  → PG + OS 카테고리별 병렬 검색 → 후보 ~20건                                                                                                                                                      
  → Greedy NN (Haversine 직선 거리) → 최단 동선 5곳                                                                                                                                                
  → Gemini Flash 코스 구성 (시간 배분 + 추천 사유)                                                                                                                                                 
  → text_stream + course + map_route 블록                                                                                                                                                          
                                                                                                                                                                                                   
  **Phase 1 단순화:**                                                                                                                                                                              
  - OSRM 미사용 → polyline.type="straight" (Phase 2에서 road 교체, 스키마 변경 없음)                                                                                                               
  - ST_DWithin 공간 필터 미적용 → district 매칭 (user_location 추가 후 도입)                                                                                                                       
                                                                                                                                                                                                   
  ## #️⃣  테스트 결과                                                                                                                                                                                
                                                                                                                                                                                                   
  | 검증 항목 | 결과 |                                                                                                                                                                             
  |---|---|                                                                                                                                                                                    
  | ruff check | All checks passed |                                                                                                                                                               
  | ruff format | Passed |                                                                                                                                                                         
  | pyright | 0 errors, 0 warnings |                                                                                                                                                               
  | pytest (12건) | 11 passed, 1 error (기존 event_loop 이슈) |                                                                                                                                    
  | build_graph() smoke | OK |                                                                                                                                                                     
  | pre-commit hooks | 전체 통과 |                                                                                                                                                                 
                                                                                                                                                                                                   
  ## #️⃣  변경 사항 체크리스트                                                                                                                                                                       
                                                                                                                                                                                                   
  - [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?                                                                                                                          
  - [x] 문서를 작성하거나 수정했나요? (필요한 경우)                                                                                                                                                
  - [x] 코드 컨벤션에 따라 코드를 작성했나요?                                                                                                                                                      
  - [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?                                                                                                                                  
                                                                                                                                                                                                   
  ## #️⃣  리뷰 요구사항 (선택)                                                                                                                                                                       
                                                                                                                                                                                                   
  - `blocks.py` CourseStop/CourseBlock/MapRouteBlock 재정의가 기존 CONTENT_BLOCK_TYPES 레지스트리와 호환되는지 확인 부탁드립니다                                                                   
  - Greedy NN 경로 최적화 로직이 5곳 이상일 때 합리적인 동선을 생성하는지 검토 부탁드립니다                                                                                                        
  - LLM 실패 시 균등 배분 fallback이 적절한지 의견 부탁드립니다                                                                                                                                    
                                                                                                                                                                                                   
  ## 📎 참고 자료 (선택)                                                                                                                                                                           
                                                                                                                                                                                                   
  - Plan: `.sisyphus/plans/2026-05-05-course-plan/plan.md` (Metis okay + Momus approved)                                                                                                           
  - 코스 응답 스키마: `기획/_legacy/api-course-quick-spec.md`                                                                                                                                      
  - 기획 편차: course_id를 ULID(spec) → UUID4로 변경 (기존 PK 패턴 일관성, spec 갱신 예정)                                                                                                         
  - blocks.py flat 패턴 유지 (spec의 content wrapper 미적용 — 기존 16종 블록 전부 flat)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course planning: multi-category place search, greedy straight-line route ordering, per-stop timings/recommendations, and integrated map route (straight-segment polylines) with graceful LLM fallback timing.

* **Tests**
  * End-to-end and unit tests for category parsing, distance/routing behavior, block assembly, empty/single-stop cases, and LLM failure fallbacks.

* **Documentation**
  * Added Phase‑1 course plan design and review records clarifying schema, block order, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->