### PR TITLE
feat(booking): 예약 연동 고도화 (#127)

### DIFF
--- a/backend/src/graph/booking_node.py
+++ b/backend/src/graph/booking_node.py
@@ -108,22 +108,20 @@ async def booking_node(state: AgentState) -> dict[str, Any]:
         category = (row["category"] if row else "") or "unknown"
         phone = row["phone"] if row else None
         logger.info(
-            "booking_node: place_id=%s category=%s check_in=%s check_out=%s",
-            place_id,
+            "booking_node: has_place_id=True category=%s has_dates=%s",
             category,
-            check_in_val,
-            check_out_val,
+            bool(check_in_val and check_out_val),
         )
+        logger.debug("booking_node: place_id=%s check_in=%s check_out=%s", place_id, check_in_val, check_out_val)
     else:
         # place_id 없으면 processed_query의 category 사용
         category = pq.get("category", "") or "unknown"
         logger.info(
-            "booking_node: place_name=%s category=%s check_in=%s check_out=%s (no place_id)",
-            place_name,
+            "booking_node: has_place_id=False category=%s has_dates=%s",
             category,
-            check_in_val,
-            check_out_val,
+            bool(check_in_val and check_out_val),
         )
+        logger.debug("booking_node: place_name=%s check_in=%s check_out=%s", place_name, check_in_val, check_out_val)
 
     # ── 카테고리별 딥링크 생성 ────────────────────────────────────────────
     try:
@@ -159,7 +157,10 @@ async def _build_links(
     has_dates = bool(pq.get("check_in") and pq.get("check_out"))
 
     if any(c in cat for c in _UNAVAILABLE_CATS):
-        return _build_unavailable_message(category)
+        raise _BookingError(
+            f"'{category}' 카테고리는 온라인 예약 연동을 지원하지 않아요. "
+            "해당 장소에 직접 문의하시거나 네이버/카카오맵에서 검색해 보세요."
+        )
     elif any(c in cat for c in _RESTAURANT_CATS):
         return await _build_restaurant_links(place_name, phone)
     elif any(c in cat for c in _ACCOMMODATION_CATS):
@@ -296,14 +297,6 @@ def _build_tourist_links(place_name: str) -> str:
         f"🌐 [구글 검색](https://www.google.com/search?q={encoded}+예약)",
     ]
     return "\n".join(lines)
-
-
-def _build_unavailable_message(category: str) -> str:
-    """예약 연동 미지원 카테고리 안내."""
-    return (
-        f"'{category}' 카테고리는 온라인 예약 연동을 지원하지 않아요. "
-        "해당 장소에 직접 문의하시거나 네이버/카카오맵에서 검색해 보세요."
-    )
 
 
 def _build_fallback_links(place_name: str) -> str:

--- a/backend/src/graph/booking_node.py
+++ b/backend/src/graph/booking_node.py
@@ -38,13 +38,16 @@ _places_cache: TTLCache = TTLCache(maxsize=500, ttl=3600)
 _GOOGLE_PLACES_URL = "https://places.googleapis.com/v1/places:searchText"
 
 # ---------------------------------------------------------------------------
-# 카테고리 분류 집합 — DB의 category 컬럼 값과 매핑
-# lower()로 소문자 변환 후 비교하므로 모두 소문자로 정의
+# 카테고리 분류 집합 — DB 18종 한글값 기준 + Gemini 추론값 alias 포함
+# any(c in cat for c in _CATS) 패턴으로 substring 매칭
 # ---------------------------------------------------------------------------
 _RESTAURANT_CATS = {"음식점", "카페", "주점", "restaurant", "cafe", "pub", "bar"}
-_ACCOMMODATION_CATS = {"숙박", "호텔", "모텔", "게스트하우스", "accommodation", "hotel"}
-_PUBLIC_CATS = {"공공시설", "공공", "public"}
-_CULTURAL_CATS = {"문화", "관광", "공연", "전시", "cultural", "tourist"}
+_ACCOMMODATION_CATS = {"숙박", "호텔", "모텔", "게스트하우스", "민박", "여관", "accommodation", "hotel"}
+_PUBLIC_CATS = {"공공시설", "공원", "체육시설", "도서관", "복지시설", "public", "sports", "park", "library"}
+_CULTURAL_CATS = {"문화시설", "문화", "공연", "전시", "영화관", "박물관", "미술관", "cultural"}
+_TOURIST_CATS = {"관광지", "관광", "tourist"}
+# 예약 연동 미지원 카테고리 — 안내 메시지만 반환
+_UNAVAILABLE_CATS = {"의료", "쇼핑", "미용", "뷰티", "주차장", "지하철역", "노래방"}
 
 
 # ---------------------------------------------------------------------------
@@ -74,22 +77,26 @@ async def booking_node(state: AgentState) -> dict[str, Any]:
     # ── 입력 검증 ──────────────────────────────────────────────────────────
     if not pq:
         logger.warning("booking_node: processed_query 없음")
-        return {"response_blocks": [_error_block("예약할 장소를 알 수 없습니다. 장소 이름을 포함해 말씀해 주세요.")]}
+        return {"response_blocks": [_ask_block("예약할 장소를 알 수 없습니다. 장소 이름을 포함해 말씀해 주세요.")]}
 
     place_name: str = pq.get("place_name", "").strip()
     if not place_name:
         logger.warning("booking_node: place_name 없음")
-        return {"response_blocks": [_error_block("예약할 장소 이름을 알려주세요. 예) '스타벅스 강남 예약해줘'")]}
+        return {"response_blocks": [_ask_block("예약할 장소 이름을 알려주세요. 예) '스타벅스 강남 예약해줘'")]}
 
     place_id: Optional[str] = pq.get("place_id")
     category: str = "unknown"
     phone: Optional[str] = None
 
     # ── place_id 있으면 캐시/DB 조회 ──────────────────────────────────────
+    check_in_val: str = pq.get("check_in") or ""
+    check_out_val: str = pq.get("check_out") or ""
+    cache_key = f"{place_id}:{check_in_val}:{check_out_val}" if place_id else ""
+
     if place_id:
-        if place_id in _places_cache:
+        if cache_key in _places_cache:
             logger.info("booking_node: cache hit place_id=%s", place_id)
-            return {"response_blocks": [_text_stream_block(_places_cache[place_id])]}
+            return {"response_blocks": [_text_stream_block(_places_cache[cache_key])]}
 
         # places 테이블에서 카테고리와 전화번호 조회 (불변식 #8: asyncpg $1 바인딩)
         pool = get_pool()
@@ -100,22 +107,34 @@ async def booking_node(state: AgentState) -> dict[str, Any]:
             )
         category = (row["category"] if row else "") or "unknown"
         phone = row["phone"] if row else None
