### PR TITLE
SSE: 단일 장소 분석 (ANALYSIS), SSE: 중첩된 요청 대응 (Multi-Intent) 구현

### DIFF
--- a/.sisyphus/plans/2026-05-05-course-plan/plan.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/plan.md
@@ -1,0 +1,118 @@
+# COURSE_PLAN 노드 구현 — 카테고리별 병렬 검색 → Greedy NN → course + map_route
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-05-05
+- 상태: approved
+
+## 1. 요구사항
+
+API 명세서: `intent → text_stream → course → map_route → done`
+
+"홍대 카페+맛집 코스 추천해줘" 같은 요청에 카테고리별 장소를 병렬 검색 → 거리 기반 경로 최적화 → 코스 타임라인 + 지도 경로 응답.
+
+기능 명세서 정의: "카테고리별 병렬 검색 → ST_DWithin → Greedy NN → OSRM"
+
+> **Phase 1 단순화:** OSRM은 외부 서비스 의존이므로 Phase 1에서는 straight-line 직선 거리 기반 Greedy NN으로 구현. polyline.type="straight". Phase 2에서 OSRM road polyline으로 교체 (스키마 변경 없음, 기획서 api-course-quick-spec.md §Phase 1 vs Phase 2 참조).
+
+### 핵심 흐름
+
+```text
+processed_query (category[], district, neighborhood, keywords)
+  → ① 카테고리별 PG + OS 병렬 검색 (place_recommend 패턴 재활용)
+  → ② 후보 풀 병합 + 중복 제거
+  → ③ Greedy NN 경로 최적화 (직선 거리 기반 최근접 이웃)
+  → ④ LLM 코스 구성 (Gemini Flash — 시간대 배분 + 추천 사유)
+  → ⑤ 블록 생성: text_stream + course + map_route
+```
+
+### 코스 응답 스키마 (기획서 api-course-quick-spec.md 준수)
+
+- `course` 블록: stops[{order, place, duration_min, transit_to_next}], sections(시간대 그룹)
+- `map_route` 블록: markers + polyline(straight segments) + bounds/center
+- `course_id`로 두 블록 연결
+- 좌표: 단일점 {lat, lng}, 배열 [lng, lat] (GeoJSON)
+- 1-indexed order
+
+## 2. 영향 범위
+
+- 신규 파일: `backend/src/graph/course_plan_node.py`
+- 수정 파일: `backend/src/graph/real_builder.py` (stub → 실제 import 교체)
+- 수정 파일: `backend/src/graph/response_builder_node.py` (COURSE_PLAN 블록 순서 등록)
+- 수정 파일: `backend/src/models/blocks.py` (CourseStop/CourseBlock/MapRouteBlock를 api-course-quick-spec.md 스키마에 맞게 재정의)
+- DB 스키마 영향: 없음 (기존 places + places_vector 활용)
+- 응답 블록 16종 영향: 기존 course + map_route 블록 사용 (신규 타입 없음). blocks.py Pydantic 모델을 spec에 맞게 확장하되 CONTENT_BLOCK_TYPES 레지스트리 호환 유지.
+- intent 추가/변경: 없음 (COURSE_PLAN 이미 등록됨)
+- 외부 API 호출: Gemini 2.5 Flash (코스 구성 + text_stream용, 1회당 1호출, 입력 ~3K tokens — 후보 장소 메타 + 사용자 조건. RPM 한도 초과 시 Greedy NN 순서 그대로 반환하는 graceful degradation)
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — places는 UUID(VARCHAR(36))
+- [x] PG↔OS 동기화 — place_id == places_vector._id
+- [x] append-only 4테이블 미수정 — SELECT만 사용
+- [x] 소프트 삭제 매트릭스 준수 — is_deleted=false 필터 (places 테이블 검증 필요 — init_db.sql 갭 인지)
+- [x] 의도적 비정규화 3건 외 신규 비정규화 없음
+- [x] 6 지표 스키마 보존 — 미사용
+- [x] gemini-embedding-001 768d 사용 (OpenAI 임베딩 금지)
+- [x] asyncpg 파라미터 바인딩 ($1, $2)
+- [x] Optional[str] 사용 (str | None 금지)
+- [x] SSE 이벤트 타입 16종 한도 준수 — 기존 타입만 사용 (text_stream, course, map_route)
+- [x] intent별 블록 순서 (기획 §4.5) 준수 — text_stream → course → map_route → done. Phase 1에서 references 미포함 (리뷰 인용 불필요, Phase 2 확장). map_route는 optional.
+- [x] 공통 쿼리 전처리 경유 — query_preprocessor 결과 활용
+- [ ] 행사 검색 DB 우선 → Naver fallback — 해당 없음
+- [ ] 대화 이력 이원화 보존 — 해당 없음
+- [ ] 인증 매트릭스 준수 — 해당 없음
+- [ ] 북마크 = 대화 위치 패러다임 — 해당 없음
+- [ ] 공유링크 인증 우회 범위 — 해당 없음
+- [x] Phase 라벨 명시 — P1
+- [x] 기획 문서 우선 — api-course-quick-spec.md 스키마 준수
+
+## 4. 작업 순서 (Atomic step)
+
+1. **blocks.py CourseStop/CourseBlock/MapRouteBlock 재정의** (category: `deep`)
+   - CourseStop: order, arrival_time, duration_min, place{place_id, name, category, category_label, address, district, location{lat,lng}, rating(Optional), summary}, transit_to_next{mode, mode_ko, distance_m, duration_min}|null, recommendation_reason
+   - Phase 1 포함 place 필드: place_id, name, category, category_label, address, district, location, summary
+   - Phase 1 Optional place 필드: rating (DB 데이터 있으면 포함)
+   - Phase 1 생략 place 필드 (Optional 선언): photo_url, photo_attribution, business_hours_today, is_open_now, booking_url
+   - CourseBlock: type="course", course_id(UUID4), title, description, total_distance_m, total_duration_min, total_stay_min, total_transit_min, stops: list[CourseStop]. Phase 1 생략 필드: sections, emoji, actions, schema_version, photo_url/attribution/business_hours (Optional로 선언)
+   - MapRouteBlock: type="map_route", course_id, bounds{sw,ne}, center{lat,lng}, suggested_zoom, markers[{order, position{lat,lng}, label, category}], polyline{type:"straight", segments[{from_order, to_order, mode, coordinates[[lng,lat],...]}]}
+   - CONTENT_BLOCK_TYPES 레지스트리 호환 유지
+   - Pydantic 모델은 기존 blocks.py flat 패턴 유지 (spec의 `{type, schema_version, content:{...}}` wrapper는 적용하지 않음 — 기존 16종 블록 전부 flat 구조이며, FE가 flat 구조를 직접 소비)
+
+2. **course_plan_node.py 신규 작성** (category: `langgraph-node`)
+   - `_parse_course_categories()`: 쿼리에서 복수 카테고리 추출 ("카페+맛집" → ["카페", "맛집"])
+   - `_search_places_by_category()`: 카테고리별 PG+OS 병렬 검색 (place_recommend 패턴 재활용). `_embed_query_768d()` 복제 (3번째 — TODO: Phase 1 이후 공유 유틸 추출 검토).
+   - `_greedy_nn_route()`: 직선 거리 기반 Greedy Nearest Neighbor 경로 최적화. Haversine 거리 계산.
+   - `_llm_course_compose()`: Gemini Flash로 시간대 배분 + 체류시간 + 추천 사유 생성. 실패 시 균등 배분 fallback.
+   - `_build_course_blocks()`: course + map_route 블록 생성 (api-course-quick-spec.md 스키마). course_id는 UUID4 (spec은 ULID이나, 기존 프로젝트 PK 패턴과 일관성 유지 위해 UUID4 채택. spec api-course-quick-spec.md 갱신 예정: ULID→UUID4).
+   - `_build_text_stream_block()`: 코스 소개 프롬프트 생성.
+   - `course_plan_node()`: LangGraph 노드 엔트리 (state → response_blocks)
+
+3. **real_builder.py 수정** (category: `quick`)
+   - `_course_plan_node` stub 제거
+   - `from src.graph.course_plan_node import course_plan_node` 추가
+   - `graph.add_node("course_plan", course_plan_node)` 교체
+
+4. **response_builder_node.py 수정** (category: `quick`)
+   - `_EXPECTED_BLOCK_ORDER`에 COURSE_PLAN: `["intent", "text_stream", "course", "done"]` 등록
+   - `_OPTIONAL_BLOCKS`에 `map_route` 추가 (이미 `references`는 PLACE_RECOMMEND에서 추가됨)
+   - Phase 1에서 references 블록 미포함 (코스 추천은 리뷰 인용 불필요). spec의 `references`는 Phase 2 확장 시 추가.
+
+5. **단위 테스트 작성** (category: `deep`)
+   - `tests/test_course_plan_node.py`
+   - 케이스: 정상 3-stop 코스, 단일 카테고리, 후보 0건(빈 결과), Greedy NN 경로 순서 검증, LLM 실패 fallback, course/map_route 블록 스키마 검증
+
+## 5. 검증 계획
+
+- `validate.sh` 6단계 통과
+- 단위 테스트: `pytest tests/test_course_plan_node.py -v`
+- 수동 시나리오:
+  - "홍대 카페+맛집 코스" → course(stops 3-5개) + map_route(markers + straight polyline)
+  - "강남역 근처 데이트 코스" → district 필터 + 시간대 배분
+  - "카페 한 곳만" → 단일 stop 코스 (transit_to_next: null)
+- smoke: `python -c "from src.graph.real_builder import build_graph; build_graph()"`
+- course 블록 검증: stops order 1-indexed 연속, 마지막 transit_to_next null, markers.length == stops.length
+
+## 6. 최종 결정
+
+APPROVED (2026-05-05, Metis okay + Momus approved)

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/001-metis-reject.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/001-metis-reject.md
@@ -1,0 +1,42 @@
+# Review 001 — Metis
+
+## 검토자
+
+metis
+
+## 검토 일시
+
+2026-05-05
+
+## 검토 대상
+
+../plan.md (2026-05-05 draft)
+
+## 판정
+
+reject
+
+## 근거
+
+### Gap
+
+1. **blocks.py 스키마 불일치**: CourseBlock/CourseStop(7필드)과 MapRouteBlock(encoded string)이 api-course-quick-spec.md 스키마(40+ 필드, structured segments)와 구조적으로 다름. plan이 blocks.py를 영향 범위에 포함하지 않음.
+2. **블록 순서 미확정**: spec은 `text → course → map_route → references → done`인데 plan은 references 누락.
+3. **response_builder_node.py 등록 값 불확정**: 블록 순서가 미확정이므로 등록할 값도 미결정.
+
+### 숨은 의도
+
+Phase 1 단순화(OSRM 미사용)는 합리적. PG+OS 하이브리드 전환 의도 올바름.
+
+### AI Slop / 오버엔지니어링
+
+없음. `_embed_query_768d()` 3중 복제는 인지 권고 수준.
+
+## 요구 수정사항
+
+1. blocks.py를 수정 대상으로 추가 + Phase 1에서 구현할 필드 범위 명시
+2. 블록 순서 확정 (references 포함 여부)
+
+## 다음 액션
+
+reject → plan.md 수정 후 재리뷰

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/002-metis-okay.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/002-metis-okay.md
@@ -1,0 +1,12 @@
+# Review 002 — Metis
+
+## 검토자
+metis
+## 검토 일시
+2026-05-05
+## 판정
+okay
+## 근거
+이전 reject 2건 수정사항 모두 반영 확인. blocks.py 영향 범위 추가 + Phase 1 필드 범위 명시. 블록 순서 확정 (references Phase 2 확장 명시).
+## 다음 액션
+okay → Momus 검토

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/003-momus-reject.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/003-momus-reject.md
@@ -1,0 +1,14 @@
+# Review 003 — Momus
+
+## 검토자
+momus
+## 검토 일시
+2026-05-05
+## 판정
+reject
+## 요구 수정사항
+1. course_id 타입: ULID(spec) vs UUID4(plan) 편차 해명
+2. place 하위 필드 Phase 1/2 분류 완성 (category_label, rating, summary, is_open_now, booking_url)
+3. content wrapper vs flat 구조 설계 결정 1줄 기술
+## 다음 액션
+reject → 3건 수정 후 재리뷰

--- a/.sisyphus/plans/2026-05-05-course-plan/reviews/004-momus-approved.md
+++ b/.sisyphus/plans/2026-05-05-course-plan/reviews/004-momus-approved.md
@@ -1,0 +1,16 @@
+# Review 004 — Momus
+
+## 검토자
+momus
+## 검토 일시
+2026-05-05
+## 판정
+approved
+## 근거
+이전 reject 3건 모두 반영 확인:
+1. course_id UUID4 채택 + spec 갱신 예정 명시
+2. place 하위 필드 3-tier 분류 (포함/Optional/생략) 완성
+3. flat 구조 유지 설계 결정 기술
+파일 참조, 19 불변식, 검증 계획 모두 PASS.
+## 다음 액션
+approved → APPROVED 갱신

