### PR TITLE
fix: 프로덕션 500 에러 — docker-compose DB 환경변수 하드코딩 제거 (#99)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -52,14 +52,6 @@ services:
       - "8000:8000"
     env_file:
       - .env
-    environment:
-      DB_HOST: postgres
-      DB_PORT: "5432"
-      DB_NAME: localbiz
-      DB_USER: localbiz
-      DB_PASSWORD: localbiz
-      OPENSEARCH_HOST: opensearch
-      OPENSEARCH_PORT: "9200"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 프로덕션 /api/v1/chats, /api/v1/users/me/bookmarks 500 에러

## #️⃣ 작업 내용

> docker-compose.yml의 `environment` 블록이 `env_file`(.env)의 Cloud SQL 주소를
> `DB_HOST: postgres` (로컬 컨테이너)로 덮어씀.
> `--no-deps`로 DB 컨테이너를 안 띄웠으므로 연결 실패 → 500.
>
> **수정**: `environment` 블록 제거. `.env`의 Cloud SQL/OpenSearch 주소를 그대로 사용.

## #️⃣ 테스트 결과

> YAML lint 통과. docker compose config으로 env_file만 사용 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)