-        logger.info("booking_node: place_id=%s category=%s", place_id, category)
+        logger.info(
+            "booking_node: place_id=%s category=%s check_in=%s check_out=%s",
+            place_id,
+            category,
+            check_in_val,
+            check_out_val,
+        )
     else:
         # place_id 없으면 processed_query의 category 사용
         category = pq.get("category", "") or "unknown"
-        logger.info("booking_node: place_name=%s category=%s (no place_id)", place_name, category)
+        logger.info(
+            "booking_node: place_name=%s category=%s check_in=%s check_out=%s (no place_id)",
+            place_name,
+            category,
+            check_in_val,
+            check_out_val,
+        )
 
     # ── 카테고리별 딥링크 생성 ────────────────────────────────────────────
     try:
         links_text = await _build_links(category, place_name, phone, pq)
     except _BookingError as e:
-        # 숙박 날짜 누락 등 — 캐시에 저장하지 않고 error 블록 반환
-        return {"response_blocks": [_error_block(str(e))]}
+        # 날짜 누락 등 — text_stream으로 안내 (error 블록은 FE에서 빈 메시지로 처리됨)
+        return {"response_blocks": [_ask_block(str(e))]}
 
     # ── 캐시 저장 후 반환 (place_id 있을 때만) ───────────────────────────
     if place_id:
-        _places_cache[place_id] = links_text
+        _places_cache[cache_key] = links_text
     return {"response_blocks": [_text_stream_block(links_text)]}
 
 
