### PR TITLE
[Fix] 캘린더 고도화 — 이벤트 조회/삭제 엔드포인트 신설 + 응답 품질 개선 

### DIFF
--- a/backend/src/api/calendar.py
+++ b/backend/src/api/calendar.py
@@ -53,6 +53,7 @@ async def list_calendar_events(
     time_min: Optional[str] = Query(None),
     time_max: Optional[str] = Query(None),
     limit: int = Query(50, ge=1, le=250),
+    page_token: Optional[str] = Query(None),
     user_id: int = Depends(get_current_user_id),
 ) -> CalendarEventsResponse:
     """Google Calendar 이벤트 목록 조회. DB 미저장 — Google 직접 조회."""
@@ -75,13 +76,22 @@ async def list_calendar_events(
         "singleEvents": "true",
         "orderBy": "startTime",
     }
+    if page_token:
+        params["pageToken"] = page_token
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.get(
-            _GOOGLE_EVENTS_URL,
-            headers={"Authorization": f"Bearer {access_token}"},
-            params=params,
-        )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                _GOOGLE_EVENTS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params=params,
+            )
+    except httpx.RequestError as e:
+        logger.warning("calendar: events.list 네트워크 오류 user_id=%s: %s", user_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Google Calendar API 호출 실패",
+        ) from e
 
     if resp.status_code != 200:
         logger.warning("calendar: events.list 실패 status=%d user_id=%s", resp.status_code, user_id)
