### PR TITLE
fix: Docker apt repo Debian/Ubuntu 자동 감지 (#82)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,10 +29,12 @@ jobs:
 
             # Docker 공식 apt repo 등록 + Compose V2 설치 (1회성, 이후 apt upgrade로 관리)
             if ! docker compose version > /dev/null 2>&1; then
+              . /etc/os-release
+              DISTRO="$ID"  # debian 또는 ubuntu
               sudo install -m 0755 -d /etc/apt/keyrings
-              sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+              sudo curl -fsSL "https://download.docker.com/linux/${DISTRO}/gpg" -o /etc/apt/keyrings/docker.asc
               sudo chmod a+r /etc/apt/keyrings/docker.asc
-              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${DISTRO} ${VERSION_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
               sudo apt-get update -qq
               sudo apt-get install -y -qq docker-compose-plugin
               docker compose version


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #82

## #️⃣ 작업 내용

> GCE VM이 Debian(bookworm)인데 ubuntu repo를 참조해서 `Release file not found` 에러.
> `/etc/os-release`의 `ID` 필드(`debian`/`ubuntu`)로 distro 자동 감지하도록 수정.

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)