@@ -135,8 +154,13 @@ async def _build_links(
     """
     cat = category.lower()
 
-    # 카테고리 집합 중 하나라도 포함되면 해당 분기
-    if any(c in cat for c in _RESTAURANT_CATS):
+    # check_in/check_out 둘 다 있으면 관광지·unknown이라도 숙박으로 처리
+    # (DB에 관광지로 잘못 저장된 호텔 대응)
+    has_dates = bool(pq.get("check_in") and pq.get("check_out"))
+
+    if any(c in cat for c in _UNAVAILABLE_CATS):
+        return _build_unavailable_message(category)
+    elif any(c in cat for c in _RESTAURANT_CATS):
         return await _build_restaurant_links(place_name, phone)
     elif any(c in cat for c in _ACCOMMODATION_CATS):
         return _build_accommodation_links(place_name, pq)  # 날짜 없으면 raise
@@ -144,7 +168,13 @@ async def _build_links(
         return _build_public_links(place_name)
     elif any(c in cat for c in _CULTURAL_CATS):
         return _build_cultural_links(place_name)
+    elif any(c in cat for c in _TOURIST_CATS):
+        if has_dates:
+            return _build_accommodation_links(place_name, pq)
+        return _build_tourist_links(place_name)
     else:
+        if has_dates:
+            return _build_accommodation_links(place_name, pq)
         return _build_fallback_links(place_name)
 
 
@@ -250,10 +280,30 @@ def _build_cultural_links(place_name: str) -> str:
     encoded = quote(place_name, safe="")
     lines = [
         "🎭 **문화/공연 예약하기**\n",
-        f"🎫 [KOPIS](http://www.kopis.or.kr/search?query={encoded})",
+        f"🎫 [KOPIS](https://www.kopis.or.kr/search?query={encoded})",
         f"🎟️ [인터파크](https://ticket.interpark.com/search?query={encoded})",
     ]
     return "\n".join(lines)
+
+
+def _build_tourist_links(place_name: str) -> str:
+    """관광지 — 네이버/카카오/구글 검색 fallback."""
+    encoded = quote(place_name, safe="")
+    lines = [
+        "🗺️ **관광지 예약/입장 안내**\n",
+        f"🔵 [네이버 예약](https://booking.naver.com/search?query={encoded})",
+        f"🟡 [카카오맵](https://place.map.kakao.com/search?q={encoded})",
+        f"🌐 [구글 검색](https://www.google.com/search?q={encoded}+예약)",
+    ]
+    return "\n".join(lines)
+
+
+def _build_unavailable_message(category: str) -> str:
+    """예약 연동 미지원 카테고리 안내."""
+    return (
+        f"'{category}' 카테고리는 온라인 예약 연동을 지원하지 않아요. "
+        "해당 장소에 직접 문의하시거나 네이버/카카오맵에서 검색해 보세요."
+    )
 
 
 def _build_fallback_links(place_name: str) -> str:
@@ -287,6 +337,15 @@ def _text_stream_block(links_text: str) -> dict[str, Any]:
             "URL 주소는 절대 변경하거나 생략하지 마세요."
         ),
         "prompt": links_text,
+    }
+
+
+def _ask_block(message: str) -> dict[str, Any]:
+    """추가 정보 요청 text_stream 블록 — FE가 error 이벤트를 빈 메시지로 처리하므로 text_stream 사용."""
+    return {
+        "type": "text_stream",
+        "system": "사용자에게 필요한 정보를 친절하게 요청하세요. URL은 포함하지 마세요.",
+        "prompt": message,
     }
 
 

--- a/backend/tests/test_booking_node.py
+++ b/backend/tests/test_booking_node.py
@@ -57,12 +57,12 @@ async def test_place_name_only_returns_text_stream() -> None:
 
 @pytest.mark.asyncio
 async def test_missing_place_name_returns_error() -> None:
-    """place_name 없으면 error 블록 반환."""
+    """place_name 없으면 text_stream으로 안내 반환."""
     state = {"processed_query": {"place_id": "uuid-001", "place_name": ""}}
     result = await booking_node(state)  # type: ignore[arg-type]
 
     blocks = result["response_blocks"]
-    assert blocks[0]["type"] == "error"
+    assert blocks[0]["type"] == "text_stream"
 
 
 @pytest.mark.asyncio
@@ -149,8 +149,100 @@ async def test_accommodation_missing_dates_returns_error() -> None:
         result = await booking_node(state)  # type: ignore[arg-type]
 
     blocks = result["response_blocks"]
-    assert blocks[0]["type"] == "error"
-    assert "체크인" in blocks[0]["message"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "체크인" in blocks[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_tourist_category_returns_tourist_links() -> None:
+    """관광지 카테고리 → KOPIS 아닌 네이버/카카오/구글 링크."""
+    pool_mock = _make_pool_mock(category="관광지")
+
+    with (
+        patch("src.graph.booking_node.get_pool", return_value=pool_mock),
+        patch("src.graph.booking_node.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.google_places_api_key = ""
+
+        state = {"processed_query": {"place_id": "uuid-006", "place_name": "신라스테이 마포"}}
+        result = await booking_node(state)  # type: ignore[arg-type]
+
+    blocks = result["response_blocks"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "booking.naver.com" in blocks[0]["prompt"]
+    assert "kopis" not in blocks[0]["prompt"].lower()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_category_returns_text_stream() -> None:
+    """예약 불가 카테고리(의료) → text_stream 안내 메시지."""
+    pool_mock = _make_pool_mock(category="의료")
+
+    with (
+        patch("src.graph.booking_node.get_pool", return_value=pool_mock),
+        patch("src.graph.booking_node.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.google_places_api_key = ""
+
+        state = {"processed_query": {"place_id": "uuid-007", "place_name": "강남 내과"}}
+        result = await booking_node(state)  # type: ignore[arg-type]
+
+    blocks = result["response_blocks"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "의료" in blocks[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_accommodation_different_dates_different_cache() -> None:
+    """숙박 날짜 다르면 캐시 별도 저장 — 날짜 오염 없음."""
+    pool_mock = _make_pool_mock(category="숙박")
+
+    with (
+        patch("src.graph.booking_node.get_pool", return_value=pool_mock),
+        patch("src.graph.booking_node.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.google_places_api_key = ""
+
+        state_a = {
+            "processed_query": {
+                "place_id": "uuid-008",
+                "place_name": "롯데호텔",
+                "check_in": "2026-05-22",
+                "check_out": "2026-05-23",
+            }
+        }
+        state_b = {
+            "processed_query": {
+                "place_id": "uuid-008",
+                "place_name": "롯데호텔",
+                "check_in": "2026-06-10",
+                "check_out": "2026-06-12",
+            }
+        }
+        result_a = await booking_node(state_a)  # type: ignore[arg-type]
+        result_b = await booking_node(state_b)  # type: ignore[arg-type]
+
+    prompt_a = result_a["response_blocks"][0]["prompt"]
+    prompt_b = result_b["response_blocks"][0]["prompt"]
+    assert "2026-05-22" in prompt_a
+    assert "2026-06-10" in prompt_b
+    assert prompt_a != prompt_b
+
+
+@pytest.mark.asyncio
+async def test_accommodation_missing_checkin_returns_ask() -> None:
+    """check_in/check_out 둘 다 없으면 text_stream으로 날짜 요청."""
+    state = {
+        "processed_query": {
+            "place_name": "신라스테이 마포",
+            "category": "호텔",
+        }
+    }
+    result = await booking_node(state)  # type: ignore[arg-type]
+
+    blocks = result["response_blocks"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "체크인" in blocks[0]["prompt"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_booking_node.py
+++ b/backend/tests/test_booking_node.py
@@ -272,6 +272,33 @@ async def test_cache_hit_skips_google_places_api() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tourist_category_with_dates_returns_accommodation_links() -> None:
+    """관광지 카테고리 + 날짜 있음 → 숙박 예약 링크 (yanolja/goodchoice)."""
+    pool_mock = _make_pool_mock(category="관광지")
+
+    with (
+        patch("src.graph.booking_node.get_pool", return_value=pool_mock),
+        patch("src.graph.booking_node.get_settings") as mock_settings,
+    ):
+        mock_settings.return_value.google_places_api_key = ""
+
+        state = {
+            "processed_query": {
+                "place_id": "uuid-009",
+                "place_name": "신라스테이 마포",
+                "check_in": "2026-05-22",
+                "check_out": "2026-05-23",
+            }
+        }
+        result = await booking_node(state)  # type: ignore[arg-type]
+
+    blocks = result["response_blocks"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "yanolja.com" in blocks[0]["prompt"]
+    assert "goodchoice.kr" in blocks[0]["prompt"]
+
+
+@pytest.mark.asyncio
 async def test_unknown_category_returns_naver_fallback() -> None:
     """unknown 카테고리 → 네이버/카카오 fallback URL 포함."""
     pool_mock = _make_pool_mock(category="unknown")


### PR DESCRIPTION
## Summary

- error 블록 → text_stream 교체 (FE가 error 이벤트를 빈 메시지 처리하는 버그 수정)
- 카테고리 매핑 DB 18종 한글값 기준으로 정리 (`_TOURIST_CATS` 분리, `_UNAVAILABLE_CATS` 신규)
- 관광지 카테고리 + 날짜 있으면 숙박으로 처리 (DB 오분류 호텔 대응)
- 체육시설/공원/도서관/복지시설 → 서울시 공공서비스예약 연결
- 숙박 캐시 키에 check_in/check_out 포함 (날짜 오염 방지)
- KOPIS URL http → https 수정
- 시나리오 테스트 4개 추가 (총 12개)
- [CodeRabbit] INFO 로그 민감값(place_name, check_in, check_out) → DEBUG 격하, 불리언 지표만 INFO 유지
- [CodeRabbit] `_UNAVAILABLE_CATS` → `_BookingError` raise로 `_ask_block` 경로 통일 (`_build_unavailable_message` 제거)
- [CodeRabbit] 관광지 + 날짜 → 숙박 링크 테스트 케이스 추가

Closes #127

## Test plan

- [ ] `./validate.sh` 전체 통과 (12 tests)
- [ ] 숙박 날짜 누락 시 채팅창에 날짜 재요청 메시지 표시 확인
- [ ] 관광지 카테고리 호텔 + 날짜 있을 때 야놀자/여기어때 링크 확인
- [ ] 의료/쇼핑 예약 요청 시 안내 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)