### PR TITLE
fix: Docker 공식 apt repo로 Compose V2 설치 (#82)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,12 +27,14 @@ jobs:
             _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
             _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
 
-            # Docker Compose V2 플러그인 자동 설치 (없으면)
+            # Docker 공식 apt repo 등록 + Compose V2 설치 (1회성, 이후 apt upgrade로 관리)
             if ! docker compose version > /dev/null 2>&1; then
-              COMPOSE_VERSION="v2.29.2"
-              sudo mkdir -p /usr/local/lib/docker/cli-plugins
-              sudo curl -SL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose
-              sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+              sudo install -m 0755 -d /etc/apt/keyrings
+              sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+              sudo chmod a+r /etc/apt/keyrings/docker.asc
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq docker-compose-plugin
               docker compose version
             fi
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,7 +29,11 @@ jobs:
 
             # Docker Compose V2 플러그인 자동 설치 (없으면)
             if ! docker compose version > /dev/null 2>&1; then
-              sudo apt-get update -qq && sudo apt-get install -y -qq docker-compose-plugin
+              COMPOSE_VERSION="v2.29.2"
+              sudo mkdir -p /usr/local/lib/docker/cli-plugins
+              sudo curl -SL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose
+              sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+              docker compose version
             fi
 
             # Docker 빌드 + 재시작


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #82

## #️⃣ 작업 내용

> GCE VM에 Docker 공식 apt repo 등록 + `docker-compose-plugin` 설치.
> 바이너리 직접 다운로드 대신 정식 패키지 관리 방식으로 이후 `apt upgrade`로 관리 가능.

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)