### PR TITLE
fix: nginx 미설치 시 deploy 실패 방지

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,4 +23,4 @@ jobs:
             source venv/bin/activate
             pip install -q -r backend/requirements.txt
             sudo systemctl restart localbiz-api
-            sudo nginx -t && sudo systemctl reload nginx
+            if command -v nginx >/dev/null 2>&1; then sudo nginx -t && sudo systemctl reload nginx; fi


### PR DESCRIPTION
## Summary

- `deploy-dev.yml`에서 nginx 미설치 시 `command not found`로 배포 실패하던 문제 수정
- `command -v nginx` 체크로 nginx 있을 때만 reload 실행

## 배경

PR #62 머지 후 GCE에 아직 nginx가 설치되지 않은 상태에서 `sudo nginx -t`가 실패.
setup.sh 실행 전까지는 nginx 없이 배포가 통과해야 함.

## Test plan

- [ ] dev push 시 Deploy to GCE 워크플로 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)