### PR TITLE
fix: NMSLIB k-NN filter → post-filter 전환 (#122)

### DIFF
--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -155,24 +155,20 @@ async def _search_os(
     api_key: str,
     district: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    """places_vector k-NN 검색. district 있으면 필터 적용."""
+    """places_vector k-NN 검색. NMSLIB 엔진은 filter 미지원 → post-filter."""
     try:
         query_vector = await _embed_query_768d(query, api_key)
 
-        knn_params: dict[str, Any] = {"vector": query_vector, "k": _OS_TOP_K}
-        if district:
-            knn_params["filter"] = {"term": {"district": district}}
-
         body: dict[str, Any] = {
             "size": _OS_TOP_K,
-            "query": {"knn": {"embedding": knn_params}},
+            "query": {"knn": {"embedding": {"vector": query_vector, "k": _OS_TOP_K}}},
             "min_score": _OS_MIN_SCORE,
         }
 
         result = await os_client.search(index="places_vector", body=body)
         hits = result.get("hits", {}).get("hits", [])
 
-        return [
+        places = [
             {
                 "place_id": hit.get("_id", ""),
                 "name": hit.get("_source", {}).get("name", ""),
@@ -185,6 +181,10 @@ async def _search_os(
             }
             for hit in hits
         ]
+        if district:
+            filtered = [p for p in places if p.get("district") == district]
+            return filtered if filtered else places
+        return places
     except Exception:
         logger.exception("OS course search failed")
         return []

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -127,18 +127,11 @@ async def _search_os_places(
     try:
         query_vector = await _embed_query_768d(query, api_key)
 
-        knn_params: dict[str, Any] = {
-            "vector": query_vector,
-            "k": _OS_TOP_K,
-        }
-        if district:
-            knn_params["filter"] = {"term": {"district": district}}
-
         body: dict[str, Any] = {
             "size": _OS_TOP_K,
             "query": {
                 "knn": {
-                    "embedding": knn_params,
+                    "embedding": {"vector": query_vector, "k": _OS_TOP_K},
                 }
             },
             "min_score": _OS_MIN_SCORE,
@@ -162,6 +155,9 @@ async def _search_os_places(
                     "score": hit.get("_score", 0),
                 }
             )
+        if district:
+            filtered = [p for p in places if p.get("district") == district]
+            return filtered if filtered else places
         return places
 
     except Exception:

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -129,22 +129,15 @@ async def _search_os(
     api_key: str,
     district: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    """places_vector k-NN HNSW 검색. district 있으면 필터 적용."""
+    """places_vector k-NN HNSW 검색. NMSLIB 엔진은 filter 미지원 → post-filter."""
     try:
         query_vector = await _embed_query_768d(query, api_key)
-
-        knn_params: dict[str, Any] = {
-            "vector": query_vector,
-            "k": _OS_TOP_K,
-        }
-        if district:
-            knn_params["filter"] = {"term": {"district": district}}
 
         body: dict[str, Any] = {
             "size": _OS_TOP_K,
             "query": {
                 "knn": {
-                    "embedding": knn_params,
+                    "embedding": {"vector": query_vector, "k": _OS_TOP_K},
                 }
             },
             "min_score": _OS_MIN_SCORE,
@@ -168,6 +161,9 @@ async def _search_os(
                     "score": hit.get("_score", 0),
                 }
             )
+        if district:
+            filtered = [p for p in places if p.get("district") == district]
+            return filtered if filtered else places
         return places
 
     except Exception:


### PR DESCRIPTION
## Summary
- places_vector 인덱스(NMSLIB)가 k-NN filter 미지원 → 400 에러로 OS 검색 전부 실패
- `course_plan_node`, `place_search_node`, `place_recommend_node` 3개 노드 모두 post-filter로 전환
- district 매칭 0건이면 전체 결과 반환 (graceful degradation)

Closes #122

## Test plan
- [ ] "홍대 쇼핑 코스 짜줘" → GS25 단독이 아닌 복수 쇼핑 장소 반환
- [ ] "강남 카페 추천해줘" → 강남구 카페 위주 결과
- [ ] OS 검색 에러 로그 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search result availability when filtering by district. Searches now return broader results when no exact matches are found in the specified district, ensuring better access to relevant information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->