@@ -129,11 +139,18 @@ async def delete_calendar_event(
             detail="google_calendar_not_connected",
         ) from e
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.delete(
-            f"{_GOOGLE_EVENTS_URL}/{event_id}",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.delete(
+                f"{_GOOGLE_EVENTS_URL}/{event_id}",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+    except httpx.RequestError as e:
+        logger.warning("calendar: events.delete 네트워크 오류 event_id=%s: %s", event_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Google Calendar API 호출 실패",
+        ) from e
 
     if resp.status_code == 404:
         raise HTTPException(

--- a/backend/src/api/calendar.py
+++ b/backend/src/api/calendar.py
@@ -1,0 +1,148 @@
+"""Google Calendar 이벤트 조회/삭제 엔드포인트 (Phase 1).
+
+흐름:
+  GET  /api/v1/users/me/calendar/events
+    → user_oauth_tokens에서 refresh_token 조회 → access_token 발급
+    → Google Calendar events.list API 호출 → items[] 반환
+  DELETE /api/v1/users/me/calendar/events/{event_id}
+    → access_token 발급 → Google Calendar events.delete API 호출
+
+우리 DB에 별도 저장 없음. Google Calendar가 source of truth.
+FE CalendarPanel이 소비. 403 시 "Google Calendar 연동" CTA 표시.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from src.api.deps import get_current_user_id  # pyright: ignore[reportMissingImports]
+from src.graph.calendar_node import _CalendarError, _get_access_token  # pyright: ignore[reportMissingImports]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/users/me/calendar", tags=["calendar"])
+
+_KST = timezone(timedelta(hours=9))
+_GOOGLE_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+
+
+class CalendarEventItem(BaseModel):
+    event_id: str
+    title: str
+    start_time: Optional[str]
+    end_time: Optional[str]
+    location: Optional[str]
+    description: Optional[str]
+    calendar_link: Optional[str]
+    source: str  # "localbiz" | "user"
+
+
+class CalendarEventsResponse(BaseModel):
+    items: list[CalendarEventItem]
+    next_page_token: Optional[str]
+
+
+@router.get("/events", response_model=CalendarEventsResponse, status_code=status.HTTP_200_OK)
+async def list_calendar_events(
+    time_min: Optional[str] = Query(None),
+    time_max: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=250),
+    user_id: int = Depends(get_current_user_id),
+) -> CalendarEventsResponse:
+    """Google Calendar 이벤트 목록 조회. DB 미저장 — Google 직접 조회."""
+    try:
+        access_token = await _get_access_token(user_id)
+    except _CalendarError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="google_calendar_not_connected",
+        ) from e
+
+    now = datetime.now(_KST)
+    effective_time_min = time_min or now.isoformat()
+    effective_time_max = time_max or (now + timedelta(days=90)).isoformat()
+
+    params: dict[str, Any] = {
+        "timeMin": effective_time_min,
+        "timeMax": effective_time_max,
+        "maxResults": limit,
+        "singleEvents": "true",
+        "orderBy": "startTime",
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            _GOOGLE_EVENTS_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            params=params,
+        )
+
+    if resp.status_code != 200:
+        logger.warning("calendar: events.list 실패 status=%d user_id=%s", resp.status_code, user_id)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Google Calendar API 호출 실패",
+        )
+
+    data = resp.json()
+    items: list[CalendarEventItem] = []
+    for raw in data.get("items", []):
+        start = raw.get("start", {})
+        end = raw.get("end", {})
+        ext_private = raw.get("extendedProperties", {}).get("private", {})
+        items.append(
+            CalendarEventItem(
+                event_id=raw.get("id", ""),
+                title=raw.get("summary", ""),
+                start_time=start.get("dateTime") or start.get("date"),
+                end_time=end.get("dateTime") or end.get("date"),
+                location=raw.get("location"),
+                description=raw.get("description"),
+                calendar_link=raw.get("htmlLink"),
+                source=ext_private.get("source", "user"),
+            )
+        )
+
+    return CalendarEventsResponse(
+        items=items,
+        next_page_token=data.get("nextPageToken"),
+    )
+
+
+@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_calendar_event(
+    event_id: str,
+    user_id: int = Depends(get_current_user_id),
+) -> None:
+    """Google Calendar 이벤트 삭제."""
+    try:
+        access_token = await _get_access_token(user_id)
+    except _CalendarError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="google_calendar_not_connected",
+        ) from e
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.delete(
+            f"{_GOOGLE_EVENTS_URL}/{event_id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    if resp.status_code == 404:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="이벤트를 찾을 수 없습니다.",
+        )
+    if resp.status_code not in (200, 204):
+        logger.warning("calendar: events.delete 실패 status=%d event_id=%s", resp.status_code, event_id)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Google Calendar API 호출 실패",
+        )

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -341,7 +341,7 @@ async def _create_event(
         event_body["location"] = location
     if description:
         event_body["description"] = description
-    if url:
+    if url and url.startswith(("http://", "https://")):
         event_body["source"] = {"title": "AnyWay", "url": url}
 
     async with httpx.AsyncClient(timeout=10.0) as client:

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -49,7 +49,9 @@ _CALENDAR_EXTRACT_PROMPT = """\
   "event_title": "일정 제목 (문자열, 불명확하면 null)",
   "start_time": "ISO 8601 KST 예: 2026-05-02T14:00:00+09:00 (불명확하면 null)",
   "end_time": "ISO 8601 KST (언급 없으면 null)",
-  "location": "장소명 (언급 없으면 null)"
+  "location": "장소명 (언급 없으면 null)",
+  "description": "대화 맥락에서 파악한 장소 설명·코스 메모·특이사항 (없으면 null)",
+  "url": "대화에서 언급된 예약 URL 또는 장소 상세 링크 (없으면 null)"
 }}
 
 규칙:
@@ -133,6 +135,8 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
     start_time: Optional[str] = extracted.get("start_time")
     end_time: Optional[str] = extracted.get("end_time")
     location: Optional[str] = extracted.get("location")
+    description: Optional[str] = extracted.get("description")
+    url: Optional[str] = extracted.get("url")
 
     # 필수 필드 미입력 시 재질문 블록 반환
     if not event_title:
@@ -165,6 +169,8 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
             start_time=start_time,
             end_time=end_time,
             location=location,
+            description=description,
+            url=url,
         )
         status = "created"
     except _CalendarError as e:
