### PR TITLE
Fix : 즉시 북마크 시 422 오류 — done 이벤트에 message_id 추가

### DIFF
--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -73,9 +73,10 @@ def format_status_event(message: str, node: Optional[str] = None) -> str:
 def format_done_event(
     status: str = "done",
     error_message: Optional[str] = None,
+    message_id: Optional[int] = None,
 ) -> str:
     """done 이벤트 생성."""
-    done = DoneBlock(status=status, error_message=error_message)
+    done = DoneBlock(status=status, error_message=error_message, message_id=message_id)
     return format_block_event(done)
 
 
@@ -168,18 +169,20 @@ async def _insert_message(
     thread_id: str,
     role: str,
     blocks: list[dict[str, Any]],
-) -> None:
+) -> int:
     """messages 테이블에 INSERT (append-only, 불변식 #3).
 
     message_id는 BIGSERIAL auto-increment (불변식 #1).
+    삽입된 message_id 반환.
     """
     blocks_json = json.dumps(blocks, ensure_ascii=False)
-    await pool.execute(
-        "INSERT INTO messages (thread_id, role, blocks) VALUES ($1, $2, $3::jsonb)",
+    row = await pool.fetchrow(
+        "INSERT INTO messages (thread_id, role, blocks) VALUES ($1, $2, $3::jsonb) RETURNING message_id",
         thread_id,
         role,
         blocks_json,
     )
+    return int(row["message_id"])
 
 
 # ---------------------------------------------------------------------------
@@ -414,9 +417,10 @@ async def chat_stream(
 
             # 4. assistant 메시지 INSERT (done 전에 완료)
             persistence_success = True
+            assistant_message_id: Optional[int] = None
             if assistant_blocks:
                 try:
-                    await _insert_message(pool, thread_id, "assistant", assistant_blocks)
+                    assistant_message_id = await _insert_message(pool, thread_id, "assistant", assistant_blocks)
                 except Exception:
                     logger.exception("assistant message INSERT failed: thread_id=%s", thread_id)
                     persistence_success = False
@@ -431,7 +435,7 @@ async def chat_stream(
                 yield format_error_event("PERSISTENCE_ERROR", "응답 저장에 실패했습니다.", recoverable=True)
                 yield format_done_event(status="error", error_message="응답 저장에 실패했습니다.")
             else:
-                yield format_done_event(status="done")
+                yield format_done_event(status="done", message_id=assistant_message_id)
 
         except Exception:
             logger.exception("SSE error: thread_id=%s", thread_id)

--- a/backend/src/models/blocks.py
+++ b/backend/src/models/blocks.py
@@ -320,11 +320,13 @@ class DoneBlock(BaseModel):
 
     error 발생 시 status="error" + error_message에 상세 내용.
     기획서 기준 done 블록이 error 역할도 수행.
+    message_id: 방금 저장된 assistant 메시지 DB id (FE 북마크용).
     """
 
     type: str = "done"
     status: str = "done"  # "done" | "error" | "cancelled"
     error_message: Optional[str] = None
+    message_id: Optional[int] = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

#️⃣  연관된 이슈

  ▎ #79

  #️⃣  작업 내용

  ▎ SSE 응답 완료 직후 북마크 시 FE가 BE message_id를 몰라 임시 id 전송 → 422 발생하던 문제 수정
  ▎ - _insert_message: RETURNING message_id로 변경, int 반환
  ▎ - DoneBlock: message_id: Optional[int] 필드 추가
  ▎ - done 이벤트에 방금 저장된 assistant 메시지 id 포함해서 전송

  #️⃣  테스트 결과

  ▎ validate.sh 171 passed ✅

  #️⃣  변경 사항 체크리스트

  - 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
  - 문서를 작성하거나 수정했나요? (필요한 경우)
  - 코드 컨벤션에 따라 코드를 작성했나요?
  - 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Streaming chat responses now include unique message identifiers in completion events, enabling message reference and bookmarking capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->