### PR TITLE
[Fix] DELETE 라우트 response_model=None 명시 — pytest collection 전체 실패 수정 

### DIFF
--- a/backend/src/api/calendar.py
+++ b/backend/src/api/calendar.py
@@ -125,7 +125,7 @@ async def list_calendar_events(
     )
 
 
-@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_calendar_event(
     event_id: str,
     user_id: int = Depends(get_current_user_id),


### PR DESCRIPTION
## Summary

- `src/api/calendar.py:128` DELETE 라우트 데코레이터에 `response_model=None` 추가
- FastAPI 0.115.4가 `-> None` 어노테이션을 `NoneType` 클래스(truthy)로 추론 → 204 바디 금지 assert가 import 시점에 발동 → pytest collection 전체 실패
- `response_model=None` 명시로 추론 스킵 → 195개 테스트 정상 수집

Closes #125

## Test plan

- [ ] `cd backend && venv/bin/python -c "import src.api.calendar"` — 에러 없음
- [ ] `venv/bin/python -m pytest -q --co` — 195 tests collected
- [ ] `./validate.sh` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar event deletion endpoint to properly return an empty response body when events are successfully deleted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->