### PR TITLE
fix: SSE 핸들러 JWT 인증 적용 — user_id 불일치 해결 (#64)

### DIFF
--- a/.sisyphus/dependency-maps/2026-05-12-sse-jwt-auth.md
+++ b/.sisyphus/dependency-maps/2026-05-12-sse-jwt-auth.md
@@ -1,0 +1,30 @@
+# Dependency Map — SSE JWT Auth
+
+## Plan
+
+`.sisyphus/plans/2026-05-12-sse-jwt-auth/plan.md`
+
+## Steps
+
+| # | Step | Category | Files | Depends On |
+|---|---|---|---|---|
+| 1 | sse.py JWT 파싱 + _ensure_seed_user 제거 | quick | `backend/src/api/sse.py` | — |
+| 2 | 기존 테스트 수정 (있는 경우) | quick | `backend/tests/test_sse.py` | 1 |
+| 3 | validate.sh 검증 | quick | — | 1, 2 |
+
+## Recommended Order
+
+```
+g1: [step 1]          — sse.py 수정
+g2: [step 2]          — 테스트 반영
+g3: [step 3]          — 검증
+```
+
+## Parallelizable
+
+- g1 → g2 → g3: 순차 (의존성 체인)
+
+## Notes
+
+- 단일 파일 수정 (sse.py) + 테스트 반영. 병렬화 불필요.
+- `_ensure_seed_user` 함수 정의도 함께 제거 (dead code).

--- a/.sisyphus/plans/2026-05-12-sse-jwt-auth/plan.md
+++ b/.sisyphus/plans/2026-05-12-sse-jwt-auth/plan.md
@@ -1,0 +1,70 @@
+# SSE 핸들러 JWT 인증 적용 — user_id 불일치 버그 수정
+
+- Phase: P1
+- 요청자: 이정
+- 작성일: 2026-05-12
+- 상태: approved
+- 최종 결정: APPROVED
+
+> 상태 워크플로: draft → review → approved → done
+
+## 1. 요구사항
+
+SSE 핸들러(`GET /api/v1/chat/stream`)가 JWT `token` 파라미터를 받지만 파싱하지 않고
+항상 seed `user_id=1`로 conversation/message를 저장함.
+이후 `GET /api/v1/chats` 등이 JWT에서 추출한 실제 user_id로 조회하므로 결과가 빈 배열/404.
+
+**수정**: `token` query parameter를 `decode_access_token()`으로 파싱 → 실제 user_id 사용.
+`_ensure_seed_user()` 호출 제거. 토큰 누락/무효 시 SSE error 이벤트 전송.
+
+## 2. 영향 범위
+
+- 수정 파일:
+  - `backend/src/api/sse.py` — token 파싱 + user_id 추출, `_ensure_seed_user` 호출 제거
+  - `backend/tests/test_sse.py` — 테스트에 token/user_id mock 반영 (있는 경우)
+- 신규 파일: 없음
+- DB 스키마 영향: 없음
+- 응답 블록 16종 영향: 없음
+- intent 추가/변경: 없음
+- 외부 API 호출: 없음
+
+## 3. 19 불변식 체크리스트
+
+- [x] PK 이원화 준수 — 해당 없음
+- [x] PG↔OS 동기화 — 해당 없음
+- [x] append-only 4테이블 미수정 — messages INSERT 유지, UPDATE/DELETE 없음
+- [x] 소프트 삭제 매트릭스 준수 — 해당 없음
+- [x] 의도적 비정규화 3건 외 신규 비정규화 없음 — 해당 없음
+- [x] 6 지표 스키마 보존 — 해당 없음
+- [x] gemini-embedding-001 768d 사용 — 해당 없음
+- [x] asyncpg 파라미터 바인딩 — 기존 $1/$2 유지
+- [x] Optional[str] 사용 — 기존 유지
+- [x] SSE 이벤트 타입 16종 한도 준수 — 기존 error 이벤트 재사용
+- [x] intent별 블록 순서 준수 — 변경 없음
+- [x] 공통 쿼리 전처리 경유 — 변경 없음
+- [x] 행사 검색 DB 우선 — 해당 없음
+- [x] 대화 이력 이원화 보존 — 변경 없음
+- [x] 인증 매트릭스 준수 — JWT sub → user_id 사용 (불변식 #15 정합)
+- [x] 북마크 = 대화 위치 패러다임 — 해당 없음
+- [x] 공유링크 인증 우회 범위 정확 — SSE는 인증 필수 (우회 대상 아님)
+- [x] Phase 라벨 명시 — P1
+- [x] 기획 문서 우선 — 인증 매트릭스 준수
+
+## 4. 작업 순서 (Atomic step)
+
+1. `sse.py` 수정 — `event_generator()` 시작부에서 token 파싱:
+   - `token` 없으면 → error 이벤트 + done(error) + return
+   - `decode_access_token(token)` 실패 → error 이벤트 + done(error) + return
+   - 성공 → `user_id = int(payload["sub"])`
+   - `_ensure_seed_user(pool)` 호출 → `user_id` 직접 사용으로 교체
+2. 기존 테스트 수정 — token/user_id mock 반영
+3. 검증 — validate.sh (ruff/pyright/pytest)
+
+## 5. 검증 계획
+
+- validate.sh 통과
+- 수동 시나리오: FE 이슈 재현 절차(curl) 반복 → thread/message 정상 저장 확인
+
+## 6. 최종 결정
+
+APPROVED

--- a/.sisyphus/plans/2026-05-12-sse-jwt-auth/reviews/001-metis-okay.md
+++ b/.sisyphus/plans/2026-05-12-sse-jwt-auth/reviews/001-metis-okay.md
@@ -1,0 +1,21 @@
+# Review 001 — Metis
+
+## 판정: okay
+
+## 근거
+
+- **갭**: `_ensure_seed_user` 함수 정의 삭제 여부 미명시 → 구현 시 dead code 제거 권고. reject 사유 아님.
+- **숨은 의도**: chats API와 SSE 간 user_id 정합성 확보. plan이 정확히 포착.
+- **AI Slop**: 없음. 기존 `decode_access_token` + `format_error_event` 재사용.
+- **오버엔지니어링**: 없음. 버그 1건에 한정.
+- **19 불변식**: #3 append-only 유지, #8 파라미터 바인딩 유지, #15 JWT sub→user_id 정합.
+
+## 구현 시 권고
+
+1. `_ensure_seed_user` 함수 정의 자체도 제거 (dead code 방지)
+2. `int(payload["sub"])` 변환 실패 시 error 이벤트 전송 (`deps.py` 패턴과 동일)
+3. 수동 검증: token 유효/무효/누락 3케이스 확인
+
+## 다음 액션
+
+Momus 검토 → APPROVED.

--- a/.sisyphus/plans/2026-05-12-sse-jwt-auth/reviews/002-momus-approved.md
+++ b/.sisyphus/plans/2026-05-12-sse-jwt-auth/reviews/002-momus-approved.md
@@ -1,0 +1,20 @@
+# Review 002 — Momus
+
+## 판정: approved
+
+## 파일 참조 검증
+
+| 경로 | 결과 |
+|---|---|
+| `backend/src/api/sse.py` | EXISTS — L210 token param, L243 _ensure_seed_user 확인 |
+| `backend/src/core/security.py` | EXISTS — L68 decode_access_token 확인 |
+| `backend/src/api/deps.py` | EXISTS — L36 get_current_user_id 확인 |
+| `backend/tests/test_sse.py` | NOT FOUND — plan이 "있는 경우" 조건부 처리, 결함 아님 |
+
+## 19 불변식
+
+19개 항목 모두 실체적 근거 확인. #3 append-only 유지, #15 JWT 정합, #17 SSE 인증 필수.
+
+## 다음 액션
+
+plan.md → APPROVED.

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -113,30 +113,8 @@ _NODE_STATUS_MESSAGES: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
-# DB 헬퍼 — seed user, conversations, messages
+# DB 헬퍼 — conversations, messages
 # ---------------------------------------------------------------------------
-async def _ensure_seed_user(pool: Any) -> int:
-    """개발용 seed user 보장. user_id=1 없으면 INSERT.
-
-    Returns:
-        user_id (int).
-    """
-    row = await pool.fetchrow("SELECT user_id FROM users WHERE user_id = $1", 1)
-    if row:
-        return int(row["user_id"])
-
-    await pool.execute(
-        "INSERT INTO users (user_id, email, auth_provider, password_hash) "
-        "VALUES ($1, $2, $3, $4) ON CONFLICT (user_id) DO NOTHING",
-        1,
-        "dev@localhost",
-        "email",
-        "dev_placeholder_hash",
-    )
-    logger.info("Seed user created: user_id=1, email=dev@localhost")
-    return 1
-
-
 async def _ensure_conversation(pool: Any, thread_id: str, user_id: int) -> None:
     """conversations 테이블에 thread_id가 없으면 auto-create.
 
@@ -231,7 +209,24 @@ async def chat_stream(
         )
 
         try:
-            # 1. DB 준비 — seed user + conversation
+            # 0. JWT 인증 — token query parameter에서 user_id 추출
+            if not token:
+                yield format_error_event("AUTH_MISSING", "인증 토큰이 필요합니다.", recoverable=False)
+                yield format_done_event(status="error", error_message="인증 토큰이 필요합니다.")
+                return
+
+            try:
+                from src.core.security import decode_access_token  # pyright: ignore[reportMissingImports]
+
+                payload = decode_access_token(token)
+                user_id = int(payload["sub"])
+            except Exception:
+                logger.info("SSE JWT decode failed: thread_id=%s", thread_id)
+                yield format_error_event("AUTH_INVALID", "유효하지 않은 인증 토큰입니다.", recoverable=False)
+                yield format_done_event(status="error", error_message="유효하지 않은 인증 토큰입니다.")
+                return
+
+            # 1. DB 준비 — conversation auto-create
             try:
                 pool = get_pool()
             except RuntimeError:
@@ -240,7 +235,6 @@ async def chat_stream(
                 yield format_done_event(status="error", error_message="서버 DB 연결에 실패했습니다.")
                 return
 
-            user_id = await _ensure_seed_user(pool)
             await _ensure_conversation(pool, thread_id, user_id)
 
             # 2. user 메시지 INSERT (retry 시 생략)


### PR DESCRIPTION
## Summary

- SSE 핸들러(`GET /api/v1/chat/stream`)가 JWT `token` 파라미터를 파싱하지 않고 항상 `user_id=1`로 저장하던 버그 수정
- `decode_access_token(token)`으로 실제 user_id 추출하여 conversation/message 저장
- `_ensure_seed_user()` 함수 제거 (dead code)
- 토큰 누락/무효 시 SSE error 이벤트 전송

Closes #64

## Plan

`.sisyphus/plans/2026-05-12-sse-jwt-auth/plan.md` — Metis okay + Momus approved

## Test plan

- [ ] 회원가입 → 토큰 발급 → SSE 호출 → `GET /api/v1/chats`에서 thread 조회 확인
- [ ] `GET /api/v1/chats/{thread_id}/messages`에서 user/assistant 메시지 2건 확인
- [ ] 토큰 누락 시 SSE error 이벤트(`AUTH_MISSING`) 수신 확인
- [ ] 잘못된 토큰 시 SSE error 이벤트(`AUTH_INVALID`) 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)