### PR TITLE
Fix : OAuth callback 완료 후 FE /calendar/connected 페이지로 redirect

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,6 @@ jobs:
             _upsert_env "GOOGLE_CALENDAR_CLIENT_ID" "${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}"
             _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
             _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
-            _upsert_env "FRONTEND_BASE_URL" "${{ secrets.FRONTEND_BASE_URL }}"
+            if [ -n "${{ secrets.FRONTEND_BASE_URL }}" ]; then _upsert_env "FRONTEND_BASE_URL" "${{ secrets.FRONTEND_BASE_URL }}"; fi
             sudo systemctl restart localbiz-api
             if command -v nginx >/dev/null 2>&1; then sudo nginx -t && sudo systemctl reload nginx; fi

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,5 +26,6 @@ jobs:
             _upsert_env "GOOGLE_CALENDAR_CLIENT_ID" "${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}"
             _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
             _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
+            _upsert_env "FRONTEND_BASE_URL" "${{ secrets.FRONTEND_BASE_URL }}"
             sudo systemctl restart localbiz-api
             if command -v nginx >/dev/null 2>&1; then sudo nginx -t && sudo systemctl reload nginx; fi

--- a/backend/src/api/google_calendar_auth.py
+++ b/backend/src/api/google_calendar_auth.py
@@ -14,7 +14,7 @@ import hmac
 import logging
 import time
 from typing import Optional
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -109,7 +109,7 @@ def _calendar_redirect(base_url: str, error: Optional[str] = None) -> RedirectRe
     """FE /calendar/connected 페이지로 302 리다이렉트. 에러 시 ?error= 쿼리 추가."""
     url = f"{base_url}/calendar/connected"
     if error:
-        url = f"{url}?error={error}"
+        url = f"{url}?error={quote(error, safe='')}"
     return RedirectResponse(url=url, status_code=302)
 
 
