### PR TITLE
fix: deploy-dev.yml Docker Compose V2 플러그인 자동 설치 (#82)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,6 +27,11 @@ jobs:
             _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
             _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
 
+            # Docker Compose V2 플러그인 자동 설치 (없으면)
+            if ! docker compose version > /dev/null 2>&1; then
+              sudo apt-get update -qq && sudo apt-get install -y -qq docker-compose-plugin
+            fi
+
             # Docker 빌드 + 재시작
             cd backend
             docker compose build api


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #82

## #️⃣ 작업 내용

> GCE VM에 `docker compose` 명령이 없어서 배포 실패.
> `docker-compose-plugin` 자동 설치 가드 추가.

## #️⃣ 테스트 결과

> YAML lint 통과. 로직: `docker compose version` 실패 시에만 apt 설치.

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)