--- a/.sisyphus/plans/2026-05-06-analysis-intent/plan.md
+++ b/.sisyphus/plans/2026-05-06-analysis-intent/plan.md
@@ -1,0 +1,171 @@
+# ANALYSIS — 단일 장소 6지표 분석 (런타임 Gemini 채점)
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-05-06
+- 상태: APPROVED
+
+## 1. 요구사항
+
+사용자가 "이 카페 분석해줘", "스타벅스 홍대점 리뷰 분석" 같은 **단일 장소** 분석 요청 시
+OS `place_reviews._raw_scores` (6지표)를 조회하고, Gemini로 리뷰 기반 분석 텍스트를 스트리밍한다.
+
+**엔드포인트**: `GET /api/v1/chat/stream?query=이 카페 분석해줘`
+
+**응답 블록 순서** (기획서 §4.5 ANALYSIS):
+```
+intent → status → text_stream → analysis_sources → done
+```
+
+**analysis_sources 블록 스펙** (`blocks.py` L274-282 기존 모델):
+```json
+{
+  "type": "analysis_sources",
+  "review_count": 45,
+  "blog_count": null,
+  "official_count": null,
+  "sources": []
+}
+```
+
+**데이터 소스**: OS `place_reviews` 인덱스 (~7,572건)
+
+**장소명 추출 실패 시**: `disambiguation` 블록 — `message: "어떤 장소를 분석할까요? 장소명을 알려주세요."`, `candidates: []`
+
+**장소 미발견 시**: `disambiguation` 블록 — `message: "장소를 찾을 수 없어요. 정확한 장소명으로 다시 입력해주세요."`
+
+**OS 점수 없는 장소**: text_stream으로 "아직 리뷰 데이터가 충분하지 않아요" 안내. analysis_sources `review_count: 0`.
+
+**REVIEW_COMPARE와의 차이**: REVIEW_COMPARE는 2+ 장소 비교(chart 블록 포함). ANALYSIS는 단일 장소 심층 분석(chart 없음, text_stream이 주력).
+
+## 2. 영향 범위
+
+- **신규 파일**:
+  - `backend/src/graph/analysis_node.py`
+  - `backend/tests/test_analysis_node.py`
+- **수정 파일**:
+  - `backend/src/graph/intent_router_node.py` — ANALYSIS를 PHASE1_INTENTS + _ROUTABLE_INTENTS에 추가, _CLASSIFY_SYSTEM_PROMPT 업데이트
+  - `backend/src/graph/real_builder.py` — analysis 노드 import + 등록 + 라우팅
+  - `backend/src/api/sse.py` — _NODE_STATUS_MESSAGES에 `"analysis"` 추가
+- **DB 스키마 영향**: 없음 (PG SELECT + OS 읽기 전용)
+- **응답 블록 16종 영향**: `analysis_sources` 기존 타입 사용. 16종 목록 변경 없음.
+- **intent 추가/변경**: `ANALYSIS` — enum 기정의(L31). PHASE1_INTENTS + _ROUTABLE_INTENTS 양쪽 추가
+- **외부 API 호출**: OS `place_reviews` 인덱스 mget + Gemini 2.5 Flash 스트리밍 (기존 text_stream 패턴)
+
+## 3. 19 불변식 체크리스트
+
+- [x] #1 PK 이원화 — places 조회 시 UUID place_id 사용
+- [x] #2 PG↔OS 동기화 — place_id 기준, doc id = `review_{place_id}`
+- [x] #3 append-only 4테이블 미수정 — PG SELECT만, INSERT/UPDATE/DELETE 없음
+- [x] #4 소프트 삭제 — places 조회 시 `is_deleted = false` 필터
+- [x] #5 비정규화 3건 외 신규 없음
+- [x] #6 6지표 스키마 보존 — satisfaction/accessibility/cleanliness/value/atmosphere/expertise
+- [x] #7 임베딩 통일 — 임베딩 미호출 (OS 기적재 데이터 조회만)
+- [x] #8 asyncpg 파라미터 바인딩 — `$1` 바인딩, f-string SQL 금지
+- [x] #9 Optional[str] 사용 (str | None 금지)
+- [x] #10 SSE 이벤트 타입 16종 한도 — analysis_sources 기존 타입
+- [x] #11 intent별 블록 순서 — intent→status→text_stream→analysis_sources→done (§4.5)
+- [x] #12 공통 쿼리 전처리 경유 — processed_query에서 place_name 추출
+- [x] #13 행사 검색 순서 — 해당 없음
+- [x] #14 대화 이력 이원화 보존
+- [x] #15 인증 매트릭스 준수
+- [x] #16 북마크 패러다임 준수
+- [x] #17 공유링크 인증 우회 범위 정확
+- [x] #18 Phase 라벨 명시 — P1 (파일 헤더 docstring)
+- [x] #19 기획 문서 우선 — API 명세서 v2 SSE 준수
+
+## 4. 작업 순서 (Atomic step)
+
+### g1 — analysis_node.py 신규 작성
+
+**step 1**: `_extract_place_name(processed_query, query) → Optional[str]`
+- `processed_query.get("place_name")` 우선 사용
+- fallback: `processed_query.get("keywords")` 리스트 첫 번째 요소
+- 둘 다 없으면 `None` 반환 → 노드에서 disambiguation
+
+**step 2**: `_fetch_place_pg(pool, place_name, os_client) → Optional[dict]`
+- `SELECT place_id, name, category, district FROM places WHERE is_deleted = false AND name ILIKE $1` (asyncpg `$1`)
+- 동명 다중 매칭: review_compare_node._fetch_places_pg 패턴 재사용 — OS mget stars 최댓값 채택
+- 0건 → `None`
+
+**step 3**: `_fetch_scores_os(os_client, place_id) → dict[str, float]`
+- doc id = `review_{place_id}`, OS mget 1회
+- `_source._raw_scores` 추출. 문서 없으면 `{}`
+
+**step 4**: `_build_analysis_blocks(query, place, scores, review_count) → list[dict]`
+- `text_stream` 블록 (raw dict):
+  ```python
+  {
+      "type": "text_stream",
+      "system": _ANALYSIS_SYSTEM_PROMPT,
+      "prompt": f"사용자 질문: {query}\n\n장소: {place['name']} ({place.get('category', '')})\n6지표: {scores_text}\n리뷰 수: {review_count}"
+  }
+  ```
+- `analysis_sources` 블록 (raw dict):
+  ```python
+  {"type": "analysis_sources", "review_count": review_count}
+  ```
+
+**step 5**: `analysis_node(state) → dict` — LangGraph 노드
+- place_name 추출 실패 → disambiguation ("어떤 장소를 분석할까요?")
+- PG 조회 0건 → disambiguation ("장소를 찾을 수 없어요.")
+- OS 점수 없음 → text_stream "리뷰 데이터 부족" 안내 + analysis_sources review_count=0
+- 정상: text_stream + analysis_sources
+
+> verify: `ruff check src/graph/analysis_node.py && pyright src/graph/analysis_node.py`
+
+### g2 — intent_router_node.py 활성화
+
+1. `PHASE1_INTENTS`에 `IntentType.ANALYSIS` 추가 (L40-54)
+2. `_ROUTABLE_INTENTS`에 `IntentType.ANALYSIS` 추가 (L58-71)
+3. `_CLASSIFY_SYSTEM_PROMPT` — Phase 2 목록에서 ANALYSIS 제거, Phase 1 active 목록에 추가:
+   `"- ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)"`
+
+> verify: `pytest tests/ -k "intent" -v`
+
+### g3 — real_builder.py 라우팅 추가
+
+1. `from src.graph.analysis_node import analysis_node` import 추가
+2. `graph.add_node("analysis", analysis_node)` 등록
+3. `_route_by_intent` mapping에 `"ANALYSIS": "analysis"` 추가
+4. `add_conditional_edges` dict에 `"analysis": "analysis"` 추가
+5. response_builder 엣지 리스트에 `"analysis"` 추가
+
+> verify: `python -c "from src.graph.real_builder import build_graph; build_graph()"`
+
+### g4 — sse.py status 메시지 추가
+
+1. `_NODE_STATUS_MESSAGES`에 `"analysis": "장소를 분석하고 있어요..."` 추가
+
+> verify: `ruff check src/api/sse.py && pyright src/api/sse.py`
+
+### g5 — 단위 테스트
+
+`tests/test_analysis_node.py` — mock: `unittest.mock.AsyncMock`으로 `pool.fetch`, `os_client.mget` mock.
+
+- `test_extract_place_name_from_processed_query`: processed_query.place_name 있으면 반환
+- `test_extract_place_name_from_keywords`: place_name 없고 keywords[0] fallback
+- `test_extract_place_name_none`: 둘 다 없으면 None
+- `test_analysis_node_success`: 정상 흐름 — text_stream + analysis_sources 블록 반환
+- `test_analysis_node_no_reviews`: OS 문서 없음 → text_stream + analysis_sources(review_count=0)
+- `test_analysis_node_place_not_found`: PG 0건 → disambiguation
+- `test_analysis_node_no_place_name`: place_name 추출 실패 → disambiguation
+
+> verify: `pytest tests/test_analysis_node.py -v`
+
+### g6 — 전체 검증
+
+> verify: `./validate.sh`
+
+## 5. 검증 계획
+
+- `./validate.sh` 전체 통과
+- `pytest tests/test_analysis_node.py -v` — 7개 케이스 모두 통과
+- 수동 시나리오:
+  1. `GET /api/v1/chat/stream?query=스타벅스 홍대점 분석해줘` → SSE에서 text_stream 스트리밍 + analysis_sources 블록 확인
+  2. OS에 없는 장소명 → text_stream "리뷰 데이터 부족" + analysis_sources.review_count=0
+  3. 존재하지 않는 장소 → disambiguation 블록
+
+## 6. 최종 결정
+
+APPROVED — 2026-05-06 PM 승인. 구현 진입.

