### PR TITLE
fix: 프로덕션 배포 --no-deps로 DB 컨테이너 pull 방지 (#92)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -44,7 +44,7 @@ jobs:
             # Docker 빌드 + 재시작
             cd backend
             docker compose build api
-            docker compose up -d api
+            docker compose up -d --no-deps api
 
             # 헬스체크 대기 (최대 60초)
             for i in $(seq 1 30); do


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #92

## #️⃣ 작업 내용

> `docker compose up -d api` → `docker compose up -d --no-deps api`
> 프로덕션은 Cloud SQL + 별도 GCE OpenSearch 사용. depends_on의 postgres/opensearch 이미지(900MB+) pull 방지.

## #️⃣ 테스트 결과

> YAML lint 통과. `--no-deps`는 compose 표준 플래그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dev deployment process for service initialization during Docker Compose operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->