### PR TITLE
feat: Nginx SSL reverse proxy 설정 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,3 +23,4 @@ jobs:
             source venv/bin/activate
             pip install -q -r backend/requirements.txt
             sudo systemctl restart localbiz-api
+            sudo nginx -t && sudo systemctl reload nginx

--- a/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/plan.md
+++ b/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/plan.md
@@ -1,0 +1,82 @@
+# Nginx SSL Reverse Proxy — GCE HTTPS 종료
+
+- Phase: Infra
+- 요청자: 이정
+- 작성일: 2026-05-12
+- 상태: approved
+- 최종 결정: APPROVED
+
+> 상태 워크플로: draft → review → approved → done
+
+## 1. 요구사항
+
+프론트엔드(Vercel, HTTPS)에서 백엔드(GCE, HTTP:8000)로 요청 시 HTTPS 거부 발생.
+GCE 앞단에 Nginx를 리버스 프록시로 두어 SSL을 종료(terminate)하고, 내부적으로 uvicorn(HTTP:8000)으로 프록시.
+
+- HTTPS(443) → Nginx → HTTP(127.0.0.1:8000) uvicorn
+- HTTP(80) → 301 HTTPS 리다이렉트
+- SSE 스트리밍(`/api/v1/chat/stream`)은 `proxy_buffering off` 필수
+- Let's Encrypt(certbot)로 무료 SSL 인증서 자동 발급/갱신
+- 도메인은 `DOMAIN_PLACEHOLDER`로 작성 — 실제 도메인 확보 후 sed 치환
+
+## 2. 영향 범위
+
+- 신규 파일:
+  - `deploy/nginx/anyway-api.conf` — Nginx site 설정 (SSL + reverse proxy + SSE)
+  - `deploy/nginx/setup.sh` — GCE 1회성 셋업 스크립트 (nginx + certbot 설치, 인증서 발급, 서비스 활성화)
+- 수정 파일:
+  - `.github/workflows/deploy-dev.yml` — 배포 시 nginx reload 추가 (conf 변경 반영)
+- DB 스키마 영향: 없음
+- 응답 블록 16종 영향: 없음
+- intent 추가/변경: 없음
+- 외부 API 호출: 없음
+- FastAPI 코드 변경: 없음 (CORS는 이미 `*.vercel.app` HTTPS 허용)
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — 해당 없음 (인프라)
+- [x] PG↔OS 동기화 — 해당 없음
+- [x] append-only 4테이블 미수정 — 해당 없음
+- [x] 소프트 삭제 매트릭스 준수 — 해당 없음
+- [x] 의도적 비정규화 4건 외 신규 비정규화 없음 — 해당 없음
+- [x] 6 지표 스키마 보존 — 해당 없음
+- [x] gemini-embedding-001 768d 사용 — 해당 없음
+- [x] asyncpg 파라미터 바인딩 — 해당 없음
+- [x] Optional[str] 사용 — 해당 없음
+- [x] SSE 이벤트 타입 16종 한도 준수 — 해당 없음
+- [x] intent별 블록 순서 준수 — 해당 없음
+- [x] 공통 쿼리 전처리 경유 — 해당 없음
+- [x] 행사 검색 DB 우선 — 해당 없음
+- [x] 대화 이력 이원화 보존 — 해당 없음
+- [x] 인증 매트릭스 준수 — 해당 없음
+- [x] 북마크 = 대화 위치 패러다임 — 해당 없음
+- [x] 공유링크 인증 우회 범위 정확 — 해당 없음
+- [x] Phase 라벨 명시 — Infra
+- [x] 기획 문서 우선 — 해당 없음 (인프라 구성)
+
+## 4. 작업 순서 (Atomic step)
+
+1. `deploy/nginx/anyway-api.conf` 작성
+   - HTTP(80) → HTTPS(301) 리다이렉트 + certbot ACME 챌린지 location
+   - HTTPS(443) → proxy_pass http://127.0.0.1:8000
+   - `/api/v1/chat/stream` location: proxy_buffering off, proxy_cache off, read_timeout 300s
+   - SSL 프로토콜: TLSv1.2 + TLSv1.3, 안전한 cipher suite
+2. `deploy/nginx/setup.sh` 작성
+   - nginx + certbot 설치 (apt)
+   - certbot 인증서 발급 (--webroot 또는 --standalone)
+   - anyway-api.conf 심볼릭 링크 → /etc/nginx/sites-enabled/
+   - default site 비활성화
+   - nginx 시작 + 자동 갱신 cron 확인
+3. `.github/workflows/deploy-dev.yml` 수정
+   - 배포 스크립트에 `sudo nginx -t && sudo systemctl reload nginx` 추가
+
+## 5. 검증 계획
+
+- `nginx -t` — 설정 문법 검증 (setup.sh 내에서 실행)
+- `curl -I https://DOMAIN` — SSL 핸드셰이크 + 200 확인
+- `curl -N https://DOMAIN/api/v1/chat/stream?...` — SSE 스트리밍 정상 수신 확인
+- 프론트엔드(Vercel)에서 HTTPS 요청 → 응답 수신 확인
+
+## 6. 최종 결정
+
+APPROVED