@@ -176,7 +182,7 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
 
     return {
         "response_blocks": [
-            _text_stream_block(event_title, start_time, status),
+            _text_stream_block(event_title, start_time, status, end_time=end_time, location=location),
             _calendar_block(
                 event_title=event_title,
                 start_time=start_time,
@@ -314,6 +320,8 @@ async def _create_event(
     start_time: str,
     end_time: Optional[str],
     location: Optional[str],
+    description: Optional[str] = None,
+    url: Optional[str] = None,
 ) -> str:
     """Google Calendar API로 이벤트 생성 후 htmlLink 반환.
 
@@ -324,9 +332,14 @@ async def _create_event(
         "summary": event_title,
         "start": {"dateTime": start_time, "timeZone": "Asia/Seoul"},
         "end": {"dateTime": end_time, "timeZone": "Asia/Seoul"},
+        "extendedProperties": {"private": {"source": "localbiz"}},
     }
     if location:
         event_body["location"] = location
+    if description:
+        event_body["description"] = description
+    if url:
+        event_body["source"] = {"title": "AnyWay", "url": url}
 
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.post(
@@ -349,10 +362,21 @@ def _add_one_hour(iso_time: str) -> Optional[str]:
         return None
 
 
-def _text_stream_block(event_title: str, start_time: str, status: str) -> dict[str, Any]:
+def _text_stream_block(
+    event_title: str,
+    start_time: str,
+    status: str,
+    end_time: Optional[str] = None,
+    location: Optional[str] = None,
+) -> dict[str, Any]:
     """이벤트 생성 결과 안내용 text_stream 블록 생성."""
     if status == "created":
-        prompt = f"'{event_title}' 일정을 Google Calendar에 추가했어요. ({start_time})"
+        details: list[str] = [start_time]
+        if end_time:
+            details.append(f"~{end_time}")
+        if location:
+            details.append(location)
+        prompt = f"'{event_title}' 일정을 Google Calendar에 추가했어요. ({', '.join(details)})"
     else:
         prompt = "죄송합니다. Google Calendar 일정 추가에 실패했습니다. 잠시 후 다시 시도해 주세요."
 

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -157,8 +157,9 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
         except ValueError:
             end_time = None
 
-    # end_time 미입력 시 1시간 자동 추가
-    if not end_time:
+    # end_time 미입력 시 1시간 자동 추가 (자동 설정 여부 기록)
+    end_time_auto = end_time is None
+    if end_time_auto:
         end_time = _add_one_hour(start_time)
 
     try:
@@ -182,7 +183,7 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
 
     return {
         "response_blocks": [
-            _text_stream_block(event_title, start_time, status, end_time=end_time, location=location),
+            _text_stream_block(event_title, start_time, status, end_time=end_time, location=location, end_time_auto=end_time_auto),
             _calendar_block(
                 event_title=event_title,
                 start_time=start_time,
@@ -368,6 +369,7 @@ def _text_stream_block(
     status: str,
     end_time: Optional[str] = None,
     location: Optional[str] = None,
+    end_time_auto: bool = False,
 ) -> dict[str, Any]:
     """이벤트 생성 결과 안내용 text_stream 블록 생성."""
     if status == "created":
@@ -376,7 +378,11 @@ def _text_stream_block(
             details.append(f"~{end_time}")
         if location:
             details.append(location)
-        prompt = f"'{event_title}' 일정을 Google Calendar에 추가했어요. ({', '.join(details)})"
+        time_info = ", ".join(details)
+        if end_time_auto:
+            prompt = f"'{event_title}' 일정을 Google Calendar에 추가했어요. 종료 시간을 말씀 안 하셔서 1시간으로 자동 설정했어요. ({time_info})"
+        else:
+            prompt = f"'{event_title}' 일정을 Google Calendar에 추가했어요. ({time_info})"
     else:
         prompt = "죄송합니다. Google Calendar 일정 추가에 실패했습니다. 잠시 후 다시 시도해 주세요."
 

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -55,7 +55,7 @@ _CALENDAR_EXTRACT_PROMPT = """\
 }}
 
 규칙:
-- 오늘 날짜: {today}
+- 현재 일시(KST): {today}
 - 상대 날짜("내일", "이번 주 토요일" 등)는 오늘 기준으로 절대 날짜로 변환.
 - 시간은 KST(+09:00) 기준. 오전/오후 표현 그대로 반영.
 - 이벤트 제목은 키워드에서 자연스럽게 유추. 예) keywords=["경복궁"] → "경복궁 방문".
