### PR TITLE
fix: requirements.txt 의존성 버전 고정 — Docker 빌드 6분→21초 (#90)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,6 +14,7 @@ jobs:
           host: ${{ secrets.GCE_HOST }}
           username: ${{ secrets.GCE_USER }}
           key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
+          command_timeout: 5m
           script: |
             set -euo pipefail
             cd ~/LocalBiz-Seoul

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,15 @@
+# ============================================================
+# AnyWay backend — pinned dependencies (pip freeze 2026-05-15)
+# 버전 고정: Docker 빌드 시 pip resolver backtracking 방지.
+# 업데이트: venv에서 pip install -U <pkg> 후 pip freeze로 재고정.
+# ============================================================
+
 # Web Framework
 fastapi==0.115.4
 uvicorn[standard]==0.30.6
 python-multipart==0.0.9
 websockets==13.1
+starlette==0.41.3
 
 # LangGraph / LangChain
 langgraph==0.2.55
@@ -10,17 +17,22 @@ langchain-anthropic==0.3.0
 langchain-google-genai==2.1.12
 langchain-ollama==0.2.2
 langgraph-checkpoint-postgres==2.0.8
+langchain-core==0.3.86
+langgraph-checkpoint==2.1.2
+langgraph-sdk==0.1.74
+langsmith==0.8.4
 
 # Database
 asyncpg==0.30.0
 psycopg[binary,pool]==3.2.3
+psycopg-binary==3.2.3
+psycopg-pool==3.3.1
 opensearch-py==2.7.1
 aiohttp==3.13.5
 
 # External API
 httpx==0.27.2
 anthropic==0.40.0
-# openai 제거 — 임베딩을 Gemini text-embedding-004로 전환
 
 # Auth (PR #4 회원가입 시리즈 도입)
 python-jose[cryptography]==3.3.0
@@ -43,8 +55,6 @@ opentelemetry-instrumentation-fastapi==0.49b1
 pydantic-settings==2.6.1
 python-dateutil==2.9.0
 pytz==2024.2
-
-# Config / Utils (booking_node 캐시)
 cachetools==5.5.0
 
 # Testing
@@ -52,3 +62,83 @@ pytest==8.3.3
 pytest-asyncio==0.24.0
 httpx[test]==0.27.2
 respx==0.21.1
+
+# ---------------------------------------------------------------------------
+# Transitive dependencies (pinned to prevent pip backtracking)
+# ---------------------------------------------------------------------------
+aiohappyeyeballs==2.6.1
+aiosignal==1.4.0
+annotated-types==0.7.0
+anyio==4.13.0
+asgiref==3.11.1
+attrs==26.1.0
+certifi==2026.4.22
+cffi==2.0.0
+charset-normalizer==3.4.7
+click==8.3.3
+cryptography==48.0.0
+defusedxml==0.7.1
+Deprecated==1.3.1
+distro==1.9.0
+dnspython==2.8.0
+ecdsa==0.19.2
+Events==0.5
+filetype==1.2.0
+frozenlist==1.8.0
+google-ai-generativelanguage==0.10.0
+google-api-core==1.34.1
+googleapis-common-protos==1.56.2
+grpcio==1.80.0
+grpcio-status==1.49.0rc1
+h11==0.16.0
+httpcore==1.0.9
+httptools==0.7.1
+idna==3.15
+importlib_metadata==8.5.0
+iniconfig==2.3.0
+jiter==0.14.0
+jsonpatch==1.33
+jsonpointer==3.1.1
+multidict==6.7.1
+ollama==0.6.2
+opentelemetry-api==1.28.1
+opentelemetry-exporter-jaeger-proto-grpc==1.20.0
+opentelemetry-exporter-jaeger-thrift==1.20.0
+opentelemetry-instrumentation==0.49b1
+opentelemetry-instrumentation-asgi==0.49b1
+opentelemetry-semantic-conventions==0.49b1
+opentelemetry-util-http==0.49b1
+orjson==3.11.9
+ormsgpack==1.12.2
+packaging==25.0
+pluggy==1.6.0
+prometheus_client==0.25.0
+propcache==0.5.2
+proto-plus==1.27.1
+protobuf==3.20.3
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+python-dotenv==1.2.2
+PyYAML==6.0.3
+requests==2.34.2
+requests-toolbelt==1.0.0
+rsa==4.9.1
+six==1.17.0
+sniffio==1.3.1
+tenacity==9.1.4
+thrift==0.23.0
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+tzdata==2026.2
+urllib3==2.7.0
+uuid_utils==0.15.0
+uvloop==0.22.1
+watchfiles==1.1.1
+wrapt==1.17.3
+xxhash==3.7.0
+yarl==1.23.0
+zipp==3.23.1
+zstandard==0.25.0


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #90

## #️⃣ 작업 내용

> - `requirements.txt`를 pip freeze 기반 전체 의존성 트리 버전 고정
> - transitive deps (protobuf, grpcio-status, proto-plus, google-api-core 등) 포함
> - `deploy-dev.yml` command_timeout을 5분으로 명시
> - PR #89 (20분 타임아웃 우회) 닫음 — 이 PR로 대체

## #️⃣ 테스트 결과

> - `docker build --no-cache`: 21초 (이전 6분+)
> - pip resolver backtracking 메시지 0건
> - 로컬 venv 정상 동작 (validate.sh ruff/pyright 통과)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)