### PR TITLE
fix: 배포 SSH 타임아웃 20분 확대 (#82)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,6 +14,7 @@ jobs:
           host: ${{ secrets.GCE_HOST }}
           username: ${{ secrets.GCE_USER }}
           key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          command_timeout: 20m
           script: |
             set -euo pipefail
             cd ~/LocalBiz-Seoul


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #82

## #️⃣ 작업 내용

> pip dependency resolver(protobuf backtracking)로 첫 Docker 빌드가 5분+ 소요.
> SSH action 기본 타임아웃(5분)을 `command_timeout: 20m`으로 확대.
> (향후 requirements.txt 버전 고정으로 빌드 시간 단축 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)