@@ -134,7 +134,7 @@ async def google_calendar_callback(
         return _calendar_redirect(base_url, error="invalid_request")
 
     if not settings.jwt_secret:
-        raise HTTPException(status_code=503, detail="서버 설정 오류: JWT 시크릿 미설정.")
+        return _calendar_redirect(base_url, error="server_error")
 
     try:
         user_id = _verify_state(state, settings.jwt_secret)

--- a/backend/src/api/google_calendar_auth.py
+++ b/backend/src/api/google_calendar_auth.py
@@ -18,6 +18,7 @@ from urllib.parse import urlencode
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import RedirectResponse
 
 from src.api.deps import get_current_user_id  # pyright: ignore[reportMissingImports]
 from src.config import get_settings  # pyright: ignore[reportMissingImports]
@@ -104,27 +105,41 @@ async def google_calendar_auth_url(
     return {"auth_url": auth_url}
 
 
+def _calendar_redirect(base_url: str, error: Optional[str] = None) -> RedirectResponse:
+    """FE /calendar/connected 페이지로 302 리다이렉트. 에러 시 ?error= 쿼리 추가."""
+    url = f"{base_url}/calendar/connected"
+    if error:
+        url = f"{url}?error={error}"
+    return RedirectResponse(url=url, status_code=302)
+
+
 @router.get("/calendar/callback")
 async def google_calendar_callback(
     code: Optional[str] = Query(None),
     state: Optional[str] = Query(None),
     error: Optional[str] = Query(None),
-) -> dict[str, str]:
-    """Google OAuth 콜백 — code 수신 → refresh_token 저장.
+) -> RedirectResponse:
+    """Google OAuth 콜백 — code 수신 → refresh_token 저장 → FE redirect.
 
     구글이 직접 호출하는 엔드포인트. JWT 인증 없음.
     user_id는 state 파라미터 서명 검증으로 추출.
+    성공/실패 모두 FE /calendar/connected 페이지로 redirect.
     """
-    if error:
-        raise HTTPException(status_code=400, detail=f"구글 인증 거부: {error}")
-    if not code or not state:
-        raise HTTPException(status_code=400, detail="code 또는 state 파라미터가 없습니다.")
-
     settings = get_settings()
+    base_url = settings.frontend_base_url
+
+    if error:
+        return _calendar_redirect(base_url, error=error)
+    if not code or not state:
+        return _calendar_redirect(base_url, error="invalid_request")
+
     if not settings.jwt_secret:
         raise HTTPException(status_code=503, detail="서버 설정 오류: JWT 시크릿 미설정.")
 
-    user_id = _verify_state(state, settings.jwt_secret)
+    try:
+        user_id = _verify_state(state, settings.jwt_secret)
+    except HTTPException:
+        return _calendar_redirect(base_url, error="invalid_state")
 
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.post(
@@ -144,15 +159,12 @@ async def google_calendar_callback(
             resp.status_code,
             resp.text[:200],
         )
-        raise HTTPException(status_code=400, detail="Google 인증 코드 교환에 실패했습니다.")
+        return _calendar_redirect(base_url, error="token_exchange_failed")
 
     token_data = resp.json()
     refresh_token: Optional[str] = token_data.get("refresh_token")
     if not refresh_token:
-        raise HTTPException(
-            status_code=400,
-            detail="refresh_token을 받지 못했습니다. prompt=consent가 필요합니다.",
-        )
+        return _calendar_redirect(base_url, error="no_refresh_token")
 
     pool = get_pool()
     async with pool.acquire() as conn:
@@ -172,4 +184,4 @@ async def google_calendar_callback(
 
     clear_token_cache(user_id)
     logger.info("google_calendar_callback: user_id=%d calendar OAuth 완료", user_id)
-    return {"message": "Google Calendar 연동이 완료되었습니다."}
+    return _calendar_redirect(base_url)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     google_calendar_client_id: str = ""
     google_calendar_client_secret: str = ""
     google_calendar_redirect_uri: str = "http://localhost:8000/api/v1/auth/google/calendar/callback"
+    frontend_base_url: str = "https://seoul-ai-guide.vercel.app"
 
     # --- App ---
     debug: bool = False

--- a/backend/tests/test_google_calendar_auth.py
+++ b/backend/tests/test_google_calendar_auth.py
@@ -214,6 +214,16 @@ async def test_callback_invalid_state_redirects_with_invalid_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_callback_no_jwt_secret_redirects_with_server_error() -> None:
+    """jwt_secret 미설정 → ?error=server_error redirect."""
+    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock(jwt_secret="")):
+        result = await google_calendar_callback(code="auth-code", state=_make_valid_state(), error=None)
+
+    assert result.status_code == 302
+    assert "error=server_error" in result.headers["location"]
+
+
+@pytest.mark.asyncio
 async def test_callback_token_exchange_failure_redirects_with_error() -> None:
     """code 교환 실패 (구글 400) → ?error=token_exchange_failed redirect."""
     state = _make_valid_state()

--- a/backend/tests/test_google_calendar_auth.py
+++ b/backend/tests/test_google_calendar_auth.py
@@ -27,6 +27,8 @@ from src.api.google_calendar_auth import (
 
 _SECRET = "test-jwt-secret"
 _USER_ID = 42
+_FRONTEND_URL = "https://seoul-ai-guide.vercel.app"
+_CONNECTED_URL = f"{_FRONTEND_URL}/calendar/connected"
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +98,7 @@ def _settings_mock(jwt_secret: str = _SECRET) -> Any:
     m.jwt_secret = jwt_secret
     m.google_calendar_client_id = "test-client-id"
     m.google_calendar_redirect_uri = "http://localhost:8000/api/v1/auth/google/calendar/callback"
+    m.frontend_base_url = _FRONTEND_URL
     return m
 
 
@@ -133,7 +136,7 @@ async def test_auth_url_no_client_id_raises_503() -> None:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/v1/auth/google/calendar/callback — code 교환 → upsert
+# GET /api/v1/auth/google/calendar/callback — code 교환 → upsert → redirect
 # ---------------------------------------------------------------------------
 
 
@@ -152,8 +155,8 @@ def _make_valid_state() -> str:
 
 
 @pytest.mark.asyncio
-async def test_callback_success_upserts_token() -> None:
-    """정상 code + valid state → user_oauth_tokens upsert 후 200 반환."""
+async def test_callback_success_redirects_to_connected_page() -> None:
+    """정상 code + valid state → upsert 후 /calendar/connected 로 redirect."""
     pool = _pool_mock()
     state = _make_valid_state()
 
@@ -168,7 +171,8 @@ async def test_callback_success_upserts_token() -> None:
 
         result = await google_calendar_callback(code="auth-code", state=state, error=None)
 
-    assert result == {"message": "Google Calendar 연동이 완료되었습니다."}
+    assert result.status_code == 302
+    assert result.headers["location"] == _CONNECTED_URL
 
     conn = pool.acquire().__aenter__.return_value
     conn.execute.assert_awaited_once()
@@ -179,8 +183,39 @@ async def test_callback_success_upserts_token() -> None:
 
 
 @pytest.mark.asyncio
-async def test_callback_token_exchange_failure_raises_400() -> None:
-    """code 교환 실패 (구글 400) → 400."""
+async def test_callback_error_param_redirects_with_error() -> None:
+    """구글이 error 파라미터 전달 (사용자 거부) → ?error=access_denied redirect."""
+    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
+        result = await google_calendar_callback(code=None, state=None, error="access_denied")
+
+    assert result.status_code == 302
+    assert "error=access_denied" in result.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_code_redirects_with_invalid_request() -> None:
+    """code 파라미터 없음 → ?error=invalid_request redirect."""
+    state = _make_valid_state()
+    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
+        result = await google_calendar_callback(code=None, state=state, error=None)
+
+    assert result.status_code == 302
+    assert "error=invalid_request" in result.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_callback_invalid_state_redirects_with_invalid_state() -> None:
+    """위조된 state → ?error=invalid_state redirect."""
+    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
+        result = await google_calendar_callback(code="auth-code", state=f"1:{int(time.time())}:fakesig", error=None)
+
+    assert result.status_code == 302
+    assert "error=invalid_state" in result.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_callback_token_exchange_failure_redirects_with_error() -> None:
+    """code 교환 실패 (구글 400) → ?error=token_exchange_failed redirect."""
     state = _make_valid_state()
 
     with (
@@ -192,15 +227,15 @@ async def test_callback_token_exchange_failure_raises_400() -> None:
             return_value=Response(400, json={"error": "invalid_grant"})
         )
 
-        with pytest.raises(HTTPException) as exc:
-            await google_calendar_callback(code="bad-code", state=state, error=None)
+        result = await google_calendar_callback(code="bad-code", state=state, error=None)
 
-    assert exc.value.status_code == 400
+    assert result.status_code == 302
+    assert "error=token_exchange_failed" in result.headers["location"]
 
 
 @pytest.mark.asyncio
-async def test_callback_no_refresh_token_raises_400() -> None:
-    """구글이 refresh_token 없이 응답 → 400 (prompt=consent 미적용 케이스)."""
+async def test_callback_no_refresh_token_redirects_with_error() -> None:
+    """구글이 refresh_token 없이 응답 → ?error=no_refresh_token redirect."""
     state = _make_valid_state()
 
     with (
@@ -212,35 +247,7 @@ async def test_callback_no_refresh_token_raises_400() -> None:
             return_value=Response(200, json={"access_token": "at-only"})
         )
 
-        with pytest.raises(HTTPException) as exc:
-            await google_calendar_callback(code="auth-code", state=state, error=None)
+        result = await google_calendar_callback(code="auth-code", state=state, error=None)
 
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_callback_missing_code_raises_400() -> None:
-    """code 파라미터 없음 → 400."""
-    state = _make_valid_state()
-    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
-        with pytest.raises(HTTPException) as exc:
-            await google_calendar_callback(code=None, state=state, error=None)
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_callback_error_param_raises_400() -> None:
-    """구글이 error 파라미터 전달 (사용자 거부) → 400."""
-    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
-        with pytest.raises(HTTPException) as exc:
-            await google_calendar_callback(code=None, state=None, error="access_denied")
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_callback_invalid_state_raises_400() -> None:
-    """위조된 state → 400."""
-    with patch("src.api.google_calendar_auth.get_settings", return_value=_settings_mock()):
-        with pytest.raises(HTTPException) as exc:
-            await google_calendar_callback(code="auth-code", state=f"1:{int(time.time())}:fakesig", error=None)
-    assert exc.value.status_code == 400
+    assert result.status_code == 302
+    assert "error=no_refresh_token" in result.headers["location"]


### PR DESCRIPTION
#️⃣  연관된 이슈

  ▎ #72

  #️⃣  작업 내용

  ▎ Google Calendar OAuth 콜백 완료 후 브라우저에 raw JSON이 노출되던 문제 수정
  ▎ - 성공 시 {FRONTEND_BASE_URL}/calendar/connected 로 302 redirect
  ▎ - 에러 시 ?error={code} 쿼리 붙여서 같은 페이지로 redirect
  ▎ - frontend_base_url 환경변수 추가 (기본값: https://seoul-ai-guide.vercel.app)
  ▎ - deploy-dev.yml 에 FRONTEND_BASE_URL 시크릿 자동 주입 추가

  #️⃣  테스트 결과

  ▎ validate.sh 162 passed ✅

  #️⃣  변경 사항 체크리스트

  - 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
  - 문서를 작성하거나 수정했나요? (필요한 경우)
  - 코드 컨벤션에 따라 코드를 작성했나요?
  - 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Calendar authentication now redirects users to a dedicated connected page upon successful authorization and provides error-specific feedback for failed authentication attempts, improving the user experience.

* **Chores**
  * Updated configuration and deployment workflow to support frontend integration URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/75)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->