### PR TITLE
fix: 배포 파이프라인 안정화 — systemd 중지 + 컨테이너 정리 (#92)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,10 +28,10 @@ jobs:
             _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
             _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
 
-            # Docker 공식 apt repo 등록 + Compose V2 설치 (1회성, 이후 apt upgrade로 관리)
+            # Docker 공식 apt repo 등록 + Compose V2 설치 (1회성)
             if ! docker compose version > /dev/null 2>&1; then
               . /etc/os-release
-              DISTRO="$ID"  # debian 또는 ubuntu
+              DISTRO="$ID"
               sudo install -m 0755 -d /etc/apt/keyrings
               sudo curl -fsSL "https://download.docker.com/linux/${DISTRO}/gpg" -o /etc/apt/keyrings/docker.asc
               sudo chmod a+r /etc/apt/keyrings/docker.asc
@@ -41,8 +41,13 @@ jobs:
               docker compose version
             fi
 
-            # Docker 빌드 + 재시작
+            # 기존 서비스 정리 — systemd(bare VM) 또는 이전 Docker 컨테이너
+            sudo systemctl stop localbiz-api 2>/dev/null || true
+            sudo systemctl disable localbiz-api 2>/dev/null || true
             cd backend
+            docker compose down 2>/dev/null || true
+
+            # Docker 빌드 + 시작 (DB 컨테이너 제외 — 프로덕션은 Cloud SQL + 별도 GCE OpenSearch)
             docker compose build api
             docker compose up -d --no-deps api
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #92

## #️⃣ 작업 내용

> - `systemctl stop/disable localbiz-api` — 기존 bare VM 서비스 중지 (포트 8000 충돌 해소)
> - `docker compose down` — 이전 컨테이너 정리 후 재시작
> - `--no-deps` 유지 — 프로덕션 DB는 Cloud SQL + 별도 GCE OpenSearch

## #️⃣ 변경 사항 체크리스트

- [x] YAML 문법 검증 완료
- [x] 필수 요소 전수 확인 (systemctl stop, compose down, --no-deps, timeout, healthcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)