### PR TITLE
feat: 장소 응답에 네이버맵/카카오맵 검색 링크 자동 부착 (#97)

### DIFF
--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -478,6 +478,9 @@ def _build_blocks(
             "transit_to_next": transit_to_next,
             "recommendation_reason": detail.get("recommendation_reason"),
         }
+        from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+        attach_map_urls(stop["place"])
         course_stops.append(stop)
 
     blocks.append(

--- a/backend/src/graph/detail_inquiry_node.py
+++ b/backend/src/graph/detail_inquiry_node.py
@@ -147,6 +147,9 @@ def _build_detail_blocks(
     if place_row.get("lng") is not None:
         place_block["lng"] = place_row["lng"]
 
+    from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+    attach_map_urls(place_block)
     blocks.append(place_block)
 
     return blocks

--- a/backend/src/graph/image_search_node.py
+++ b/backend/src/graph/image_search_node.py
@@ -640,6 +640,9 @@ def _place_to_block(place: dict[str, Any]) -> dict[str, Any]:
         block["lat"] = place["lat"]
     if place.get("lng") is not None:
         block["lng"] = place["lng"]
+    from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+    attach_map_urls(block)
     return block
 
 

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -428,6 +428,9 @@ def _build_blocks(
         reason = reasons.get(pid)
         if reason:
             item["summary"] = reason
+        from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+        attach_map_urls(item)
         place_items.append(item)
 
     # places 블록은 항상 반환 (빈 배열 포함 — 블록 순서 검증 일관성)

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -285,6 +285,9 @@ def _build_blocks(
         desc = descriptions.get(r.get("place_id", ""))
         if desc:
             item["summary"] = desc
+        from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+        attach_map_urls(item)
         place_items.append(item)
 
     if place_items:

--- a/backend/src/models/blocks.py
+++ b/backend/src/models/blocks.py
@@ -15,6 +15,7 @@ SSE 제어 이벤트 (런타임 한정, messages 미저장):
 from __future__ import annotations
 
 from typing import Any, Optional
+from urllib.parse import quote
 
 from pydantic import BaseModel, Field
 
@@ -75,6 +76,8 @@ class PlaceBlock(BaseModel):
     rating: Optional[float] = None
     image_url: Optional[str] = None
     summary: Optional[str] = None  # LLM 요약 (선택)
+    naver_map_url: Optional[str] = None  # 런타임 생성 (네이버 지도 검색)
+    kakao_map_url: Optional[str] = None  # 런타임 생성 (카카오맵 검색)
     congestion: Optional[CongestionInfo] = None
 
 
@@ -399,3 +402,23 @@ def deserialize_block(data: dict[str, Any]) -> BaseModel:
     if cls is None:
         raise ValueError(f"알 수 없는 블록 type: {block_type!r}")
     return cls.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# 유틸: place 블록에 지도 검색 URL 부착
+# ---------------------------------------------------------------------------
+def attach_map_urls(place_dict: dict[str, Any]) -> dict[str, Any]:
+    """place 블록 dict에 naver_map_url, kakao_map_url을 런타임 생성하여 추가.
+
+    DB 변경 없이 장소명 기반 검색 URL 패턴 사용.
+    이미 URL이 있으면 덮어쓰지 않음.
+    """
+    name = place_dict.get("name", "")
+    if not name:
+        return place_dict
+    encoded = quote(name)
+    if not place_dict.get("naver_map_url"):
+        place_dict["naver_map_url"] = f"https://map.naver.com/v5/search/{encoded}"
+    if not place_dict.get("kakao_map_url"):
+        place_dict["kakao_map_url"] = f"https://map.kakao.com/?q={encoded}"
+    return place_dict


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97

## #️⃣ 작업 내용

> **PlaceBlock 필드 추가**: `naver_map_url`, `kakao_map_url` (Optional)
>
> **`attach_map_urls()` 유틸** (`src/models/blocks.py`):
> ```
> naver_map_url = https://map.naver.com/v5/search/{장소명}
> kakao_map_url = https://map.kakao.com/?q={장소명}
> ```
> DB/ETL 변경 없이 장소명 기반 런타임 URL 생성.
>
> **적용 노드** (5개):
> - place_search_node, place_recommend_node, detail_inquiry_node, image_search_node, course_plan_node

## #️⃣ 테스트 결과

> - ruff check: Passed
> - ruff format: Passed  
> - pyright: 0 errors, 0 warnings

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)