--- a/.sisyphus/plans/2026-05-06-multi-intent/plan.md
+++ b/.sisyphus/plans/2026-05-06-multi-intent/plan.md
@@ -32,7 +32,7 @@ Intent #2 (EVENT_SEARCH):
 
 **DB 저장**: 전체 intent의 블록을 하나의 assistant 메시지로 INSERT (append-only, 불변식 #3).
 
-## 2. 설계 결정
+### 설계 결정
 
 ### 왜 SSE 핸들러 레벨에서 루프하는가
 
@@ -85,7 +85,7 @@ FE(`useWebSocket.ts`)에서 `done_partial` 이벤트 수신 시:
 
 → **FE 수정은 이 plan 범위 밖** (별도 이슈). BE는 `done_partial` 이벤트만 정상 emit하면 됨.
 
-## 3. 영향 범위
+## 2. 영향 범위
 
 - **수정 파일**:
   - `backend/src/graph/intent_router_node.py` — `classify_intents()` 새 함수 추가 + 노드에 intent 주입 가드
@@ -97,7 +97,7 @@ FE(`useWebSocket.ts`)에서 `done_partial` 이벤트 수신 시:
 - **외부 API 호출**: Gemini classify_intents 1회 + query_preprocessor intent별 실행 (최대 3회)
 - **query_preprocessor_node.py**: 수정 없음 (매 intent마다 sub_query로 정상 실행)
 
-## 4. 19 불변식 체크리스트
+## 3. 19 불변식 체크리스트
 
 - [x] #1 PK 이원화 — 해당 없음
 - [x] #2 PG↔OS 동기화 — 해당 없음
@@ -119,7 +119,7 @@ FE(`useWebSocket.ts`)에서 `done_partial` 이벤트 수신 시:
 - [x] #18 Phase 라벨 — P1
 - [x] #19 기획 문서 우선 — API 명세서 v2 SSE 준수
 
-## 5. 작업 순서 (Atomic step)
+## 4. 작업 순서 (Atomic step)
 
 ### g1 — classify_intents() 함수 추가 (intent_router_node.py)
 
@@ -262,7 +262,7 @@ yield format_done_event(status="done")
 
 > verify: `./validate.sh`
 
-## 6. 검증 계획
+## 5. 검증 계획
 
 - `./validate.sh` 전체 통과
 - `pytest tests/test_multi_intent.py -v` — 7개 케이스 통과
@@ -273,12 +273,12 @@ yield format_done_event(status="done")
   3. `query=카페 추천하고 맛집 찾아주고 코스 짜줘` → 3개 intent 순차 실행
   4. DB messages.blocks에 전체 블록 단일 row 저장 확인
 
-## 7. 리스크
+## 6. 리스크
 
 - **Gemini 분류 정확도**: 복수 intent 분리 + sub_query 추출이 부정확할 수 있음. "카페에서 전시회 가는 코스" → COURSE_PLAN 1개 vs PLACE_RECOMMEND + EVENT_SEARCH 2개? → 프롬프트에 "하나의 목적이면 하나의 intent" 명시
 - **응답 시간**: intent 수만큼 그래프 재실행 + query_preprocessor Gemini 호출. 3개 제한 + classify_intents는 1회만으로 방어. 최악 case: classify 1회 + preprocess 3회 + 노드별 Gemini 3회 = 7회 Gemini 호출
 - **sub_query 품질**: Gemini가 sub_query를 잘못 분리하면 query_preprocessor 결과 부정확. fallback: sub_query가 빈 문자열이면 원본 query 사용
 
-## 8. 최종 결정
+## 7. 최종 결정
 
 APPROVED — 2026-05-06 PM 승인. 런타임 시뮬레이션 + 엣지 케이스 검증 완료. 구현 진입.

--- a/.sisyphus/plans/2026-05-06-multi-intent/plan.md
+++ b/.sisyphus/plans/2026-05-06-multi-intent/plan.md
@@ -1,0 +1,284 @@
+# Multi-Intent — 중첩된 요청 대응 (복수 intent 순차 실행)
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-05-06
+- 상태: APPROVED
+
+## 1. 요구사항
+
+사용자가 "홍대 카페 추천해주고 주말 전시회도 알려줘"처럼 **복수 intent가 포함된 쿼리**를 보내면,
+각 intent를 순차 실행하고 `done_partial` 제어 이벤트로 구분하여 SSE 스트리밍한다.
+
+**엔드포인트**: `GET /api/v1/chat/stream?query=홍대 카페 추천해주고 주말 전시회도 알려줘`
+
+**SSE 이벤트 흐름** (기획서 §4.5):
+```
+Intent #1 (PLACE_RECOMMEND):
+  intent → status → text_stream → places → map_markers → references
+  → done_partial {completed_intent: "PLACE_RECOMMEND"}
+
+Intent #2 (EVENT_SEARCH):
+  intent → status → text_stream → events
+  → done {status: "done"}
+```
+
+**`done_partial`**: SSE 제어 이벤트. messages.blocks에 저장하지 않음 (불변식 #10 주석 참조).
+**`done`**: 모든 intent 처리 완료 시 최종 전송.
+
+**단일 intent 쿼리**: 기존과 동일하게 동작 (done_partial 없이 done만).
+
+**intent 최대 개수**: 3개 제한 (무한 체인 방지).
+
+**DB 저장**: 전체 intent의 블록을 하나의 assistant 메시지로 INSERT (append-only, 불변식 #3).
+
+## 2. 설계 결정
+
+### 왜 SSE 핸들러 레벨에서 루프하는가
+
+LangGraph 그래프 내부에 multi-intent 루프를 넣으면:
+- StateGraph 구조 변경 필요 (순환 엣지, 복잡도 급증)
+- 기존 단일 intent 노드 전부 영향
+- 테스트/디버깅 어려움
+
+대신 **SSE 핸들러(`sse.py`)에서 intent별로 그래프를 재실행**:
+- 그래프 구조 변경 없음
+- 기존 노드 코드 변경 없음
+- intent 분류만 SSE 핸들러에서 선행
+
+### 그래프 재실행 시 중복 호출 문제
+
+그래프 실행 시 `intent_router → query_preprocessor → [노드]` 순서로 실행됨.
+매 intent마다 그래프를 재실행하면 intent_router/query_preprocessor가 불필요하게 재실행되는 문제.
+
+**해결**: SSE에서 `classify_intents()` 선행 호출 → **모든 intent에 대해** `input_state`에 `intent`를 주입.
+그래프 내 `intent_router_node`는 **intent가 주입되면 분류 스킵**, intent 블록만 emit.
+
+```python
+# intent_router_node — 이미 intent가 주입되면 classify 스킵
+if state.get("intent"):
+    return {"response_blocks": [{"type":"intent", ...}]}  # intent 블록만 emit
+```
+
+### processed_query 재사용 불가 — intent별 sub_query로 전처리
+
+"카페 추천하고 전시회 알려줘"에서 첫 intent의 processed_query(`category="카페"`)를
+두번째 intent(EVENT_SEARCH)에 재사용하면 **category 오염**. 따라서:
+
+- `classify_intents()`가 **intent별 sub_query**도 함께 반환
+- 매 intent마다 **sub_query로 query_preprocessor를 실행** (스킵하지 않음)
+- query_preprocessor는 가드 없이 기존 코드 그대로 유지
+
+```json
+{"intents": [
+  {"intent": "PLACE_RECOMMEND", "confidence": 0.9, "sub_query": "홍대 카페 추천해줘"},
+  {"intent": "EVENT_SEARCH", "confidence": 0.85, "sub_query": "주말 전시회 알려줘"}
+]}
+```
+
+### FE 영향
+
+FE(`useWebSocket.ts`)에서 `done_partial` 이벤트 수신 시:
+- `isLoading = true` 유지 (finalize 하지 않음)
+- 블록 누적 계속
+- `done` 수신 시 비로소 finalize
+
+→ **FE 수정은 이 plan 범위 밖** (별도 이슈). BE는 `done_partial` 이벤트만 정상 emit하면 됨.
+
+## 3. 영향 범위
+
+- **수정 파일**:
+  - `backend/src/graph/intent_router_node.py` — `classify_intents()` 새 함수 추가 + 노드에 intent 주입 가드
+  - `backend/src/api/sse.py` — event_generator에 multi-intent 루프 추가
+- **신규 파일**:
+  - `backend/tests/test_multi_intent.py`
+- **DB 스키마 영향**: 없음 (messages.blocks JSONB에 블록 리스트 그대로 저장)
+- **응답 블록 16종 영향**: 변경 없음. `done_partial`은 SSE 제어 이벤트 (16종 밖)
+- **외부 API 호출**: Gemini classify_intents 1회 + query_preprocessor intent별 실행 (최대 3회)
+- **query_preprocessor_node.py**: 수정 없음 (매 intent마다 sub_query로 정상 실행)
+
+## 4. 19 불변식 체크리스트
+
+- [x] #1 PK 이원화 — 해당 없음
+- [x] #2 PG↔OS 동기화 — 해당 없음
+- [x] #3 append-only 4테이블 — messages INSERT만 (전체 블록 단일 메시지)
+- [x] #4 소프트 삭제 — 해당 없음
+- [x] #5 비정규화 — 신규 없음
+- [x] #6 6지표 — 해당 없음
+- [x] #7 임베딩 — 해당 없음
+- [x] #8 asyncpg 바인딩 — 해당 없음 (기존 _insert_message 재사용)
+- [x] #9 Optional[str] — 준수
+- [x] #10 SSE 이벤트 타입 16종 — done_partial은 SSE 제어 이벤트 (16종 밖, 기획서 §4.5 명시)
+- [x] #11 intent별 블록 순서 — 각 intent 실행마다 기존 순서 그대로 유지
+- [x] #12 공통 쿼리 전처리 — intent별 sub_query로 실행 (경로 유지)
+- [x] #13 행사 검색 순서 — 해당 없음 (노드 코드 미수정)
+- [x] #14 대화 이력 이원화 — 보존
+- [x] #15 인증 매트릭스 — 해당 없음
+- [x] #16 북마크 — 해당 없음
+- [x] #17 공유링크 — 해당 없음
+- [x] #18 Phase 라벨 — P1
+- [x] #19 기획 문서 우선 — API 명세서 v2 SSE 준수
+
+## 5. 작업 순서 (Atomic step)
+
+### g1 — classify_intents() 함수 추가 (intent_router_node.py)
+
+기존 `classify_intent()` 유지 (하위 호환). 새 함수 `classify_intents()` 추가.
+
+**핵심**: intent별 **sub_query**를 함께 반환하여 query_preprocessor가 각 intent에 맞는 전처리 실행 가능.
+
+```python
+_CLASSIFY_MULTI_SYSTEM_PROMPT = """
+...
+If the query contains multiple distinct requests, split them and return ALL matching intents.
+Return JSON: {"intents": [{"intent": "...", "confidence": 0.X, "sub_query": "..."}, ...]}
+- sub_query: the portion of the original query that corresponds to this intent (in Korean)
+- Maximum 3 intents per query.
+- If only one intent, return list with single element (sub_query = original query).
+- "카페에서 전시회 가는 코스" is ONE intent (COURSE_PLAN), not two.
+"""
+
+async def classify_intents(
+    query: str,
+    conversation_history: Optional[list[dict[str, str]]] = None,
+) -> list[tuple[IntentType, float, str]]:
+    """복수 intent 분류. 최대 3개.
+
+    Returns:
+        [(IntentType, confidence, sub_query), ...]. 최소 1개 보장.
+    """
+```
+
+- 단일 intent → `[("PLACE_SEARCH", 0.95, "홍대 카페 추천해줘")]`
+- 복수 intent → `[("PLACE_RECOMMEND", 0.9, "홍대 카페 추천해줘"), ("EVENT_SEARCH", 0.85, "주말 전시회 알려줘")]`
+- Phase 2 intent → GENERAL fallback (sub_query 유지)
+- 빈 결과 → `[("GENERAL", 0.0, query)]` fallback
+- 3개 초과 → 앞 3개만 채택
+
+> verify: 단위 테스트 — mock Gemini 응답으로 단일/복수/3개 초과 검증
+
+### g2 — intent_router_node 주입 가드
+
+`intent_router_node(state)` 수정:
+- `state.get("intent")`가 이미 있으면 classify 스킵, intent 블록만 emit
+- 없으면 기존 `classify_intent()` 호출 (단일 intent, 하위 호환)
+
+```python
+async def intent_router_node(state: dict[str, Any]) -> dict[str, Any]:
+    pre_injected = state.get("intent")
+    if pre_injected:
+        return {
+            "response_blocks": [
+                {"type": "intent", "intent": pre_injected, "confidence": 1.0}
+            ]
+        }
+    # 기존 로직 (classify_intent 호출)...
+```
+
+> verify: `ruff check && pyright`
+
+### g3 — sse.py multi-intent 루프 (핵심)
+
+`event_generator()` 수정:
+
+**변경 후** (multi-intent):
+```python
+from src.graph.intent_router_node import classify_intents
+
+graph = build_graph()
+
+# 1. 복수 intent 분류 (SSE에서 선행, Gemini 1회)
+intents = await classify_intents(query, conversation_history=[])
+
+# 2. intent별로 그래프 순차 실행
+for idx, (intent, confidence, sub_query) in enumerate(intents):
+    is_last = (idx == len(intents) - 1)
+
+    # 모든 intent에 intent를 주입 → intent_router_node 스킵
+    # sub_query를 query로 전달 → query_preprocessor가 intent별 전처리
+    input_state = {
+        "query": sub_query,
+        "intent": intent.value,
+        "thread_id": thread_id,
+        "user_id": user_id,
+        "conversation_history": [],
+    }
+
+    async for event in graph.astream(input_state):
+        for node_name, node_output in event.items():
+            blocks = node_output.get("response_blocks", [])
+            for block in blocks:
+                block_type = block.get("type", "")
+
+                # done 블록: 중간 intent에서는 무시 + DB 저장도 안 함
+                if block_type == "done":
+                    if is_last:
+                        assistant_blocks.append(block)
+                    # 중간 intent의 done은 완전히 무시
+                    continue
+
+                # 나머지 블록: 기존 로직 (text_stream 스트리밍 등)
+                ...
+
+    # 중간 intent 완료 → done_partial emit (DB 미저장)
+    if not is_last:
+        yield format_sse_event("done_partial", {
+            "type": "done_partial",
+            "completed_intent": intent.value,
+        })
+
+# 전체 블록 단일 메시지 INSERT
+await _insert_message(pool, thread_id, "assistant", assistant_blocks)
+yield format_done_event(status="done")
+```
+
+**핵심 변경점**:
+- **모든 intent에 intent 주입** → intent_router_node가 분류 스킵 (Gemini 중복 호출 방지)
+- **sub_query를 query로 전달** → query_preprocessor가 intent에 맞는 전처리 실행 (category 오염 방지)
+- **중간 intent의 done 블록**: SSE emit도 안 하고 assistant_blocks 저장도 안 함 (중복 done 방지)
+- **마지막 intent의 done 블록만** assistant_blocks에 저장
+- **done_partial**: SSE emit만 (DB 미저장, 기획서 §4.5 준수)
+
+> verify: 수동 테스트 — 단일/복수 intent 쿼리 모두 정상 동작
+
+### g4 — 단위/통합 테스트
+
+`tests/test_multi_intent.py`:
+
+- `test_classify_intents_single`: "홍대 카페 추천" → 1개 intent, sub_query = 원본
+- `test_classify_intents_multi`: "카페 추천해주고 전시회 알려줘" → 2개 intent + sub_query 분리 (mock Gemini)
+- `test_classify_intents_max_3`: 4개 이상 → 앞 3개만 채택
+- `test_classify_intents_phase2_filter`: Phase 2 intent → GENERAL fallback
+- `test_classify_intents_fallback`: Gemini 실패 → [("GENERAL", 0.0, query)]
+- `test_intent_router_node_injected`: intent 주입 시 classify 스킵, intent 블록만 반환
+- `test_intent_router_node_no_injection`: intent 미주입 시 기존 classify_intent 호출 (regression)
+
+> verify: `pytest tests/test_multi_intent.py -v`
+
+### g5 — 전체 검증 + regression
+
+- 기존 단일 intent 테스트 전부 통과 확인 (intent_router_node 가드가 기존 동작에 영향 없는지)
+- `pytest tests/ -v` 전체 통과
+
+> verify: `./validate.sh`
+
+## 6. 검증 계획
+
+- `./validate.sh` 전체 통과
+- `pytest tests/test_multi_intent.py -v` — 7개 케이스 통과
+- `pytest tests/ -v` 전체 통과 (기존 단일 intent 테스트 regression 없음)
+- 수동 시나리오:
+  1. `query=홍대 카페 추천해주고 주말 전시회도 알려줘` → SSE에서 PLACE_RECOMMEND 블록 → done_partial → EVENT_SEARCH 블록 → done
+  2. `query=홍대 카페 추천해줘` → 기존과 동일 (done_partial 없음, done만)
+  3. `query=카페 추천하고 맛집 찾아주고 코스 짜줘` → 3개 intent 순차 실행
+  4. DB messages.blocks에 전체 블록 단일 row 저장 확인
+
+## 7. 리스크
+
+- **Gemini 분류 정확도**: 복수 intent 분리 + sub_query 추출이 부정확할 수 있음. "카페에서 전시회 가는 코스" → COURSE_PLAN 1개 vs PLACE_RECOMMEND + EVENT_SEARCH 2개? → 프롬프트에 "하나의 목적이면 하나의 intent" 명시
+- **응답 시간**: intent 수만큼 그래프 재실행 + query_preprocessor Gemini 호출. 3개 제한 + classify_intents는 1회만으로 방어. 최악 case: classify 1회 + preprocess 3회 + 노드별 Gemini 3회 = 7회 Gemini 호출
+- **sub_query 품질**: Gemini가 sub_query를 잘못 분리하면 query_preprocessor 결과 부정확. fallback: sub_query가 빈 문자열이면 원본 query 사용
+
+## 8. 최종 결정
+
+APPROVED — 2026-05-06 PM 승인. 런타임 시뮬레이션 + 엣지 케이스 검증 완료. 구현 진입.

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -106,6 +106,8 @@ _NODE_STATUS_MESSAGES: dict[str, str] = {
     "detail_inquiry": "상세 정보를 조회하고 있어요...",
     "booking": "예약 정보를 확인하고 있어요...",
     "calendar": "일정을 추가하고 있어요...",
+    "review_compare": "장소를 비교하고 있어요...",
+    "analysis": "장소를 분석하고 있어요...",
 }
 
 

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -273,75 +273,110 @@ async def chat_stream(
                 user_blocks = [{"type": "text", "content": query}]
                 await _insert_message(pool, thread_id, "user", user_blocks)
 
-            # 3. LangGraph astream() 실행
+            # 3. 복수 intent 분류 (Gemini 1회) + LangGraph 순차 실행
+            from src.graph.intent_router_node import classify_intents  # pyright: ignore[reportMissingImports]
+
             graph = build_graph(checkpointer=None)
-            input_state: dict[str, Any] = {
-                "query": query,
-                "thread_id": thread_id,
-                "user_id": user_id,
-                "conversation_history": [],
-            }
+
+            try:
+                intents = await classify_intents(query, conversation_history=[])
+            except Exception:
+                logger.exception("classify_intents failed: thread_id=%s", thread_id)
+                intents = []
+
+            # fallback: 분류 실패 시 기존 단일 intent 동작 (intent 미주입 → intent_router가 분류)
+            if not intents:
+                intents_with_query: list[tuple[str, float, str, bool]] = [
+                    ("", 0.0, query, True)  # intent="" → 미주입, 기존 로직
+                ]
+            else:
+                intents_with_query = [
+                    (intent.value, conf, sub_q, idx == len(intents) - 1)
+                    for idx, (intent, conf, sub_q) in enumerate(intents)
+                ]
 
             assistant_blocks: list[dict[str, Any]] = []
             cancelled = False
             gemini_error = False
 
-            async for event in graph.astream(input_state):
-                if await request.is_disconnected():
-                    logger.info("Client disconnected: thread_id=%s", thread_id)
-                    cancelled = True
+            for intent_value, _conf, sub_query, is_last in intents_with_query:
+                if cancelled or gemini_error:
                     break
 
-                # event는 {node_name: node_output} 형태
-                for node_name, node_output in event.items():
-                    if not isinstance(node_output, dict):
-                        continue
+                input_state: dict[str, Any] = {
+                    "query": sub_query,
+                    "thread_id": thread_id,
+                    "user_id": user_id,
+                    "conversation_history": [],
+                }
+                # intent 주입 → intent_router_node가 classify 스킵
+                if intent_value:
+                    input_state["intent"] = intent_value
 
-                    # 노드 전환 시 status 이벤트 전송 (DB 미저장)
-                    status_msg = _NODE_STATUS_MESSAGES.get(node_name)
-                    if status_msg:
-                        yield format_status_event(status_msg, node=node_name)
+                async for event in graph.astream(input_state):
+                    if await request.is_disconnected():
+                        logger.info("Client disconnected: thread_id=%s", thread_id)
+                        cancelled = True
+                        break
 
-                    blocks = node_output.get("response_blocks", [])
-                    for block in blocks:
-                        if not isinstance(block, dict):
+                    for node_name, node_output in event.items():
+                        if not isinstance(node_output, dict):
                             continue
 
-                        block_type = block.get("type", "")
+                        status_msg = _NODE_STATUS_MESSAGES.get(node_name)
+                        if status_msg:
+                            yield format_status_event(status_msg, node=node_name)
 
-                        if block_type == "text_stream":
-                            # Gemini 토큰 스트리밍
-                            system_prompt = block.get("system", "")
-                            user_prompt = block.get("prompt", query)
-                            full_text = ""
+                        blocks = node_output.get("response_blocks", [])
+                        for block in blocks:
+                            if not isinstance(block, dict):
+                                continue
 
-                            try:
-                                async for delta in _stream_gemini(system_prompt, user_prompt):
-                                    if await request.is_disconnected():
-                                        cancelled = True
-                                        break
-                                    full_text += delta
-                                    yield format_sse_event("text_stream", {"type": "text_stream", "delta": delta})
-                            except Exception:
-                                logger.exception("Gemini streaming failed: thread_id=%s", thread_id)
-                                gemini_error = True
+                            block_type = block.get("type", "")
 
-                            # 부분이든 전체든 저장
-                            if full_text:
-                                assistant_blocks.append({"type": "text_stream", "content": full_text})
-
-                            if cancelled or gemini_error:
-                                break
-                        else:
-                            # done 블록은 루프 후에 전송 (INSERT→done 순서 보장)
+                            # done 블록: 마지막 intent만 저장, 중간은 완전 무시
                             if block_type == "done":
-                                assistant_blocks.append(block)
+                                if is_last:
+                                    assistant_blocks.append(block)
+                                continue
+
+                            if block_type == "text_stream":
+                                system_prompt = block.get("system", "")
+                                user_prompt = block.get("prompt", sub_query)
+                                full_text = ""
+
+                                try:
+                                    async for delta in _stream_gemini(system_prompt, user_prompt):
+                                        if await request.is_disconnected():
+                                            cancelled = True
+                                            break
+                                        full_text += delta
+                                        yield format_sse_event("text_stream", {"type": "text_stream", "delta": delta})
+                                except Exception:
+                                    logger.exception("Gemini streaming failed: thread_id=%s", thread_id)
+                                    gemini_error = True
+
+                                if full_text:
+                                    assistant_blocks.append({"type": "text_stream", "content": full_text})
+
+                                if cancelled or gemini_error:
+                                    break
                             else:
                                 yield format_sse_event(block_type, block)
                                 assistant_blocks.append(block)
 
-                    if cancelled or gemini_error:
-                        break
+                        if cancelled or gemini_error:
+                            break
+
+                # 중간 intent 완료 → done_partial emit (DB 미저장)
+                if not is_last and not cancelled and not gemini_error:
+                    yield format_sse_event(
+                        "done_partial",
+                        {
+                            "type": "done_partial",
+                            "completed_intent": intent_value,
+                        },
+                    )
 
             # 4. assistant 메시지 INSERT (done 전에 완료)
             persistence_success = True

--- a/backend/src/graph/analysis_node.py
+++ b/backend/src/graph/analysis_node.py
@@ -1,0 +1,198 @@
+"""ANALYSIS 노드 — 단일 장소 6지표 분석 (Phase 1).
+
+기획서 §4.5 블록 순서: intent → status → text_stream → analysis_sources → done
+불변식 #4: is_deleted=false 필터
+불변식 #6: 6지표 키 (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
+불변식 #8: asyncpg $1 바인딩
+불변식 #18: Phase 1
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_ANALYSIS_SYSTEM_PROMPT = """\
+당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다.
+장소의 6지표(만족도/접근성/청결도/가성비/분위기/전문성) 데이터를 바탕으로
+해당 장소를 심층 분석하여 친절하게 설명해주세요.
+각 지표의 의미와 강점/약점을 구체적으로 설명하고, 어떤 상황에 적합한 장소인지 추천 포인트를 제시하세요.
+데이터가 없는 경우 솔직하게 안내하세요.
+"""
+
+_NO_SCORES_SYSTEM_PROMPT = """\
+당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다.
+사용자가 요청한 장소의 리뷰 데이터가 아직 충분하지 않습니다.
+장소의 기본 정보(이름, 카테고리, 지역)를 바탕으로 간단히 소개하고,
+아직 리뷰 분석 데이터가 쌓이지 않았음을 안내해주세요.
+"""
+
+
+def _extract_place_name(
+    processed_query: dict[str, Any],
+    query: str,
+) -> Optional[str]:
+    """processed_query에서 단일 장소명 추출."""
+    place_name = processed_query.get("place_name")
+    if place_name and isinstance(place_name, str) and place_name.strip():
+        return place_name.strip()
+
+    keywords: list[str] = processed_query.get("keywords") or []
+    if isinstance(keywords, list) and len(keywords) >= 1:
+        first = keywords[0]
+        if isinstance(first, str) and first.strip():
+            return first.strip()
+
+    return None
+
+
+async def _fetch_place_pg(
+    pool: Any,
+    place_name: str,
+    os_client: Any,
+) -> Optional[dict[str, Any]]:
+    """장소명 → PG places 조회. 동명 다중 매칭 시 OS stars 최댓값 채택."""
+    rows = await pool.fetch(
+        "SELECT place_id, name, category, district FROM places WHERE is_deleted = false AND name ILIKE $1 LIMIT 20",
+        f"%{place_name}%",
+    )
+    if not rows:
+        return None
+
+    if len(rows) == 1:
+        return dict(rows[0])
+
+    # 동명 다중 매칭 → OS stars 최댓값 1건
+    place_ids = [row["place_id"] for row in rows]
+    doc_ids = [f"review_{pid}" for pid in place_ids]
+    try:
+        mget_resp = await os_client.mget(
+            body={"ids": doc_ids},
+            index="place_reviews",
+            _source=["stars", "place_id"],
+        )
+        stars_map: dict[str, float] = {}
+        for hit in mget_resp.get("docs", []):
+            if hit.get("found"):
+                src = hit.get("_source", {})
+                pid = src.get("place_id", "")
+                stars_map[pid] = float(src.get("stars", 0.0))
+        best = max(rows, key=lambda r: stars_map.get(r["place_id"], 0.0))
+        return dict(best)
+    except Exception:
+        logger.exception("_fetch_place_pg: OS mget 실패 → PG 첫 번째 row 사용")
+        return dict(rows[0])
+
+
+async def _fetch_scores_os(
+    os_client: Any,
+    place_id: str,
+) -> tuple[dict[str, float], int]:
+    """place_id → OS place_reviews._raw_scores + review_count 조회.
+
+    Returns:
+        (scores_dict, review_count). 문서 없으면 ({}, 0).
+    """
+    doc_id = f"review_{place_id}"
+    try:
+        mget_resp = await os_client.mget(
+            body={"ids": [doc_id]},
+            index="place_reviews",
+            _source=["_raw_scores", "review_count", "place_id"],
+        )
+        for hit in mget_resp.get("docs", []):
+            if hit.get("found"):
+                src = hit.get("_source", {})
+                raw = src.get("_raw_scores", {})
+                raw_count = src.get("review_count", 0)
+                review_count = int(raw_count) if raw_count is not None else 0
+                scores = {k: float(v) for k, v in raw.items() if isinstance(v, (int, float))}
+                return (scores, review_count)
+        return ({}, 0)
+    except Exception:
+        logger.exception("_fetch_scores_os: OS mget 실패")
+        return ({}, 0)
+
+
+def _build_analysis_blocks(
+    query: str,
+    place: dict[str, Any],
+    scores: dict[str, float],
+    review_count: int,
+) -> list[dict[str, Any]]:
+    """text_stream + analysis_sources raw dict 블록 생성."""
+    if scores:
+        score_str = ", ".join(f"{k}: {v:.1f}" for k, v in scores.items())
+        system = _ANALYSIS_SYSTEM_PROMPT
+        prompt = (
+            f"사용자 질문: {query}\n\n"
+            f"장소: {place['name']} ({place.get('category', '')})\n"
+            f"지역: {place.get('district', '')}\n"
+            f"6지표: {score_str}\n"
+            f"리뷰 수: {review_count}"
+        )
+    else:
+        system = _NO_SCORES_SYSTEM_PROMPT
+        prompt = (
+            f"사용자 질문: {query}\n\n"
+            f"장소: {place['name']} ({place.get('category', '')})\n"
+            f"지역: {place.get('district', '')}\n"
+            f"리뷰 데이터: 없음"
+        )
+
+    return [
+        {
+            "type": "text_stream",
+            "system": system,
+            "prompt": prompt,
+        },
+        {
+            "type": "analysis_sources",
+            "review_count": review_count,
+        },
+    ]
+
+
+async def analysis_node(state: dict[str, Any]) -> dict[str, Any]:
+    """LangGraph 노드 — ANALYSIS intent 처리 (Phase 1)."""
+    query: str = state.get("query", "")
+    processed_query: dict[str, Any] = state.get("processed_query") or {}
+
+    place_name = _extract_place_name(processed_query, query)
+
+    if not place_name:
+        return {
+            "response_blocks": [
+                {
+                    "type": "disambiguation",
+                    "message": "어떤 장소를 분석할까요? 장소명을 알려주세요.",
+                    "candidates": [],
+                }
+            ]
+        }
+
+    from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
+    from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+
+    pool = get_pool()
+    os_client = get_os_client()
+
+    place = await _fetch_place_pg(pool, place_name, os_client)
+
+    if not place:
+        return {
+            "response_blocks": [
+                {
+                    "type": "disambiguation",
+                    "message": "장소를 찾을 수 없어요. 정확한 장소명으로 다시 입력해주세요.",
+                    "candidates": [],
+                }
+            ]
+        }
+
+    scores, review_count = await _fetch_scores_os(os_client, place["place_id"])
+    blocks = _build_analysis_blocks(query, place, scores, review_count)
+
+    return {"response_blocks": blocks}

--- a/backend/src/graph/analysis_node.py
+++ b/backend/src/graph/analysis_node.py
@@ -14,6 +14,11 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# 불변식 #6: 6지표 키 고정 (이름·개수 변경 금지)
+_VALID_SCORE_KEYS: frozenset[str] = frozenset(
+    {"satisfaction", "accessibility", "cleanliness", "value", "atmosphere", "expertise"}
+)
+
 _ANALYSIS_SYSTEM_PROMPT = """\
 당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다.
 장소의 6지표(만족도/접근성/청결도/가성비/분위기/전문성) 데이터를 바탕으로
@@ -64,6 +69,10 @@ async def _fetch_place_pg(
     if len(rows) == 1:
         return dict(rows[0])
 
+    # OS 미가용 시 PG 첫 번째 row 사용
+    if os_client is None:
+        return dict(rows[0])
+
     # 동명 다중 매칭 → OS stars 최댓값 1건
     place_ids = [row["place_id"] for row in rows]
     doc_ids = [f"review_{pid}" for pid in place_ids]
@@ -108,7 +117,7 @@ async def _fetch_scores_os(
                 raw = src.get("_raw_scores", {})
                 raw_count = src.get("review_count", 0)
                 review_count = int(raw_count) if raw_count is not None else 0
-                scores = {k: float(v) for k, v in raw.items() if isinstance(v, (int, float))}
+                scores = {k: float(v) for k, v in raw.items() if k in _VALID_SCORE_KEYS and isinstance(v, (int, float))}
                 return (scores, review_count)
         return ({}, 0)
     except Exception:
@@ -173,11 +182,18 @@ async def analysis_node(state: dict[str, Any]) -> dict[str, Any]:
             ]
         }
 
-    from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
 
     pool = get_pool()
-    os_client = get_os_client()
+
+    # OS 클라이언트 — 미가용 시 PG만으로 동작 (점수 빈 값)
+    os_client: Any = None
+    try:
+        from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
+
+        os_client = get_os_client()
+    except Exception:
+        logger.warning("analysis_node: OS 클라이언트 초기화 실패 → PG만으로 진행")
 
     place = await _fetch_place_pg(pool, place_name, os_client)
 
@@ -192,7 +208,10 @@ async def analysis_node(state: dict[str, Any]) -> dict[str, Any]:
             ]
         }
 
-    scores, review_count = await _fetch_scores_os(os_client, place["place_id"])
+    if os_client:
+        scores, review_count = await _fetch_scores_os(os_client, place["place_id"])
+    else:
+        scores, review_count = {}, 0
     blocks = _build_analysis_blocks(query, place, scores, review_count)
 
     return {"response_blocks": blocks}

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -65,7 +65,11 @@ async def _embed_query_768d(query: str, api_key: str) -> list[float]:
         resp.raise_for_status()
         data = resp.json()
 
-    return data.get("embedding", {}).get("values", [0.0] * 768)
+    values = data.get("embedding", {}).get("values")
+    if not values:
+        logger.warning("_embed_query_768d: API 응답에 embedding.values 없음 → zero vector fallback")
+        return [0.0] * 768
+    return values
 
 
 # ---------------------------------------------------------------------------
@@ -402,9 +406,19 @@ def _build_blocks(
     total_stay_min = 0
     total_transit_min = 0
 
+    # order 기준 dict lookup (LLM이 순서 바꿔 반환할 수 있음)
+    detail_by_order: dict[int, dict[str, Any]] = {}
+    for d in stop_details:
+        order = d.get("order")
+        if isinstance(order, int):
+            detail_by_order[order] = d
+    # order 키 없으면 index fallback
+    if not detail_by_order:
+        detail_by_order = {i + 1: d for i, d in enumerate(stop_details)}
+
     course_stops: list[dict[str, Any]] = []
     for i, place in enumerate(route):
-        detail = stop_details[i] if i < len(stop_details) else {}
+        detail = detail_by_order.get(i + 1, {})
 
         duration = detail.get("duration_min", _DEFAULT_DURATION_MIN)
         total_stay_min += duration

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -75,7 +75,7 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
     categories: list[str] = []
 
-    # query에서 +, &, 와/과 구분자로 분리
+    # query에서 +, &, 와/과 구분자로 분리 — 첫 매칭 구분자만 사용
     for sep in ["+", "&", "와 ", "과 ", ", "]:
         if sep in query:
             parts = [p.strip() for p in query.split(sep)]
@@ -83,6 +83,7 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
                 for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
                     if keyword in part and keyword not in categories:
                         categories.append(keyword)
+            break  # 첫 매칭 구분자로만 파싱
 
     if not categories and pq_category:
         categories = [pq_category]
@@ -191,7 +192,7 @@ async def _search_by_categories(
     seen: set[str] = set()
     merged: list[dict[str, Any]] = []
     for result in results:
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             logger.warning("Category search error: %s", result)
             continue
         for place in result:
@@ -441,8 +442,9 @@ def _build_blocks(
                 "category_label": place.get("category"),
                 "address": place.get("address"),
                 "district": place.get("district"),
-                "location": {"lat": place["lat"], "lng": place["lng"]} if place.get("lat") is not None else None,
-                "summary": place.get("name", ""),
+                "location": {"lat": place["lat"], "lng": place["lng"]}
+                if place.get("lat") is not None and place.get("lng") is not None
+                else None,
             },
             "transit_to_next": transit_to_next,
             "recommendation_reason": detail.get("recommendation_reason"),
@@ -466,7 +468,7 @@ def _build_blocks(
     # --- map_route 블록 ---
     markers: list[dict[str, Any]] = []
     for i, place in enumerate(route):
-        if place.get("lat") is not None:
+        if place.get("lat") is not None and place.get("lng") is not None:
             markers.append(
                 {
                     "order": i + 1,
@@ -567,7 +569,7 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
                     "system": _COURSE_SYSTEM_PROMPT,
                     "prompt": f"사용자 질문: {query}\n\n코스를 구성할 장소를 찾지 못했습니다. 다른 지역이나 카테고리로 다시 시도해보세요.",
                 },
-                {"type": "course", "stops": [], "total_duration_min": 0},
+                {"type": "course", "course_id": str(uuid.uuid4()), "stops": [], "total_duration_min": 0},
             ]
         }
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -79,15 +79,23 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
     categories: list[str] = []
 
+    _KNOWN_CATEGORIES = ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]
+
     # query에서 +, &, 와/과 구분자로 분리 — 첫 매칭 구분자만 사용
     for sep in ["+", "&", "와 ", "과 ", ", "]:
         if sep in query:
             parts = [p.strip() for p in query.split(sep)]
             for part in parts:
-                for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
+                for keyword in _KNOWN_CATEGORIES:
                     if keyword in part and keyword not in categories:
                         categories.append(keyword)
             break  # 첫 매칭 구분자로만 파싱
+
+    # 구분자 없는 단일 카테고리 쿼리 ("홍대 카페 코스") — whole-query 키워드 스캔
+    if not categories:
+        for keyword in _KNOWN_CATEGORIES:
+            if keyword in query and keyword not in categories:
+                categories.append(keyword)
 
     if not categories and pq_category:
         categories = [pq_category]
@@ -187,9 +195,9 @@ async def _search_by_categories(
 
     for cat in categories:
         tasks.append(_search_pg(pool, district, cat, neighborhood))
-
-    if os_client and api_key:
-        tasks.append(_search_os(os_client, expanded_query, api_key))
+        # 카테고리별 OS 검색 — 카테고리 키워드를 포함한 쿼리로 분리
+        if os_client and api_key:
+            tasks.append(_search_os(os_client, f"{expanded_query} {cat}", api_key))
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -330,9 +338,24 @@ async def _llm_course_compose(
             text = text.strip()
 
         result = json.loads(text)
+        if not isinstance(result, dict):
+            logger.warning("LLM course compose: 응답이 dict 아님 → fallback")
+            return None, None, []
+
         title = result.get("title")
         description = result.get("description")
-        stop_details = result.get("stops", [])
+        raw_stops = result.get("stops", [])
+
+        # stops 요소 검증 — dict가 아니거나 order 없으면 제외
+        stop_details: list[dict[str, Any]] = []
+        for s in raw_stops:
+            if not isinstance(s, dict):
+                continue
+            # duration_min 타입 정규화
+            dur = s.get("duration_min")
+            if isinstance(dur, str) and dur.isdigit():
+                s["duration_min"] = int(dur)
+            stop_details.append(s)
 
         return title, description, stop_details
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -1,0 +1,591 @@
+"""COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
+
+검색 흐름:
+  1. 쿼리에서 복수 카테고리 파싱 ("카페+맛집" → ["카페", "맛집"])
+  2. 카테고리별 PG + OS 병렬 검색 (place_recommend 패턴 재활용)
+  3. Greedy Nearest Neighbor 경로 최적화 (Haversine 직선 거리)
+  4. LLM 코스 구성 (Gemini Flash — 시간대 배분 + 추천 사유)
+  5. 블록: text_stream + course + map_route
+
+Phase 1 단순화: OSRM 미사용, polyline.type="straight". Phase 2에서 road polyline 교체.
+ST_DWithin 공간 필터는 AgentState에 user_location 추가 후 도입 예정.
+
+불변식 #2: place_id == places_vector._id
+불변식 #7: gemini-embedding-001 768d
+불변식 #8: asyncpg $1,$2 바인딩
+불변식 #11: intent → text_stream → course → map_route → done
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import uuid
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_COURSE_SYSTEM_PROMPT = (
+    "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
+    "사용자의 코스 추천 결과를 친절하게 소개해주세요. "
+    "각 장소의 추천 이유와 이동 동선을 자연스럽게 설명하고, "
+    "소요 시간과 팁도 포함해주세요."
+)
+
+_MAX_STOPS = 5
+_DEFAULT_DURATION_MIN = 60
+_OS_TOP_K = 10
+_OS_MIN_SCORE = 0.4
+_PG_LIMIT = 10
+
+
+# ---------------------------------------------------------------------------
+# Gemini 768d 임베딩 (place_search/place_recommend 동일 로직 복제)
+# TODO: Phase 1 이후 공유 유틸 추출 검토
+# ---------------------------------------------------------------------------
+async def _embed_query_768d(query: str, api_key: str) -> list[float]:
+    """Gemini embedding-001 768d 단건 임베딩. 불변식 #7."""
+    import httpx
+
+    url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent"
+    body = {
+        "model": "models/gemini-embedding-001",
+        "content": {"parts": [{"text": query[:2000]}]},
+        "outputDimensionality": 768,
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "x-goog-api-key": api_key,
+    }
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(url, json=body, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+    return data.get("embedding", {}).get("values", [0.0] * 768)
+
+
+# ---------------------------------------------------------------------------
+# ① 카테고리 파싱
+# ---------------------------------------------------------------------------
+def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
+    """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
+    categories: list[str] = []
+
+    # query에서 +, &, 와/과 구분자로 분리
+    for sep in ["+", "&", "와 ", "과 ", ", "]:
+        if sep in query:
+            parts = [p.strip() for p in query.split(sep)]
+            for part in parts:
+                for keyword in ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]:
+                    if keyword in part and keyword not in categories:
+                        categories.append(keyword)
+
+    if not categories and pq_category:
+        categories = [pq_category]
+
+    if not categories:
+        categories = ["맛집"]
+
+    return categories[:3]  # 최대 3 카테고리
+
+
+# ---------------------------------------------------------------------------
+# ② 카테고리별 PG + OS 병렬 검색
+# ---------------------------------------------------------------------------
+async def _search_pg(
+    pool: Any,
+    district: Optional[str],
+    category: str,
+    neighborhood: Optional[str],
+) -> list[dict[str, Any]]:
+    """places 테이블 카테고리별 검색. 불변식 #8."""
+    sql = (
+        "SELECT place_id, name, category, address, district, "
+        "ST_Y(geom::geometry) AS lat, ST_X(geom::geometry) AS lng "
+        "FROM places WHERE is_deleted = false"
+    )
+    params: list[Any] = []
+
+    params.append(f"%{category}%")
+    sql += f" AND category ILIKE ${len(params)}"
+
+    if district:
+        params.append(district)
+        sql += f" AND district = ${len(params)}"
+
+    if neighborhood:
+        params.append(f"%{neighborhood}%")
+        sql += f" AND (address ILIKE ${len(params)} OR name ILIKE ${len(params)})"
+
+    params.append(_PG_LIMIT)
+    sql += f" LIMIT ${len(params)}"
+
+    try:
+        rows = await pool.fetch(sql, *params)
+        return [dict(r) for r in rows]
+    except Exception:
+        logger.exception("PG course search failed for category=%s", category)
+        return []
+
+
+async def _search_os(
+    os_client: Any,
+    query: str,
+    api_key: str,
+) -> list[dict[str, Any]]:
+    """places_vector k-NN 검색."""
+    try:
+        query_vector = await _embed_query_768d(query, api_key)
+
+        body: dict[str, Any] = {
+            "size": _OS_TOP_K,
+            "query": {"knn": {"embedding": {"vector": query_vector, "k": _OS_TOP_K}}},
+            "min_score": _OS_MIN_SCORE,
+        }
+
+        result = await os_client.search(index="places_vector", body=body)
+        hits = result.get("hits", {}).get("hits", [])
+
+        return [
+            {
+                "place_id": hit.get("_id", ""),
+                "name": hit.get("_source", {}).get("name", ""),
+                "category": hit.get("_source", {}).get("category", ""),
+                "address": hit.get("_source", {}).get("address", ""),
+                "district": hit.get("_source", {}).get("district", ""),
+                "lat": hit.get("_source", {}).get("lat"),
+                "lng": hit.get("_source", {}).get("lng"),
+                "score": hit.get("_score", 0),
+            }
+            for hit in hits
+        ]
+    except Exception:
+        logger.exception("OS course search failed")
+        return []
+
+
+async def _search_by_categories(
+    pool: Any,
+    os_client: Optional[Any],
+    categories: list[str],
+    district: Optional[str],
+    neighborhood: Optional[str],
+    expanded_query: str,
+    api_key: Optional[str],
+) -> list[dict[str, Any]]:
+    """카테고리별 PG + OS 병렬 검색 → 병합."""
+    tasks: list[Any] = []
+
+    for cat in categories:
+        tasks.append(_search_pg(pool, district, cat, neighborhood))
+
+    if os_client and api_key:
+        tasks.append(_search_os(os_client, expanded_query, api_key))
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    seen: set[str] = set()
+    merged: list[dict[str, Any]] = []
+    for result in results:
+        if isinstance(result, Exception):
+            logger.warning("Category search error: %s", result)
+            continue
+        for place in result:
+            pid = place.get("place_id", "")
+            if pid and pid not in seen:
+                seen.add(pid)
+                merged.append(place)
+
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# ③ Greedy Nearest Neighbor 경로 최적화
+# ---------------------------------------------------------------------------
+def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """두 좌표 간 Haversine 거리 (미터)."""
+    r = 6371000
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return r * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _greedy_nn_route(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Greedy Nearest Neighbor — 직선 거리 기반 최근접 이웃 순서 결정.
+
+    좌표 없는 후보는 뒤에 배치. 최대 _MAX_STOPS건.
+    """
+    with_coords = [c for c in candidates if c.get("lat") is not None and c.get("lng") is not None]
+    without_coords = [c for c in candidates if c.get("lat") is None or c.get("lng") is None]
+
+    if not with_coords:
+        return candidates[:_MAX_STOPS]
+
+    route: list[dict[str, Any]] = [with_coords[0]]
+    remaining = with_coords[1:]
+
+    while remaining and len(route) < _MAX_STOPS:
+        last = route[-1]
+        nearest_idx = 0
+        nearest_dist = float("inf")
+        for i, c in enumerate(remaining):
+            dist = _haversine_m(last["lat"], last["lng"], c["lat"], c["lng"])
+            if dist < nearest_dist:
+                nearest_dist = dist
+                nearest_idx = i
+        route.append(remaining.pop(nearest_idx))
+
+    # 좌표 없는 후보로 남은 슬롯 채우기
+    for c in without_coords:
+        if len(route) >= _MAX_STOPS:
+            break
+        route.append(c)
+
+    return route
+
+
+# ---------------------------------------------------------------------------
+# ④ LLM 코스 구성
+# ---------------------------------------------------------------------------
+_COURSE_COMPOSE_PROMPT = """\
+사용자의 코스 추천 요청에 맞춰 코스를 구성해주세요.
+장소 목록과 순서가 주어집니다. 각 장소에 대해:
+
+JSON으로만 응답하세요:
+{
+  "title": "코스 제목 (예: '홍대 카페+맛집 한나절 코스')",
+  "description": "코스 한줄 설명",
+  "stops": [
+    {
+      "order": 1,
+      "arrival_time": "HH:mm (예: 11:00)",
+      "duration_min": 체류시간(분),
+      "recommendation_reason": "추천 이유 한 줄",
+      "transit_mode": "walk|subway|bus|taxi (다음 장소까지 이동 수단)"
+    }
+  ]
+}
+
+시간대 배분 규칙:
+- 시작 시간은 11:00 기본
+- 각 장소 체류 30-90분
+- 이동 시간은 도보 기준 예상
+- 마지막 장소의 transit_mode는 null
+"""
+
+
+async def _llm_course_compose(
+    route: list[dict[str, Any]],
+    query: str,
+) -> tuple[Optional[str], Optional[str], list[dict[str, Any]]]:
+    """Gemini Flash로 코스 구성. 실패 시 균등 배분 fallback.
+
+    Returns:
+        (title, description, stop_details[{arrival_time, duration_min, recommendation_reason, transit_mode}])
+    """
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    from src.config import get_settings
+
+    settings = get_settings()
+    if not settings.gemini_llm_api_key or not route:
+        return None, None, []
+
+    place_lines = "\n".join(
+        f"- {i + 1}. {p.get('name', '')} ({p.get('category', '')}, {p.get('district', '')})"
+        for i, p in enumerate(route)
+    )
+
+    try:
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+
+        response = await llm.ainvoke(
+            [
+                ("system", _COURSE_COMPOSE_PROMPT),
+                ("human", f"사용자 요청: {query}\n\n경유 장소 (순서대로):\n{place_lines}"),
+            ]
+        )
+        text = str(response.content).strip()
+
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+        title = result.get("title")
+        description = result.get("description")
+        stop_details = result.get("stops", [])
+
+        return title, description, stop_details
+
+    except Exception:
+        logger.exception("LLM course compose failed → fallback")
+        return None, None, []
+
+
+def _apply_fallback_times(route: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """LLM 실패 시 균등 배분 fallback."""
+    details: list[dict[str, Any]] = []
+    hour = 11
+    minute = 0
+
+    for i in range(len(route)):
+        details.append(
+            {
+                "order": i + 1,
+                "arrival_time": f"{hour:02d}:{minute:02d}",
+                "duration_min": _DEFAULT_DURATION_MIN,
+                "recommendation_reason": None,
+                "transit_mode": "walk" if i < len(route) - 1 else None,
+            }
+        )
+        minute += _DEFAULT_DURATION_MIN + 15  # 체류 + 이동 15분
+        while minute >= 60:
+            hour += 1
+            minute -= 60
+
+    return details
+
+
+# ---------------------------------------------------------------------------
+# ⑤ 블록 생성
+# ---------------------------------------------------------------------------
+def _build_blocks(
+    query: str,
+    route: list[dict[str, Any]],
+    title: Optional[str],
+    description: Optional[str],
+    stop_details: list[dict[str, Any]],
+    course_id: str,
+) -> list[dict[str, Any]]:
+    """text_stream + course + map_route 블록 생성."""
+    blocks: list[dict[str, Any]] = []
+
+    # fallback 적용
+    if not stop_details:
+        stop_details = _apply_fallback_times(route)
+
+    if not title:
+        title = "추천 코스"
+    if not description:
+        description = f"{len(route)}곳을 둘러보는 코스"
+
+    # --- text_stream ---
+    stop_summary = "\n".join(
+        f"- {route[i].get('name', '')} ({route[i].get('category', '')})" for i in range(len(route))
+    )
+    prompt = (
+        f"사용자 질문: {query}\n\n"
+        f"코스 제목: {title}\n"
+        f"코스 설명: {description}\n\n"
+        f"경유 장소:\n{stop_summary}\n\n"
+        "위 코스를 친절하게 소개해주세요. 각 장소의 특징과 동선을 설명해주세요."
+    )
+    blocks.append({"type": "text_stream", "system": _COURSE_SYSTEM_PROMPT, "prompt": prompt})
+
+    # --- course 블록 ---
+    total_distance_m = 0
+    total_stay_min = 0
+    total_transit_min = 0
+
+    course_stops: list[dict[str, Any]] = []
+    for i, place in enumerate(route):
+        detail = stop_details[i] if i < len(stop_details) else {}
+
+        duration = detail.get("duration_min", _DEFAULT_DURATION_MIN)
+        total_stay_min += duration
+
+        transit_to_next: Optional[dict[str, Any]] = None
+        if i < len(route) - 1:
+            next_place = route[i + 1]
+            if place.get("lat") is not None and next_place.get("lat") is not None:
+                dist = int(_haversine_m(place["lat"], place["lng"], next_place["lat"], next_place["lng"]))
+                transit_min = max(1, dist // 80)  # 도보 약 80m/min
+            else:
+                dist = 0
+                transit_min = 10
+
+            total_distance_m += dist
+            total_transit_min += transit_min
+
+            mode = detail.get("transit_mode", "walk") or "walk"
+            mode_ko_map = {"walk": "도보", "subway": "지하철", "bus": "버스", "taxi": "택시"}
+            transit_to_next = {
+                "mode": mode,
+                "mode_ko": mode_ko_map.get(mode, "도보"),
+                "distance_m": dist,
+                "duration_min": transit_min,
+            }
+
+        stop: dict[str, Any] = {
+            "order": i + 1,
+            "arrival_time": detail.get("arrival_time"),
+            "duration_min": duration,
+            "place": {
+                "place_id": place.get("place_id", ""),
+                "name": place.get("name", ""),
+                "category": place.get("category"),
+                "category_label": place.get("category"),
+                "address": place.get("address"),
+                "district": place.get("district"),
+                "location": {"lat": place["lat"], "lng": place["lng"]} if place.get("lat") is not None else None,
+                "summary": place.get("name", ""),
+            },
+            "transit_to_next": transit_to_next,
+            "recommendation_reason": detail.get("recommendation_reason"),
+        }
+        course_stops.append(stop)
+
+    blocks.append(
+        {
+            "type": "course",
+            "course_id": course_id,
+            "title": title,
+            "description": description,
+            "total_distance_m": total_distance_m,
+            "total_duration_min": total_stay_min + total_transit_min,
+            "total_stay_min": total_stay_min,
+            "total_transit_min": total_transit_min,
+            "stops": course_stops,
+        }
+    )
+
+    # --- map_route 블록 ---
+    markers: list[dict[str, Any]] = []
+    for i, place in enumerate(route):
+        if place.get("lat") is not None:
+            markers.append(
+                {
+                    "order": i + 1,
+                    "position": {"lat": place["lat"], "lng": place["lng"]},
+                    "label": place.get("name", ""),
+                    "category": place.get("category"),
+                }
+            )
+
+    segments: list[dict[str, Any]] = []
+    for i in range(len(route) - 1):
+        p1 = route[i]
+        p2 = route[i + 1]
+        if p1.get("lat") is not None and p2.get("lat") is not None:
+            detail = stop_details[i] if i < len(stop_details) else {}
+            segments.append(
+                {
+                    "from_order": i + 1,
+                    "to_order": i + 2,
+                    "mode": detail.get("transit_mode", "walk") or "walk",
+                    "coordinates": [
+                        [p1["lng"], p1["lat"]],  # GeoJSON [lng, lat]
+                        [p2["lng"], p2["lat"]],
+                    ],
+                }
+            )
+
+    # bounds 계산
+    lats = [p["lat"] for p in route if p.get("lat") is not None]
+    lngs = [p["lng"] for p in route if p.get("lng") is not None]
+
+    if markers:
+        blocks.append(
+            {
+                "type": "map_route",
+                "course_id": course_id,
+                "bounds": {
+                    "sw": {"lat": min(lats), "lng": min(lngs)},
+                    "ne": {"lat": max(lats), "lng": max(lngs)},
+                },
+                "center": {"lat": sum(lats) / len(lats), "lng": sum(lngs) / len(lngs)},
+                "suggested_zoom": 14,
+                "markers": markers,
+                "polyline": {"type": "straight", "segments": segments},
+            }
+        )
+
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# LangGraph 노드
+# ---------------------------------------------------------------------------
+async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
+    """COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
+
+    Args:
+        state: AgentState dict.
+
+    Returns:
+        {"response_blocks": [text_stream, course, map_route]}.
+    """
+    from src.config import get_settings
+    from src.db.opensearch import get_os_client
+    from src.db.postgres import get_pool
+
+    query = state.get("query", "")
+    pq = state.get("processed_query") or {}
+
+    district = pq.get("district")
+    neighborhood = pq.get("neighborhood")
+    pq_category = pq.get("category")
+    expanded_query = pq.get("expanded_query") or query
+
+    settings = get_settings()
+    pool = get_pool()
+
+    # ① 카테고리 파싱
+    categories = _parse_categories(query, pq_category)
+
+    # ② 카테고리별 병렬 검색
+    os_client: Optional[Any] = None
+    api_key: Optional[str] = settings.gemini_llm_api_key
+    try:
+        os_client = get_os_client()
+    except RuntimeError:
+        logger.warning("OpenSearch client not initialized, skipping vector search")
+
+    candidates = await _search_by_categories(
+        pool, os_client, categories, district, neighborhood, expanded_query, api_key
+    )
+
+    if not candidates:
+        return {
+            "response_blocks": [
+                {
+                    "type": "text_stream",
+                    "system": _COURSE_SYSTEM_PROMPT,
+                    "prompt": f"사용자 질문: {query}\n\n코스를 구성할 장소를 찾지 못했습니다. 다른 지역이나 카테고리로 다시 시도해보세요.",
+                },
+                {"type": "course", "stops": [], "total_duration_min": 0},
+            ]
+        }
+
+    # ③ Greedy NN 경로 최적화
+    route = _greedy_nn_route(candidates)
+
+    # ④ LLM 코스 구성
+    title, description, stop_details = await _llm_course_compose(route, query)
+
+    # ⑤ 블록 생성
+    course_id = str(uuid.uuid4())
+    blocks = _build_blocks(query, route, title, description, stop_details, course_id)
+
+    logger.info(
+        "course_plan: categories=%s, candidates=%d, route=%d stops",
+        categories,
+        len(candidates),
+        len(route),
+    )
+
+    return {"response_blocks": blocks}

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -49,6 +49,7 @@ PHASE1_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssi
         IntentType.CALENDAR,
         IntentType.FAVORITE,
         IntentType.REVIEW_COMPARE,
+        IntentType.ANALYSIS,
         IntentType.GENERAL,
     }
 )
@@ -66,6 +67,7 @@ _ROUTABLE_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportA
         IntentType.BOOKING,
         IntentType.CALENDAR,
         IntentType.REVIEW_COMPARE,
+        IntentType.ANALYSIS,
         IntentType.GENERAL,
     }
 )
@@ -89,10 +91,11 @@ Phase 1 (active):
 - CALENDAR: adding an event to calendar
 - FAVORITE: bookmarking or favoriting something
 - REVIEW_COMPARE: comparing two or more places by 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
+- ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
 - GENERAL: general conversation, greetings, or anything else
 
 Phase 2 (not yet active, classify as GENERAL for now):
-- ANALYSIS, COST_ESTIMATE, CROWDEDNESS, IMAGE_SEARCH
+- COST_ESTIMATE, CROWDEDNESS, IMAGE_SEARCH
 
 Respond in JSON: {"intent": "INTENT_NAME", "confidence": 0.0-1.0}
 """

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -101,6 +101,135 @@ Respond in JSON: {"intent": "INTENT_NAME", "confidence": 0.0-1.0}
 """
 
 
+_CLASSIFY_MULTI_SYSTEM_PROMPT = """\
+You are an intent classifier for a Seoul local-life AI chatbot.
+The user query may contain multiple distinct requests. Identify ALL intents.
+
+Phase 1 (active):
+- PLACE_SEARCH: searching for specific places (restaurants, cafes, etc.)
+- PLACE_RECOMMEND: asking for place recommendations
+- EVENT_SEARCH: searching for cultural events, festivals, exhibitions
+- EVENT_RECOMMEND: asking for event recommendations
+- COURSE_PLAN: planning a course/itinerary with multiple stops
+- DETAIL_INQUIRY: asking detailed info about a specific place or event
+- BOOKING: requesting a reservation or booking link
+- CALENDAR: adding an event to calendar
+- FAVORITE: bookmarking or favoriting something
+- REVIEW_COMPARE: comparing two or more places by 6 metrics
+- ANALYSIS: analyzing a single place with 6 metrics
+- GENERAL: general conversation, greetings, or anything else
+
+Phase 2 (not yet active, classify as GENERAL for now):
+- COST_ESTIMATE, CROWDEDNESS, IMAGE_SEARCH
+
+Rules:
+- If the query has ONE purpose, return ONE intent. Example: "카페에서 전시회 가는 코스" → COURSE_PLAN only.
+- If the query has MULTIPLE distinct requests joined by "~하고", "~그리고", "~도", return MULTIPLE intents.
+- Maximum 3 intents per query.
+- sub_query: the portion of the original query for each intent (in Korean).
+- If only one intent, sub_query = the original query.
+
+Respond in JSON: {"intents": [{"intent": "...", "confidence": 0.0-1.0, "sub_query": "..."}, ...]}
+"""
+
+_MAX_INTENTS = 3
+
+
+async def classify_intents(
+    query: str,
+    conversation_history: Optional[list[dict[str, str]]] = None,
+) -> list[tuple[IntentType, float, str]]:
+    """복수 intent 분류. 최대 3개.
+
+    Args:
+        query: 사용자 원본 쿼리.
+        conversation_history: 이전 대화 이력.
+
+    Returns:
+        [(IntentType, confidence, sub_query), ...]. 최소 1개 보장.
+    """
+    import json
+
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    from src.config import get_settings  # pyright: ignore[reportMissingImports]
+
+    settings = get_settings()
+    if not settings.gemini_llm_api_key:
+        logger.warning("classify_intents: GEMINI_LLM_API_KEY 미설정 → GENERAL fallback")
+        return [(_GENERAL_FALLBACK, 0.0, query)]
+
+    try:
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+
+        messages: list[tuple[str, str]] = [("system", _CLASSIFY_MULTI_SYSTEM_PROMPT)]
+
+        if conversation_history:
+            for msg in conversation_history[-5:]:
+                role = msg.get("role", "user")
+                content = msg.get("content", "")
+                lc_role = "human" if role == "user" else "ai"
+                messages.append((lc_role, content))
+
+        messages.append(("human", query))
+
+        response = await llm.ainvoke(messages)
+        text = str(response.content).strip()
+
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+        raw_intents = result.get("intents", [])
+        if not isinstance(raw_intents, list) or len(raw_intents) == 0:
+            return [(_GENERAL_FALLBACK, 0.0, query)]
+
+        parsed: list[tuple[IntentType, float, str]] = []
+        for item in raw_intents[:_MAX_INTENTS]:
+            intent_str = item.get("intent", "GENERAL")
+            confidence = float(item.get("confidence", 0.0))
+            sub_query = item.get("sub_query", "") or query
+
+            try:
+                intent = IntentType(intent_str)
+            except ValueError:
+                logger.warning("classify_intents: 알 수 없는 intent=%s → GENERAL", intent_str)
+                intent = _GENERAL_FALLBACK
+
+            if intent not in PHASE1_INTENTS:
+                logger.info("classify_intents: Phase 2 intent=%s → GENERAL", intent.value)
+                intent = _GENERAL_FALLBACK
+
+            if intent not in _ROUTABLE_INTENTS:
+                logger.info("classify_intents: 라우팅 불가 intent=%s → GENERAL", intent.value)
+                intent = _GENERAL_FALLBACK
+
+            parsed.append((intent, confidence, sub_query))
+
+        # 중복 GENERAL 제거 (GENERAL이 여러 개면 1개만)
+        seen_general = False
+        deduped: list[tuple[IntentType, float, str]] = []
+        for item in parsed:
+            if item[0] == _GENERAL_FALLBACK:
+                if seen_general:
+                    continue
+                seen_general = True
+            deduped.append(item)
+
+        return deduped if deduped else [(_GENERAL_FALLBACK, 0.0, query)]
+
+    except Exception:
+        logger.exception("classify_intents failed → GENERAL fallback")
+        return [(_GENERAL_FALLBACK, 0.0, query)]
+
+
 async def classify_intent(
     query: str,
     conversation_history: Optional[list[dict[str, str]]] = None,
@@ -188,12 +317,28 @@ async def classify_intent(
 async def intent_router_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 노드 함수 — intent 분류 결과를 state에 기록.
 
+    multi-intent 모드에서는 SSE 핸들러가 intent를 미리 주입하므로
+    classify 호출을 스킵하고 intent 블록만 emit.
+
     Args:
         state: AgentState (TypedDict).
 
     Returns:
         {"intent": str, "response_blocks": [IntentBlock dict]}.
     """
+    pre_injected = state.get("intent")
+    if pre_injected:
+        # SSE 핸들러가 intent를 주입한 경우 — classify 스킵
+        return {
+            "response_blocks": [
+                {
+                    "type": "intent",
+                    "intent": pre_injected,
+                    "confidence": 1.0,
+                }
+            ]
+        }
+
     query = state.get("query", "")
     history = state.get("conversation_history")
 

--- a/backend/src/graph/real_builder.py
+++ b/backend/src/graph/real_builder.py
@@ -17,6 +17,7 @@ from langgraph.graph import END, StateGraph
 
 from src.graph.booking_node import booking_node  # pyright: ignore[reportMissingImports]
 from src.graph.calendar_node import calendar_node  # pyright: ignore[reportMissingImports]
+from src.graph.course_plan_node import course_plan_node  # pyright: ignore[reportMissingImports]  # noqa: F401
 from src.graph.detail_inquiry_node import detail_inquiry_node  # pyright: ignore[reportMissingImports]  # noqa: F401
 from src.graph.general_node import general_node  # pyright: ignore[reportMissingImports]
 from src.graph.intent_router_node import intent_router_node  # pyright: ignore[reportMissingImports]
@@ -41,11 +42,6 @@ async def _event_search_node(state: AgentState) -> dict[str, Any]:
 
 async def _event_recommend_node(state: AgentState) -> dict[str, Any]:
     """행사 추천 노드 stub (events[] + references, EVENT_SEARCH 대칭)."""
-    return {"response_blocks": []}
-
-
-async def _course_plan_node(state: AgentState) -> dict[str, Any]:
-    """코스 계획 노드 stub."""
     return {"response_blocks": []}
 
 
@@ -104,7 +100,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
     graph.add_node("place_recommend", place_recommend_node)
     graph.add_node("event_search", _event_search_node)
     graph.add_node("event_recommend", _event_recommend_node)
-    graph.add_node("course_plan", _course_plan_node)
+    graph.add_node("course_plan", course_plan_node)
     graph.add_node("general", general_node)
     graph.add_node("detail_inquiry", detail_inquiry_node)
     graph.add_node("booking", booking_node)

--- a/backend/src/graph/real_builder.py
+++ b/backend/src/graph/real_builder.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 
 from langgraph.graph import END, StateGraph
 
+from src.graph.analysis_node import analysis_node  # pyright: ignore[reportMissingImports]
 from src.graph.booking_node import booking_node  # pyright: ignore[reportMissingImports]
 from src.graph.calendar_node import calendar_node  # pyright: ignore[reportMissingImports]
 from src.graph.course_plan_node import course_plan_node  # pyright: ignore[reportMissingImports]  # noqa: F401
@@ -61,6 +62,7 @@ def _route_by_intent(state: AgentState) -> str:
         - DETAIL_INQUIRY → "detail_inquiry"
         - BOOKING → "booking"
         - CALENDAR → "calendar"
+        - ANALYSIS → "analysis"
         - GENERAL (fallback) → "general"
         - Phase 2 intents → "general" (Phase 2에서 확장)
     """
@@ -75,6 +77,7 @@ def _route_by_intent(state: AgentState) -> str:
         "BOOKING": "booking",
         "CALENDAR": "calendar",
         "REVIEW_COMPARE": "review_compare",
+        "ANALYSIS": "analysis",
     }
     return mapping.get(str(intent), "general")
 
@@ -106,6 +109,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
     graph.add_node("booking", booking_node)
     graph.add_node("calendar", calendar_node)
     graph.add_node("review_compare", review_compare_node)
+    graph.add_node("analysis", analysis_node)
     graph.add_node("response_builder", response_builder_node)
 
     # 엣지 설정
@@ -126,6 +130,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
             "booking": "booking",
             "calendar": "calendar",
             "review_compare": "review_compare",
+            "analysis": "analysis",
             "general": "general",
         },
     )
@@ -142,6 +147,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
         "booking",
         "calendar",
         "review_compare",
+        "analysis",
     ]:
         graph.add_edge(node_name, "response_builder")
 

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -26,11 +26,12 @@ _EXPECTED_BLOCK_ORDER: dict[str, list[str]] = {
     "GENERAL": ["intent", "text_stream", "done"],
     "PLACE_SEARCH": ["intent", "text_stream", "places", "done"],
     "PLACE_RECOMMEND": ["intent", "text_stream", "places", "done"],
+    "COURSE_PLAN": ["intent", "text_stream", "course", "done"],
     "DETAIL_INQUIRY": ["intent", "text_stream", "done"],
 }
 
 # 선택적 블록 — 있어도 되고 없어도 되는 블록 (순서 검증에서 제외)
-_OPTIONAL_BLOCKS: frozenset[str] = frozenset({"map_markers", "place", "references"})
+_OPTIONAL_BLOCKS: frozenset[str] = frozenset({"map_markers", "map_route", "place", "references"})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/models/blocks.py
+++ b/backend/src/models/blocks.py
@@ -107,27 +107,59 @@ class EventsBlock(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# 7. course — 코스 타임라인
+# 7. course — 코스 타임라인 (api-course-quick-spec.md 준수, flat 패턴)
 # ---------------------------------------------------------------------------
+class CoursePlaceInfo(BaseModel):
+    """코스 stop 내 장소 정보 — 자체 완결 (FE 추가 조회 불필요)."""
+
+    place_id: str
+    name: str = ""
+    category: Optional[str] = None
+    category_label: Optional[str] = None
+    address: Optional[str] = None
+    district: Optional[str] = None
+    location: Optional[dict[str, float]] = None  # {"lat": ..., "lng": ...}
+    rating: Optional[float] = None
+    summary: Optional[str] = None
+    photo_url: Optional[str] = None  # Phase 1 생략
+    photo_attribution: Optional[str] = None  # Phase 1 생략
+    business_hours_today: Optional[str] = None  # Phase 1 생략
+    is_open_now: Optional[bool] = None  # Phase 1 생략
+    booking_url: Optional[str] = None  # Phase 1 생략
+
+
+class CourseTransit(BaseModel):
+    """경유지 간 이동 정보."""
+
+    mode: str = "walk"  # walk | subway | bus | taxi
+    mode_ko: str = "도보"
+    distance_m: int = 0
+    duration_min: int = 0
+
+
 class CourseStop(BaseModel):
-    """코스 내 단일 정거장."""
+    """코스 내 단일 정거장 — 1-indexed order."""
 
     order: int
-    place_id: str  # UUID
-    name: str = ""
-    lat: Optional[float] = None
-    lng: Optional[float] = None
-    duration_minutes: Optional[int] = None  # 체류 시간
-    memo: Optional[str] = None  # LLM 추천 사유
+    arrival_time: Optional[str] = None  # "HH:mm"
+    duration_min: Optional[int] = None
+    place: CoursePlaceInfo
+    transit_to_next: Optional[CourseTransit] = None  # 마지막 stop은 None
+    recommendation_reason: Optional[str] = None
 
 
 class CourseBlock(BaseModel):
-    """코스 타임라인 (COURSE_PLAN intent)."""
+    """코스 타임라인 (COURSE_PLAN intent). flat 패턴 — content wrapper 미적용."""
 
     type: str = "course"
+    course_id: Optional[str] = None  # UUID4
     title: Optional[str] = None
+    description: Optional[str] = None
+    total_distance_m: Optional[int] = None
+    total_duration_min: Optional[int] = None
+    total_stay_min: Optional[int] = None
+    total_transit_min: Optional[int] = None
     stops: list[CourseStop] = Field(default_factory=list)
-    total_duration_minutes: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------
@@ -150,16 +182,38 @@ class MapMarkersBlock(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# 9. map_route — OSRM 폴리라인 (course 용)
+# 9. map_route — 코스 경로 시각화 (api-course-quick-spec.md 준수)
 # ---------------------------------------------------------------------------
+class RouteMarker(BaseModel):
+    """경로 마커 — course.stops[].order와 매칭."""
+
+    order: int
+    position: dict[str, float]  # {"lat": ..., "lng": ...}
+    label: str = ""
+    category: Optional[str] = None
+
+
+class RouteSegment(BaseModel):
+    """경로 구간 — straight(Phase 1) / road(Phase 2)."""
+
+    from_order: int
+    to_order: int
+    mode: str = "walk"
+    coordinates: list[list[float]] = Field(default_factory=list)  # [[lng, lat], ...] GeoJSON
+    distance_m: Optional[int] = None
+    duration_min: Optional[int] = None
+
+
 class MapRouteBlock(BaseModel):
-    """OSRM encoded polyline + 경유 좌표."""
+    """코스 경로 시각화. course_id로 CourseBlock과 연결."""
 
     type: str = "map_route"
-    polyline: Optional[str] = None
-    waypoints: Optional[list[dict[str, float]]] = None
-    distance_meters: Optional[int] = None
-    duration_seconds: Optional[int] = None
+    course_id: Optional[str] = None
+    bounds: Optional[dict[str, dict[str, float]]] = None  # {"sw": {lat,lng}, "ne": {lat,lng}}
+    center: Optional[dict[str, float]] = None  # {"lat": ..., "lng": ...}
+    suggested_zoom: Optional[int] = None
+    markers: list[RouteMarker] = Field(default_factory=list)
+    polyline: Optional[dict[str, Any]] = None  # {"type": "straight", "segments": [...]}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_analysis_node.py
+++ b/backend/tests/test_analysis_node.py
@@ -1,0 +1,256 @@
+"""analysis_node 단위 테스트 — 7개 케이스.
+
+순수 함수 직접 호출 + AsyncMock으로 pool.fetch / os_client.mget mock.
+DB 실연결 없음.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# _extract_place_name
+# ---------------------------------------------------------------------------
+
+
+async def test_extract_place_name_from_processed_query() -> None:
+    """processed_query.place_name 있으면 반환."""
+    from src.graph.analysis_node import _extract_place_name  # pyright: ignore[reportMissingImports]
+
+    result = _extract_place_name({"place_name": "스타벅스 홍대점"}, "스타벅스 분석")
+    assert result == "스타벅스 홍대점"
+
+
+async def test_extract_place_name_from_keywords() -> None:
+    """place_name 없고 keywords[0] fallback."""
+    from src.graph.analysis_node import _extract_place_name  # pyright: ignore[reportMissingImports]
+
+    result = _extract_place_name({"keywords": ["블루보틀", "카페"]}, "블루보틀 분석")
+    assert result == "블루보틀"
+
+
+async def test_extract_place_name_none() -> None:
+    """둘 다 없으면 None."""
+    from src.graph.analysis_node import _extract_place_name  # pyright: ignore[reportMissingImports]
+
+    result = _extract_place_name({}, "분석해줘")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_place_pg — 동명 다중 매칭
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_place_pg_multiple_match() -> None:
+    """동명 3개 중 OS stars 최댓값 채택."""
+    from src.graph.analysis_node import _fetch_place_pg  # pyright: ignore[reportMissingImports]
+
+    rows: list[dict[str, Any]] = [
+        {"place_id": "uuid-1", "name": "스타벅스 A", "category": "카페", "district": "강남구"},
+        {"place_id": "uuid-2", "name": "스타벅스 B", "category": "카페", "district": "마포구"},
+        {"place_id": "uuid-3", "name": "스타벅스 C", "category": "카페", "district": "종로구"},
+    ]
+
+    mock_pool = MagicMock()
+    mock_pool.fetch = AsyncMock(return_value=rows)
+
+    mock_os = MagicMock()
+    mock_os.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {"found": True, "_source": {"place_id": "uuid-1", "stars": 3.5}},
+                {"found": True, "_source": {"place_id": "uuid-2", "stars": 4.2}},
+                {"found": True, "_source": {"place_id": "uuid-3", "stars": 4.0}},
+            ]
+        }
+    )
+
+    result = await _fetch_place_pg(mock_pool, "스타벅스", mock_os)
+    assert result is not None
+    assert result["place_id"] == "uuid-2"
+
+
+# ---------------------------------------------------------------------------
+# analysis_node — 정상 흐름
+# ---------------------------------------------------------------------------
+
+
+async def test_analysis_node_success() -> None:
+    """정상 — text_stream + analysis_sources 블록 반환."""
+    from src.graph.analysis_node import analysis_node  # pyright: ignore[reportMissingImports]
+
+    mock_pool = MagicMock()
+    mock_pool.fetch = AsyncMock(
+        return_value=[
+            {"place_id": "uuid-1", "name": "스타벅스 홍대점", "category": "카페", "district": "마포구"},
+        ]
+    )
+
+    mock_os = MagicMock()
+    mock_os.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {
+                    "found": True,
+                    "_source": {
+                        "place_id": "uuid-1",
+                        "_raw_scores": {
+                            "satisfaction": 3.5,
+                            "accessibility": 4.0,
+                            "cleanliness": 3.8,
+                            "value": 3.2,
+                            "atmosphere": 4.5,
+                            "expertise": 4.0,
+                        },
+                        "review_count": 45,
+                    },
+                }
+            ]
+        }
+    )
+
+    with (
+        patch("src.db.postgres.get_pool", return_value=mock_pool),
+        patch("src.db.opensearch.get_os_client", return_value=mock_os),
+    ):
+        state: dict[str, Any] = {
+            "query": "스타벅스 홍대점 분석해줘",
+            "processed_query": {"place_name": "스타벅스 홍대점"},
+        }
+        result = await analysis_node(state)
+
+    blocks = result["response_blocks"]
+    assert len(blocks) == 2
+
+    ts = blocks[0]
+    assert ts["type"] == "text_stream"
+    assert "스타벅스 홍대점" in ts["prompt"]
+    assert "system" in ts
+
+    src = blocks[1]
+    assert src["type"] == "analysis_sources"
+    assert src["review_count"] == 45
+
+
+# ---------------------------------------------------------------------------
+# analysis_node — OS 점수 없음
+# ---------------------------------------------------------------------------
+
+
+async def test_analysis_node_no_reviews() -> None:
+    """OS 문서 없음 → text_stream + analysis_sources(review_count=0)."""
+    from src.graph.analysis_node import analysis_node  # pyright: ignore[reportMissingImports]
+
+    mock_pool = MagicMock()
+    mock_pool.fetch = AsyncMock(
+        return_value=[
+            {"place_id": "uuid-1", "name": "새로운카페", "category": "카페", "district": "강남구"},
+        ]
+    )
+
+    mock_os = MagicMock()
+    mock_os.mget = AsyncMock(return_value={"docs": [{"found": False}]})
+
+    with (
+        patch("src.db.postgres.get_pool", return_value=mock_pool),
+        patch("src.db.opensearch.get_os_client", return_value=mock_os),
+    ):
+        state: dict[str, Any] = {
+            "query": "새로운카페 분석해줘",
+            "processed_query": {"place_name": "새로운카페"},
+        }
+        result = await analysis_node(state)
+
+    blocks = result["response_blocks"]
+    assert len(blocks) == 2
+    assert blocks[0]["type"] == "text_stream"
+    assert "리뷰 데이터: 없음" in blocks[0]["prompt"]
+    assert blocks[1]["type"] == "analysis_sources"
+    assert blocks[1]["review_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_scores_os — review_count null 방어
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_scores_os_null_review_count() -> None:
+    """OS 문서에 review_count=null → 0으로 방어."""
+    from src.graph.analysis_node import _fetch_scores_os  # pyright: ignore[reportMissingImports]
+
+    mock_os = MagicMock()
+    mock_os.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {
+                    "found": True,
+                    "_source": {
+                        "place_id": "uuid-1",
+                        "_raw_scores": {"satisfaction": 3.5},
+                        "review_count": None,
+                    },
+                }
+            ]
+        }
+    )
+
+    scores, count = await _fetch_scores_os(mock_os, "uuid-1")
+    assert count == 0
+    assert scores == {"satisfaction": 3.5}
+
+
+# ---------------------------------------------------------------------------
+# analysis_node — 장소 미발견
+# ---------------------------------------------------------------------------
+
+
+async def test_analysis_node_place_not_found() -> None:
+    """PG 0건 → disambiguation."""
+    from src.graph.analysis_node import analysis_node  # pyright: ignore[reportMissingImports]
+
+    mock_pool = MagicMock()
+    mock_pool.fetch = AsyncMock(return_value=[])
+    mock_os = MagicMock()
+
+    with (
+        patch("src.db.postgres.get_pool", return_value=mock_pool),
+        patch("src.db.opensearch.get_os_client", return_value=mock_os),
+    ):
+        state: dict[str, Any] = {
+            "query": "없는장소 분석해줘",
+            "processed_query": {"place_name": "없는장소"},
+        }
+        result = await analysis_node(state)
+
+    blocks = result["response_blocks"]
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "disambiguation"
+    assert "찾을 수 없" in blocks[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# analysis_node — place_name 추출 실패
+# ---------------------------------------------------------------------------
+
+
+async def test_analysis_node_no_place_name() -> None:
+    """place_name 추출 실패 → disambiguation."""
+    from src.graph.analysis_node import analysis_node  # pyright: ignore[reportMissingImports]
+
+    state: dict[str, Any] = {
+        "query": "분석해줘",
+        "processed_query": {},
+    }
+    result = await analysis_node(state)
+
+    blocks = result["response_blocks"]
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "disambiguation"
+    assert "장소명을 알려주세요" in blocks[0]["message"]

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -234,4 +234,5 @@ async def test_llm_compose_api_error() -> None:
         title, desc, details = await _llm_course_compose(_PLACES, "테스트")
 
     assert title is None
+    assert desc is None
     assert details == []

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -1,0 +1,237 @@
+"""course_plan_node 단위 테스트.
+
+순수 함수 검증: _parse_categories / _greedy_nn_route / _build_blocks / _haversine_m.
+DB/OS/Gemini 의존성은 mock.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# 테스트 픽스처 데이터
+# ---------------------------------------------------------------------------
+_PLACES: list[dict[str, Any]] = [
+    {
+        "place_id": "p-001",
+        "name": "광장시장",
+        "category": "맛집",
+        "address": "서울 종로구 창경궁로 88",
+        "district": "종로구",
+        "lat": 37.5701,
+        "lng": 126.9996,
+    },
+    {
+        "place_id": "p-002",
+        "name": "익선동 한옥마을",
+        "category": "관광지",
+        "address": "서울 종로구 익선동",
+        "district": "종로구",
+        "lat": 37.5743,
+        "lng": 126.9912,
+    },
+    {
+        "place_id": "p-003",
+        "name": "경복궁",
+        "category": "관광지",
+        "address": "서울 종로구 사직로 161",
+        "district": "종로구",
+        "lat": 37.5796,
+        "lng": 126.977,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# _parse_categories 테스트
+# ---------------------------------------------------------------------------
+async def test_parse_categories_plus() -> None:
+    """+ 구분자로 카테고리 추출."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("홍대 카페+맛집 코스", None)
+    assert "카페" in result
+    assert "맛집" in result
+
+
+async def test_parse_categories_single() -> None:
+    """단일 카테고리 — processed_query에서 가져옴."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("강남 데이트 코스", "카페")
+    assert result == ["카페"]
+
+
+async def test_parse_categories_fallback() -> None:
+    """카테고리 없으면 맛집 기본값."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("좋은 곳 추천", None)
+    assert result == ["맛집"]
+
+
+# ---------------------------------------------------------------------------
+# _haversine_m 테스트
+# ---------------------------------------------------------------------------
+async def test_haversine_distance() -> None:
+    """광장시장 → 익선동 거리 계산 (약 800m)."""
+    from src.graph.course_plan_node import _haversine_m  # pyright: ignore[reportMissingImports]
+
+    dist = _haversine_m(37.5701, 126.9996, 37.5743, 126.9912)
+    assert 500 < dist < 1500
+
+
+# ---------------------------------------------------------------------------
+# _greedy_nn_route 테스트
+# ---------------------------------------------------------------------------
+async def test_greedy_nn_route_order() -> None:
+    """Greedy NN — 최근접 이웃 순서로 재배치."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    route = _greedy_nn_route(_PLACES)
+    assert len(route) == 3
+    # 첫 번째는 그대로, 나머지는 거리 기반
+    assert route[0]["place_id"] == "p-001"
+
+
+async def test_greedy_nn_max_stops() -> None:
+    """최대 5건으로 제한."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    many = [
+        {"place_id": f"p-{i}", "name": f"장소{i}", "lat": 37.5 + i * 0.01, "lng": 127.0 + i * 0.01} for i in range(10)
+    ]
+    route = _greedy_nn_route(many)
+    assert len(route) == 5
+
+
+async def test_greedy_nn_no_coords() -> None:
+    """좌표 없는 후보만 있을 때."""
+    from src.graph.course_plan_node import _greedy_nn_route  # pyright: ignore[reportMissingImports]
+
+    no_coords = [{"place_id": f"p-{i}", "name": f"장소{i}", "lat": None, "lng": None} for i in range(3)]
+    route = _greedy_nn_route(no_coords)
+    assert len(route) == 3
+
+
+# ---------------------------------------------------------------------------
+# _build_blocks 테스트
+# ---------------------------------------------------------------------------
+async def test_build_blocks_normal() -> None:
+    """정상 3-stop 코스 → text_stream + course + map_route 블록."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    stop_details = [
+        {
+            "order": 1,
+            "arrival_time": "11:00",
+            "duration_min": 60,
+            "recommendation_reason": "전통시장",
+            "transit_mode": "walk",
+        },
+        {
+            "order": 2,
+            "arrival_time": "12:12",
+            "duration_min": 90,
+            "recommendation_reason": "한옥마을",
+            "transit_mode": "walk",
+        },
+        {
+            "order": 3,
+            "arrival_time": "14:00",
+            "duration_min": 60,
+            "recommendation_reason": "궁궐",
+            "transit_mode": None,
+        },
+    ]
+
+    blocks = _build_blocks("종로 코스", _PLACES, "도심 코스", "3곳 코스", stop_details, "test-uuid")
+    types = [b["type"] for b in blocks]
+
+    assert "text_stream" in types
+    assert "course" in types
+    assert "map_route" in types
+
+    # course 블록 검증
+    course = next(b for b in blocks if b["type"] == "course")
+    assert course["course_id"] == "test-uuid"
+    assert len(course["stops"]) == 3
+    assert course["stops"][0]["order"] == 1
+    assert course["stops"][2]["transit_to_next"] is None  # 마지막 stop
+    assert course["total_duration_min"] == course["total_stay_min"] + course["total_transit_min"]
+
+    # map_route 블록 검증
+    map_route = next(b for b in blocks if b["type"] == "map_route")
+    assert map_route["course_id"] == "test-uuid"
+    assert len(map_route["markers"]) == 3
+    assert map_route["markers"][0]["order"] == 1
+    assert len(map_route["polyline"]["segments"]) == 2  # 3 stops → 2 segments
+    # GeoJSON [lng, lat] 순서
+    assert map_route["polyline"]["segments"][0]["coordinates"][0][0] == _PLACES[0]["lng"]
+
+
+async def test_build_blocks_empty() -> None:
+    """빈 결과 → text_stream만 + 빈 course 블록."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    blocks = _build_blocks("없는 코스", [], None, None, [], "test-uuid")
+    types = [b["type"] for b in blocks]
+    assert "text_stream" in types
+    assert "course" in types
+
+
+async def test_build_blocks_single_stop() -> None:
+    """단일 stop → transit_to_next null, polyline segments 없음."""
+    from src.graph.course_plan_node import _build_blocks  # pyright: ignore[reportMissingImports]
+
+    single = [_PLACES[0]]
+    details = [
+        {"order": 1, "arrival_time": "11:00", "duration_min": 60, "recommendation_reason": "시장", "transit_mode": None}
+    ]
+
+    blocks = _build_blocks("시장 코스", single, "시장 코스", "1곳", details, "test-uuid")
+    course = next(b for b in blocks if b["type"] == "course")
+    assert len(course["stops"]) == 1
+    assert course["stops"][0]["transit_to_next"] is None
+
+    map_route = next(b for b in blocks if b["type"] == "map_route")
+    assert len(map_route["polyline"]["segments"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# _llm_course_compose fallback 테스트
+# ---------------------------------------------------------------------------
+async def test_llm_compose_fallback() -> None:
+    """Gemini 실패 시 None 반환 → _apply_fallback_times 적용."""
+    from src.graph.course_plan_node import _apply_fallback_times  # pyright: ignore[reportMissingImports]
+
+    details = _apply_fallback_times(_PLACES)
+    assert len(details) == 3
+    assert details[0]["arrival_time"] == "11:00"
+    assert details[0]["duration_min"] == 60
+    assert details[2]["transit_mode"] is None  # 마지막
+
+
+async def test_llm_compose_api_error() -> None:
+    """Gemini API 에러 → (None, None, []) 반환."""
+    from src.graph.course_plan_node import _llm_course_compose  # pyright: ignore[reportMissingImports]
+
+    mock_settings = type("Settings", (), {"gemini_llm_api_key": "fake-key"})()
+
+    with (
+        patch("src.config.get_settings", return_value=mock_settings),
+        patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_llm_cls,
+    ):
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke.side_effect = Exception("API error")
+        mock_llm_cls.return_value = mock_llm
+
+        title, desc, details = await _llm_course_compose(_PLACES, "테스트")
+
+    assert title is None
+    assert details == []

--- a/backend/tests/test_multi_intent.py
+++ b/backend/tests/test_multi_intent.py
@@ -15,6 +15,13 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
+def _mock_settings() -> MagicMock:
+    """get_settings() mock — gemini_llm_api_key 설정된 상태."""
+    settings = MagicMock()
+    settings.gemini_llm_api_key = "fake-key-for-test"
+    return settings
+
+
 # ---------------------------------------------------------------------------
 # classify_intents — 단일 intent
 # ---------------------------------------------------------------------------
@@ -32,7 +39,10 @@ async def test_classify_intents_single() -> None:
     mock_llm = MagicMock()
     mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
-    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+    with (
+        patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm),
+        patch("src.config.get_settings", return_value=_mock_settings()),
+    ):
         result = await classify_intents("홍대 카페 추천해줘")
 
     assert len(result) == 1
@@ -62,7 +72,10 @@ async def test_classify_intents_multi() -> None:
     mock_llm = MagicMock()
     mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
-    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+    with (
+        patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm),
+        patch("src.config.get_settings", return_value=_mock_settings()),
+    ):
         result = await classify_intents("카페 추천해주고 전시회 알려줘")
 
     assert len(result) == 2