@@ -223,8 +223,8 @@ async def _extract_calendar_fields(
         logger.warning("calendar_node: GEMINI_LLM_API_KEY 미설정 — 필드 추출 생략")
         return {}
 
-    today = datetime.now(_KST).strftime("%Y-%m-%d")
-    system_prompt = _CALENDAR_EXTRACT_PROMPT.format(today=today)
+    now_kst = datetime.now(_KST).strftime("%Y-%m-%d %H:%M")
+    system_prompt = _CALENDAR_EXTRACT_PROMPT.format(today=now_kst)
 
     # 사용자 메시지 구성
     parts: list[str] = []
@@ -382,7 +382,7 @@ def _text_stream_block(
 
     return {
         "type": "text_stream",
-        "system": "Google Calendar 일정 추가 결과를 친절하게 안내하세요. 불필요한 내용은 추가하지 마세요.",
+        "system": "Google Calendar 일정 추가 결과를 친절하게 안내하세요. 불필요한 내용은 추가하지 마세요. 마크다운 강조(**) 없이 대화하듯 자연스럽게 답하세요.",
         "prompt": prompt,
     }
 
@@ -415,7 +415,7 @@ def _reask_block(prompt: str) -> dict[str, Any]:
     """필수 정보 부족 시 재질문용 text_stream 블록 생성."""
     return {
         "type": "text_stream",
-        "system": "캘린더 일정 추가를 위해 필요한 정보가 부족합니다. 친절하고 자연스럽게 추가 정보를 요청하세요.",
+        "system": "캘린더 일정 추가를 위해 필요한 정보가 부족합니다. 친절하고 자연스럽게 추가 정보를 요청하세요. 마크다운 강조(**) 없이 대화하듯 짧고 간결하게 답하세요.",
         "prompt": prompt,
     }
 

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -183,7 +183,9 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
 
     return {
         "response_blocks": [
-            _text_stream_block(event_title, start_time, status, end_time=end_time, location=location, end_time_auto=end_time_auto),
+            _text_stream_block(
+                event_title, start_time, status, end_time=end_time, location=location, end_time_auto=end_time_auto
+            ),
             _calendar_block(
                 event_title=event_title,
                 start_time=start_time,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -99,6 +99,7 @@ from src.api.auth import router as auth_router  # noqa: E402, I001  # pyright: i
 from src.api.bookmarks import router as bookmarks_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.place_bookmarks import router as place_bookmarks_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.chats import router as chats_router  # noqa: E402  # pyright: ignore[reportMissingImports]
+from src.api.calendar import router as calendar_events_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.google_calendar_auth import router as google_calendar_auth_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.share import router as share_router  # noqa: E402  # pyright: ignore[reportMissingImports]
 from src.api.sse import router as sse_router  # noqa: E402  # pyright: ignore[reportMissingImports]
@@ -111,6 +112,7 @@ app.include_router(bookmarks_router)  # /api/v1/users/me/bookmarks/* 엔드포�
 app.include_router(place_bookmarks_router)  # /api/v1/users/me/place-bookmarks/* 엔드포인트 3개
 app.include_router(chats_router)  # /api/v1/chats/* 엔드포인트 5개
 app.include_router(sse_router)  # /api/v1/chat/stream SSE 엔드포인트
+app.include_router(calendar_events_router)  # /api/v1/users/me/calendar/events GET/DELETE
 app.include_router(google_calendar_auth_router)  # /api/v1/auth/google/calendar OAuth 2종
 app.include_router(share_router)  # 공유 링크 3개
 app.include_router(upload_router)  # /api/v1/upload/image 이미지 업로드

--- a/기획/API 명세서 v2 (SSE) 774222b0711e4db9a421ed770e45e621.csv
+++ b/기획/API 명세서 v2 (SSE) 774222b0711e4db9a421ed770e45e621.csv
@@ -161,6 +161,13 @@ AI 응답 피드백,,POST,Phase 2,,"Request Body:
   ""rating"": ""up""|""down"",
   ""comment"": ""string""|null }","Response (201 Created)
 { ""feedback_id"": ""uuid"", ""rating"", ""created_at"" }",/api/v1/feedback,,채팅,AI 응답에 피드백. 응답 품질 개선 데이터 수집용
+캘린더 이벤트 목록 조회,구현 완료,GET,Phase 1,"• time_min: ISO 8601 (기본: now)
+• time_max: ISO 8601 (기본: now+90d)
+• limit: 기본 50, 최대 250",,"{""items"": [{""event_id"", ""title"", ""start_time"", ""end_time"", ""location"", ""description"", ""calendar_link"", ""source"": ""localbiz""|""user""}], ""next_page_token"": ""...""|null}
+
+• 403: google_calendar_not_connected
+• 502: Google API 호출 실패",/api/v1/users/me/calendar/events,강민서,캘린더,OAuth 토큰으로 Google Calendar events.list 직접 조회. DB 미저장.
+캘린더 이벤트 삭제,구현 완료,DELETE,Phase 1,,,Response (204 No Content),/api/v1/users/me/calendar/events/{event_id},강민서,캘린더,Google Calendar에서 이벤트 삭제. FE 일정 탭 삭제 버튼 연동.
 이미지 업로드,진행중,POST,Phase 1,,"Request Body:
 multipart/form-data
 { file: 이미지 파일 (jpg/png/webp, 최대 10MB) }


### PR DESCRIPTION
closes #117

  ## #️⃣  작업 내용

  **캘린더 이벤트 조회/삭제 엔드포인트 신설**
  - `GET /api/v1/users/me/calendar/events` — Google Calendar 이벤트 목록 직접 조회 (time_min / time_max / limit
  파라미터 지원)
  - `DELETE /api/v1/users/me/calendar/events/{event_id}` — Google Calendar 이벤트 삭제
  - `extendedProperties.private.source = "localbiz"` 마킹 — FE에서 앱 생성 이벤트 필터링 가능

  **캘린더 응답 품질 개선**
  - 현재 시각(KST HH:MM) 프롬프트 반영 → "지금부터", "오늘 몇 시" 같은 표현 정확히 처리
  - 응답 텍스트에서 마크다운 `**` 강조 제거
  - 일정 추가 성공 응답에 종료 시간 표시
  - 종료 시간 미입력 시 "1시간으로 자동 설정했어요" 안내 문구 추가

  ## #️⃣  테스트 결과

  - `validate.sh` 전체 통과 (ruff / pyright / pytest / 기획 무결성 / plan 무결성)
  - 기획 문서(API 명세서 v2) 신규 엔드포인트 2개 반영 완료

  ## #️⃣  변경 사항 체크리스트

  - [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
  - [x] 문서를 작성하거나 수정했나요? (API 명세서 v2 CSV 업데이트)
  - [x] 코드 컨벤션에 따라 코드를 작성했나요?
  - [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

  ## #️⃣  리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google Calendar event retrieval with optional time range and result limit filtering
  * Calendar event deletion capability
  * Enhanced event information display including location and description
  * Improved event confirmation preview with auto-assigned end time indication

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->