--- a/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/reviews/001-metis-okay.md
+++ b/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/reviews/001-metis-okay.md
@@ -1,0 +1,35 @@
+# Review 001 — Metis
+
+## 판정: okay
+
+## 근거
+
+### 1. 갭 (Gap) — 3건 (reject 미해당, 구현 시 권고)
+
+- **(a) proxy_set_header**: `Host`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Real-IP` 미언급. 로깅/감사 시 클라이언트 IP 추적 불가. conf 작성 시 반드시 포함 권고.
+- **(b) GCE 방화벽**: 포트 443 인바운드 허용 규칙 미명시. setup.sh 또는 전제조건으로 추가 권고.
+- **(c) DNS 설정**: 도메인 A 레코드 → GCE 외부 IP 필요. ephemeral IP인 경우 static 승격 필요. 전제조건으로 명시 권고.
+
+### 2. 숨은 의도
+
+`deploy/nginx/` 디렉터리 신설 = 인프라 표준화 시작. 합리적이며 과도하지 않음.
+
+### 3. AI Slop
+
+없음. conf 1개 + setup 1개 + workflow 1줄 수정. 최소한 구성.
+
+### 4. 오버엔지니어링
+
+범위 적절. TLSv1.2+1.3, cipher suite, certbot 자동갱신 모두 보안 기본.
+
+### 5. 19 불변식
+
+인프라 전용. 체크리스트 "해당 없음" 판정 모두 정확.
+
+### 6. 검증 가능성
+
+4개 항목 실행 가능. 추가 권고: HTTP 301 리다이렉트 확인, `openssl s_client` 인증서 체인 검증.
+
+## 다음 액션
+
+Momus 검토로 진행.

--- a/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/reviews/002-momus-approved.md
+++ b/.sisyphus/plans/2026-05-12-nginx-ssl-proxy/reviews/002-momus-approved.md
@@ -1,0 +1,36 @@
+# Review 002 — Momus
+
+## 판정: approved
+
+## 근거
+
+### 1. 체크리스트 완전성
+
+필수 섹션 6개(요구사항, 영향 범위, 19 불변식, 작업 순서, 검증 계획, Phase 라벨) 모두 존재.
+
+### 2. 파일 참조 정확성
+
+| 항목 | 결과 |
+|---|---|
+| `deploy/nginx/anyway-api.conf` (신규) | 충돌 없음 |
+| `deploy/nginx/setup.sh` (신규) | 충돌 없음 |
+| `.github/workflows/deploy-dev.yml` (수정) | 존재 확인 |
+| SSE `/api/v1/chat/stream` | `sse.py:205` 일치 |
+| CORS `*.vercel.app` HTTPS | `main.py:87` 확인 |
+
+### 3. 19 불변식
+
+19개 항목 모두 "해당 없음" 판정 타당. Python/DB/SSE 변경 없음.
+경미한 부정확: 불변식 5번 "4건" → CLAUDE.md 원문은 "3건". 기능적 영향 없음.
+
+### 4. 검증 가능성
+
+4개 항목 모두 실행 가능. 인프라 plan이므로 단위 테스트 해당 없음.
+
+### 5. Metis 권고 3건
+
+proxy_set_header, GCE 방화벽 443, DNS A 레코드 — 구현 시 반영 필수. plan 구조 결함 아님.
+
+## 다음 액션
+
+plan.md 최종 결정 → APPROVED.

--- a/deploy/nginx/anyway-api.conf
+++ b/deploy/nginx/anyway-api.conf
@@ -1,0 +1,77 @@
+# AnyWay API — Nginx reverse proxy + SSL (Let's Encrypt)
+#
+# 전제조건:
+#   1. 도메인 A 레코드 → GCE 외부 IP (static 승격 권장)
+#   2. GCE 방화벽 80/443 인바운드 허용
+#   3. certbot 인증서 발급 완료 (setup.sh 참조)
+#
+# 설치:
+#   sudo ln -sf ~/LocalBiz-Seoul/deploy/nginx/anyway-api.conf \
+#               /etc/nginx/sites-enabled/anyway-api.conf
+#   sudo rm -f /etc/nginx/sites-enabled/default
+#   sudo nginx -t && sudo systemctl reload nginx
+
+# --- HTTP -> HTTPS 리다이렉트 ---
+server {
+    listen 80;
+    server_name DOMAIN_PLACEHOLDER;
+
+    # Certbot ACME 챌린지 (인증서 발급/갱신)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# --- HTTPS (SSL termination) ---
+server {
+    listen 443 ssl http2;
+    server_name DOMAIN_PLACEHOLDER;
+
+    # --- SSL 인증서 (certbot 생성) ---
+    ssl_certificate     /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/privkey.pem;
+
+    # --- SSL 보안 설정 ---
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # --- 공통 프록시 헤더 ---
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # --- API (일반 REST) ---
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+
+        proxy_connect_timeout 10s;
+        proxy_read_timeout    60s;
+        proxy_send_timeout    60s;
+    }
+
+    # --- SSE 스트리밍 (버퍼링 OFF 필수) ---
+    location /api/v1/chat/stream {
+        proxy_pass http://127.0.0.1:8000;
+
+        # SSE 핵심: 버퍼링 비활성화
+        proxy_buffering off;
+        proxy_cache off;
+
+        # long-lived 연결 타임아웃 (5분)
+        proxy_connect_timeout 10s;
+        proxy_read_timeout    300s;
+        proxy_send_timeout    300s;
+
+        # chunked transfer
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}

--- a/deploy/nginx/anyway-api.conf
+++ b/deploy/nginx/anyway-api.conf
@@ -1,20 +1,18 @@
-# AnyWay API — Nginx reverse proxy + SSL (Let's Encrypt)
+# AnyWay API — Nginx reverse proxy + SSL (Let's Encrypt + nip.io)
+#
+# 도메인: 34.22.91.75.nip.io (nip.io 와일드카드 DNS → GCE IP 자동 해석)
 #
 # 전제조건:
-#   1. 도메인 A 레코드 → GCE 외부 IP (static 승격 권장)
-#   2. GCE 방화벽 80/443 인바운드 허용
-#   3. certbot 인증서 발급 완료 (setup.sh 참조)
+#   1. GCE 방화벽 80/443 인바운드 허용
+#   2. certbot 인증서 발급 완료 (setup.sh 참조)
 #
 # 설치:
-#   sudo ln -sf ~/LocalBiz-Seoul/deploy/nginx/anyway-api.conf \
-#               /etc/nginx/sites-enabled/anyway-api.conf
-#   sudo rm -f /etc/nginx/sites-enabled/default
-#   sudo nginx -t && sudo systemctl reload nginx
+#   sudo bash deploy/nginx/setup.sh
 
 # --- HTTP -> HTTPS 리다이렉트 ---
 server {
     listen 80;
-    server_name DOMAIN_PLACEHOLDER;
+    server_name 34.22.91.75.nip.io;
 
     # Certbot ACME 챌린지 (인증서 발급/갱신)
     location /.well-known/acme-challenge/ {
@@ -29,11 +27,11 @@ server {
 # --- HTTPS (SSL termination) ---
 server {
     listen 443 ssl http2;
-    server_name DOMAIN_PLACEHOLDER;
+    server_name 34.22.91.75.nip.io;
 
     # --- SSL 인증서 (certbot 생성) ---
-    ssl_certificate     /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/34.22.91.75.nip.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/34.22.91.75.nip.io/privkey.pem;
 
     # --- SSL 보안 설정 ---
     ssl_protocols TLSv1.2 TLSv1.3;

--- a/deploy/nginx/setup.sh
+++ b/deploy/nginx/setup.sh
@@ -1,25 +1,29 @@
 #!/usr/bin/env bash
-# AnyWay API — GCE Nginx + Let's Encrypt 1회성 셋업
+# AnyWay API — GCE Nginx + Let's Encrypt 1회성 셋업 (nip.io)
 #
 # 사용법:
-#   sudo bash deploy/nginx/setup.sh <도메인>
+#   sudo bash deploy/nginx/setup.sh
 #
 # 전제조건:
-#   1. 도메인 A 레코드 → 이 서버의 외부 IP
-#   2. GCE 방화벽 80/443 인바운드 허용
+#   1. GCE 방화벽 80/443 인바운드 허용
 #      gcloud compute firewall-rules create allow-http-https \
 #        --allow tcp:80,tcp:443 --target-tags=http-server
-#   3. 이 스크립트를 root 또는 sudo로 실행
+#   2. 이 스크립트를 root 또는 sudo로 실행
 
 set -euo pipefail
 
-DOMAIN="${1:?Usage: sudo bash setup.sh <domain>}"
+# GCE 외부 IP 자동 감지 → nip.io 도메인 생성
+EXTERNAL_IP=$(curl -sf http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google" 2>/dev/null \
+    || curl -sf https://ifconfig.me)
+DOMAIN="${EXTERNAL_IP}.nip.io"
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 CONF_SRC="${REPO_DIR}/deploy/nginx/anyway-api.conf"
 
-echo "=== AnyWay Nginx SSL Setup ==="
-echo "Domain: ${DOMAIN}"
-echo "Repo:   ${REPO_DIR}"
+echo "=== AnyWay Nginx SSL Setup (nip.io) ==="
+echo "External IP: ${EXTERNAL_IP}"
+echo "Domain:      ${DOMAIN}"
+echo "Repo:        ${REPO_DIR}"
 echo ""
 
 # 1. nginx + certbot 설치
@@ -32,13 +36,13 @@ echo "[2/5] Creating certbot webroot..."
 mkdir -p /var/www/certbot
 
 # 3. 인증서 발급 (standalone — nginx 아직 미설정)
-echo "[3/5] Issuing SSL certificate..."
+echo "[3/5] Issuing SSL certificate for ${DOMAIN}..."
 systemctl stop nginx || true
 certbot certonly --standalone -d "${DOMAIN}" --non-interactive --agree-tos --register-unsafely-without-email
 
 # 4. nginx 설정 배포
 echo "[4/5] Deploying nginx config..."
-sed "s/DOMAIN_PLACEHOLDER/${DOMAIN}/g" "${CONF_SRC}" > /etc/nginx/sites-available/anyway-api.conf
+cp "${CONF_SRC}" /etc/nginx/sites-available/anyway-api.conf
 ln -sf /etc/nginx/sites-available/anyway-api.conf /etc/nginx/sites-enabled/anyway-api.conf
 rm -f /etc/nginx/sites-enabled/default
 nginx -t
@@ -58,5 +62,8 @@ fi
 
 echo ""
 echo "=== Setup complete ==="
-echo "Verify: curl -I https://${DOMAIN}"
-echo "SSE:    curl -N https://${DOMAIN}/api/v1/chat/stream"
+echo "Verify:  curl -I https://${DOMAIN}"
+echo "SSE:     curl -N https://${DOMAIN}/api/v1/chat/stream"
+echo ""
+echo "프론트엔드 환경변수:"
+echo "  NEXT_PUBLIC_API_URL=https://${DOMAIN}"

--- a/deploy/nginx/setup.sh
+++ b/deploy/nginx/setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# AnyWay API — GCE Nginx + Let's Encrypt 1회성 셋업
+#
+# 사용법:
+#   sudo bash deploy/nginx/setup.sh <도메인>
+#
+# 전제조건:
+#   1. 도메인 A 레코드 → 이 서버의 외부 IP
+#   2. GCE 방화벽 80/443 인바운드 허용
+#      gcloud compute firewall-rules create allow-http-https \
+#        --allow tcp:80,tcp:443 --target-tags=http-server
+#   3. 이 스크립트를 root 또는 sudo로 실행
+
+set -euo pipefail
+
+DOMAIN="${1:?Usage: sudo bash setup.sh <domain>}"
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CONF_SRC="${REPO_DIR}/deploy/nginx/anyway-api.conf"
+
+echo "=== AnyWay Nginx SSL Setup ==="
+echo "Domain: ${DOMAIN}"
+echo "Repo:   ${REPO_DIR}"
+echo ""
+
+# 1. nginx + certbot 설치
+echo "[1/5] Installing nginx + certbot..."
+apt-get update -qq
+apt-get install -y -qq nginx certbot python3-certbot-nginx
+
+# 2. ACME 챌린지 디렉터리
+echo "[2/5] Creating certbot webroot..."
+mkdir -p /var/www/certbot
+
+# 3. 인증서 발급 (standalone — nginx 아직 미설정)
+echo "[3/5] Issuing SSL certificate..."
+systemctl stop nginx || true
+certbot certonly --standalone -d "${DOMAIN}" --non-interactive --agree-tos --register-unsafely-without-email
+
+# 4. nginx 설정 배포
+echo "[4/5] Deploying nginx config..."
+sed "s/DOMAIN_PLACEHOLDER/${DOMAIN}/g" "${CONF_SRC}" > /etc/nginx/sites-available/anyway-api.conf
+ln -sf /etc/nginx/sites-available/anyway-api.conf /etc/nginx/sites-enabled/anyway-api.conf
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+
+# 5. nginx 시작 + certbot 자동갱신 확인
+echo "[5/5] Starting nginx..."
+systemctl enable nginx
+systemctl start nginx
+
+# certbot 자동갱신 타이머 확인 (systemd)
+if systemctl list-timers | grep -q certbot; then
+    echo "Certbot auto-renewal timer: active"
+else
+    echo "Adding certbot renewal cron..."
+    echo "0 3 * * * certbot renew --quiet --post-hook 'systemctl reload nginx'" | crontab -
+fi
+
+echo ""
+echo "=== Setup complete ==="
+echo "Verify: curl -I https://${DOMAIN}"
+echo "SSE:    curl -N https://${DOMAIN}/api/v1/chat/stream"


### PR DESCRIPTION
## Summary

- GCE 앞단에 Nginx reverse proxy 추가하여 HTTPS 종료 (Let's Encrypt/certbot)
- SSE 스트리밍(`/api/v1/chat/stream`)용 `proxy_buffering off` 전용 location 설정
- GCE 1회성 셋업 스크립트(`deploy/nginx/setup.sh`) — nginx + certbot 설치 + 인증서 발급
- CI/CD 배포 시 `nginx reload` 자동 실행

## 배경

프론트(Vercel, HTTPS) → 백엔드(GCE, HTTP:8000) 요청 시 mixed-content 에러 발생.
uvicorn 자체에 SSL을 붙이는 대신, Nginx에서 SSL termination하는 표준 구조 채택.

## 사용법

```bash
# GCE에서 1회 실행 (도메인 확보 후)
sudo bash deploy/nginx/setup.sh your-domain.com

# 프론트 환경변수 변경
NEXT_PUBLIC_API_URL=https://your-domain.com
```

## 전제조건

- [ ] 도메인 A 레코드 → GCE 외부 IP (static 승격 권장)
- [ ] GCE 방화벽 80/443 인바운드 허용

## Plan

`.sisyphus/plans/2026-05-12-nginx-ssl-proxy/plan.md` — Metis okay + Momus approved

## Test plan

- [ ] `sudo nginx -t` — 설정 문법 검증
- [ ] `curl -I https://DOMAIN` — SSL 핸드셰이크 + 200
- [ ] `curl -I http://DOMAIN` — 301 HTTPS 리다이렉트
- [ ] `curl -N https://DOMAIN/api/v1/chat/stream` — SSE 스트리밍 수신
- [ ] Vercel 프론트에서 HTTPS API 호출 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTPS/SSL support with Let's Encrypt for secure connections to the service.

* **Chores**
  * Enhanced deployment infrastructure with improved configuration validation and automated SSL certificate management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->