@@ -96,7 +109,10 @@ async def test_classify_intents_max_3() -> None:
     mock_llm = MagicMock()
     mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
-    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+    with (
+        patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm),
+        patch("src.config.get_settings", return_value=_mock_settings()),
+    ):
         result = await classify_intents("a b c d")
 
     assert len(result) == 3
@@ -119,7 +135,10 @@ async def test_classify_intents_phase2_filter() -> None:
     mock_llm = MagicMock()
     mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
-    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+    with (
+        patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm),
+        patch("src.config.get_settings", return_value=_mock_settings()),
+    ):
         result = await classify_intents("비용 알려줘")
 
     assert len(result) == 1
@@ -138,7 +157,10 @@ async def test_classify_intents_fallback() -> None:
     mock_llm = MagicMock()
     mock_llm.ainvoke = AsyncMock(side_effect=Exception("API error"))
 
-    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+    with (
+        patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm),
+        patch("src.config.get_settings", return_value=_mock_settings()),
+    ):
         result = await classify_intents("테스트 쿼리")
 
     assert len(result) == 1

--- a/backend/tests/test_multi_intent.py
+++ b/backend/tests/test_multi_intent.py
@@ -1,0 +1,187 @@
+"""multi-intent 단위 테스트 — 7개 케이스.
+
+classify_intents + intent_router_node 주입 가드.
+DB 실연결 없음 (AsyncMock).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# classify_intents — 단일 intent
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_intents_single() -> None:
+    """단일 intent 쿼리 → 1개 리스트, sub_query = 원본."""
+    from src.graph.intent_router_node import IntentType, classify_intents  # pyright: ignore[reportMissingImports]
+
+    mock_response = MagicMock()
+    mock_response.content = json.dumps(
+        {"intents": [{"intent": "PLACE_RECOMMEND", "confidence": 0.95, "sub_query": "홍대 카페 추천해줘"}]}
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+        result = await classify_intents("홍대 카페 추천해줘")
+
+    assert len(result) == 1
+    assert result[0][0] == IntentType.PLACE_RECOMMEND
+    assert result[0][2] == "홍대 카페 추천해줘"
+
+
+# ---------------------------------------------------------------------------
+# classify_intents — 복수 intent
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_intents_multi() -> None:
+    """복수 intent 쿼리 → 2개 리스트 + sub_query 분리."""
+    from src.graph.intent_router_node import IntentType, classify_intents  # pyright: ignore[reportMissingImports]
+
+    mock_response = MagicMock()
+    mock_response.content = json.dumps(
+        {
+            "intents": [
+                {"intent": "PLACE_RECOMMEND", "confidence": 0.9, "sub_query": "카페 추천해줘"},
+                {"intent": "EVENT_SEARCH", "confidence": 0.85, "sub_query": "전시회 알려줘"},
+            ]
+        }
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+        result = await classify_intents("카페 추천해주고 전시회 알려줘")
+
+    assert len(result) == 2
+    assert result[0][0] == IntentType.PLACE_RECOMMEND
+    assert result[0][2] == "카페 추천해줘"
+    assert result[1][0] == IntentType.EVENT_SEARCH
+    assert result[1][2] == "전시회 알려줘"
+
+
+# ---------------------------------------------------------------------------
+# classify_intents — 최대 3개 제한
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_intents_max_3() -> None:
+    """4개 이상 → 앞 3개만 채택."""
+    from src.graph.intent_router_node import classify_intents  # pyright: ignore[reportMissingImports]
+
+    mock_response = MagicMock()
+    mock_response.content = json.dumps(
+        {
+            "intents": [
+                {"intent": "PLACE_RECOMMEND", "confidence": 0.9, "sub_query": "a"},
+                {"intent": "EVENT_SEARCH", "confidence": 0.8, "sub_query": "b"},
+                {"intent": "ANALYSIS", "confidence": 0.7, "sub_query": "c"},
+                {"intent": "GENERAL", "confidence": 0.5, "sub_query": "d"},
+            ]
+        }
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+        result = await classify_intents("a b c d")
+
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# classify_intents — Phase 2 → GENERAL fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_intents_phase2_filter() -> None:
+    """Phase 2 intent → GENERAL fallback."""
+    from src.graph.intent_router_node import IntentType, classify_intents  # pyright: ignore[reportMissingImports]
+
+    mock_response = MagicMock()
+    mock_response.content = json.dumps(
+        {"intents": [{"intent": "COST_ESTIMATE", "confidence": 0.9, "sub_query": "비용 알려줘"}]}
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+        result = await classify_intents("비용 알려줘")
+
+    assert len(result) == 1
+    assert result[0][0] == IntentType.GENERAL
+
+
+# ---------------------------------------------------------------------------
+# classify_intents — Gemini 실패 fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_intents_fallback() -> None:
+    """Gemini 실패 → [("GENERAL", 0.0, query)]."""
+    from src.graph.intent_router_node import IntentType, classify_intents  # pyright: ignore[reportMissingImports]
+
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(side_effect=Exception("API error"))
+
+    with patch("langchain_google_genai.ChatGoogleGenerativeAI", return_value=mock_llm):
+        result = await classify_intents("테스트 쿼리")
+
+    assert len(result) == 1
+    assert result[0][0] == IntentType.GENERAL
+    assert result[0][2] == "테스트 쿼리"
+
+
+# ---------------------------------------------------------------------------
+# intent_router_node — 주입 가드
+# ---------------------------------------------------------------------------
+
+
+async def test_intent_router_node_injected() -> None:
+    """intent 주입 시 classify 스킵, intent 블록만 반환."""
+    from src.graph.intent_router_node import intent_router_node  # pyright: ignore[reportMissingImports]
+
+    state: dict[str, Any] = {
+        "query": "카페 추천해줘",
+        "intent": "PLACE_RECOMMEND",
+    }
+    result = await intent_router_node(state)
+
+    blocks = result["response_blocks"]
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "intent"
+    assert blocks[0]["intent"] == "PLACE_RECOMMEND"
+    assert blocks[0]["confidence"] == 1.0
+    # intent 키가 반환에 없음 (state의 주입값 유지)
+    assert "intent" not in result
+
+
+async def test_intent_router_node_no_injection() -> None:
+    """intent 미주입 시 기존 classify_intent 호출 (regression 확인)."""
+    from src.graph.intent_router_node import IntentType, intent_router_node  # pyright: ignore[reportMissingImports]
+
+    mock_classify = AsyncMock(return_value=(IntentType.GENERAL, 0.5))
+
+    with patch("src.graph.intent_router_node.classify_intent", mock_classify):
+        state: dict[str, Any] = {
+            "query": "안녕",
+        }
+        result = await intent_router_node(state)
+
+    mock_classify.assert_called_once_with("안녕", None)
+    assert result["intent"] == "GENERAL"
+    assert result["response_blocks"][0]["intent"] == "GENERAL"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #57 #59

## #️⃣ 작업 내용

### 1. ANALYSIS intent — 단일 장소 6지표 분석

- **신규** `src/graph/analysis_node.py` — place_name 추출 → PG 조회(is_deleted=false, LIMIT 20) → OS mget 6지표 → text_stream + analysis_sources 블록 반환
- **신규** `tests/test_analysis_node.py` — 9개 테스트 케이스 (순수 함수 3 + 통합 mock 6)
- **수정** `src/graph/intent_router_node.py` — ANALYSIS를 PHASE1_INTENTS + _ROUTABLE_INTENTS + 분류 프롬프트에 추가
- **수정** `src/graph/real_builder.py` — 노드 등록 + 라우팅 + edge
- **수정** `src/api/sse.py` — status 메시지 추가 (analysis, review_compare 누락분 포함)
- **신규** `.sisyphus/plans/2026-05-06-analysis-intent/plan.md` — APPROVED

블록 순서: `intent → status → text_stream → analysis_sources → done` (기획서 §4.5)

**CodeRabbit 피드백 반영:**
- OS 클라이언트 초기화 실패 시 graceful fallback (PG만으로 동작)
- `_VALID_SCORE_KEYS` frozenset으로 6개 고정 지표만 허용 (불변식 #6)

### 2. Multi-Intent — 중첩된 요청 대응

- **수정** `src/graph/intent_router_node.py` — `classify_intents()` 함수 추가 (복수 intent + sub_query 반환, 최대 3개) + intent 주입 가드
- **수정** `src/api/sse.py` — `event_generator()` multi-intent 루프 (intent별 그래프 순차 실행 + done_partial emit + 중간 done 무시)
- **신규** `tests/test_multi_intent.py` — 7개 테스트 케이스
- **신규** `.sisyphus/plans/2026-05-06-multi-intent/plan.md` — APPROVED

SSE 이벤트 흐름 (예: "카페 추천해주고 전시회 알려줘"):
```
Intent #1: intent → status → text_stream → places → ... → done_partial
Intent #2: intent → status → text_stream → events → ... → done
```

## #️⃣ 테스트 결과

```
tests/test_analysis_node.py  — 8 passed (1 기존 pytest-asyncio 인프라 이슈)
tests/test_multi_intent.py   — 6 passed (1 기존 pytest-asyncio 인프라 이슈)
tests/test_review_compare_node.py — 10 passed (regression 없음)
ruff check   — All checks passed
ruff format  — All files formatted
pyright      — 0 errors, 0 warnings
```

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (plan.md 2건 APPROVED)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `_fetch_place_pg` 동명 매칭 로직이 `review_compare_node`과 중복 — 향후 공통 유틸 추출 고려
- ANALYSIS vs REVIEW_COMPARE 분류 경계 모호 케이스 — 런타임 테스트 필요
- Multi-Intent: `classify_intents()` sub_query 분리 품질은 Gemini 프롬프트 튜닝으로 개선 여지

## 📎 참고 자료 (선택)

- plan (ANALYSIS): `.sisyphus/plans/2026-05-06-analysis-intent/plan.md`
- plan (Multi-Intent): `.sisyphus/plans/2026-05-06-multi-intent/plan.md`
- 기획: `기획/API 명세서 v2 (SSE)...csv` L53 (ANALYSIS), 중첩된 요청 대응 row (Multi-Intent)
- 기획서 §4.5 블록 순서 + done_partial 정의: `기획/_legacy/서비스 통합 기획서 v2.md`