### PR TITLE
[Fix] CD 파이프라인 복구 — SSH timeout + 배포 품질 개선 (#130)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,63 +4,93 @@ on:
   push:
     branches: [dev]
 
+permissions:
+  contents: read
+  id-token: write  # WIF OIDC 토큰 발급에 필요
+
+env:
+  GCE_INSTANCE: localbiz-api
+  GCE_ZONE: asia-northeast3-a
+  PROJECT_ID: project-e9a9c8f2-70da-411d-a51
+  WIF_PROVIDER: projects/124882044304/locations/global/workloadIdentityPools/github-actions/providers/github-repo
+  SA_EMAIL: github-deploy@project-e9a9c8f2-70da-411d-a51.iam.gserviceaccount.com
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+      # ① GCP 인증 (WIF — SSH key 불필요)
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
         with:
-          host: ${{ secrets.GCE_HOST }}
-          username: ${{ secrets.GCE_USER }}
-          key: ${{ secrets.GCE_SSH_PRIVATE_KEY }}
-          timeout: 60s
-          command_timeout: 5m
-          script: |
-            set -euo pipefail
-            cd ~/LocalBiz-Seoul
-            git fetch origin dev
-            git checkout dev
-            git pull origin dev
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.SA_EMAIL }}
 
-            # .env 시크릿 갱신
-            _upsert_env() { local k="$1" v="$2" f="backend/.env"; local escaped; escaped=$(printf '%s\n' "$v" | sed 's/[&/\]/\\&/g'); grep -q "^${k}=" "$f" 2>/dev/null && sed -i "s|^${k}=.*|${k}=${escaped}|" "$f" || echo "${k}=${v}" >> "$f"; }
-            _upsert_env "GOOGLE_CALENDAR_CLIENT_ID" "${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}"
-            _upsert_env "GOOGLE_CALENDAR_CLIENT_SECRET" "${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}"
-            _upsert_env "GOOGLE_CALENDAR_REDIRECT_URI" "${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}"
-            _upsert_env "GCS_BUCKET_NAME" "${{ secrets.GCS_BUCKET_NAME }}"
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
 
-            # Docker 공식 apt repo 등록 + Compose V2 설치 (1회성)
-            if ! docker compose version > /dev/null 2>&1; then
-              . /etc/os-release
-              DISTRO="$ID"
-              sudo install -m 0755 -d /etc/apt/keyrings
-              sudo curl -fsSL "https://download.docker.com/linux/${DISTRO}/gpg" -o /etc/apt/keyrings/docker.asc
-              sudo chmod a+r /etc/apt/keyrings/docker.asc
-              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${DISTRO} ${VERSION_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-              sudo apt-get update -qq
-              sudo apt-get install -y -qq docker-compose-plugin
-              docker compose version
+      # ② 배포 스크립트를 gcloud compute ssh로 실행
+      - name: Deploy via gcloud SSH
+        run: |
+          gcloud compute ssh ${{ env.GCE_INSTANCE }} \
+            --zone=${{ env.GCE_ZONE }} \
+            --project=${{ env.PROJECT_ID }} \
+            --command="$(cat <<'DEPLOY_SCRIPT'
+          set -euo pipefail
+          cd ~/LocalBiz-Seoul
+          git fetch origin dev
+          git checkout dev
+          git pull origin dev
+
+          cd backend
+
+          # .env 시크릿 갱신 (awk 방식 — sed 특수문자 문제 해결)
+          ENV_FILE=".env"
+          for pair in \
+            "GOOGLE_CALENDAR_CLIENT_ID=$GOOGLE_CALENDAR_CLIENT_ID" \
+            "GOOGLE_CALENDAR_CLIENT_SECRET=$GOOGLE_CALENDAR_CLIENT_SECRET" \
+            "GOOGLE_CALENDAR_REDIRECT_URI=$GOOGLE_CALENDAR_REDIRECT_URI" \
+            "GCS_BUCKET_NAME=$GCS_BUCKET_NAME"; do
+            key="${pair%%=*}"
+            value="${pair#*=}"
+            if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+              awk -v k="$key" -v v="$value" 'BEGIN{FS=OFS="="} $1==k{$2=v}{print}' "$ENV_FILE" > "${ENV_FILE}.tmp"
+              mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            else
+              echo "${key}=${value}" >> "$ENV_FILE"
             fi
+          done
 
-            # 기존 서비스 정리 — systemd(bare VM) 또는 이전 Docker 컨테이너
-            sudo systemctl stop localbiz-api 2>/dev/null || true
-            sudo systemctl disable localbiz-api 2>/dev/null || true
-            cd backend
-            docker compose down 2>/dev/null || true
+          # 롤백용 현재 이미지 ID 저장
+          PREV_IMAGE=$(docker inspect --format='{{.Image}}' backend-api-1 2>/dev/null || echo "")
 
-            # Docker 빌드 + 시작 (DB 컨테이너 제외 — 프로덕션은 Cloud SQL + 별도 GCE OpenSearch)
-            docker compose build api
+          # Docker 빌드 + 시작
+          docker compose build api
+          docker compose up -d --no-deps api
+
+          # 헬스체크 (최대 60초)
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "Health check passed"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          # 헬스체크 실패 → 롤백
+          echo "Health check failed — rolling back"
+          docker compose logs --tail=50 api
+          if [ -n "$PREV_IMAGE" ]; then
+            docker tag "$PREV_IMAGE" backend-api:rollback
+            docker compose down api 2>/dev/null || true
             docker compose up -d --no-deps api
-
-            # 헬스체크 대기 (최대 60초)
-            for i in $(seq 1 30); do
-              if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
-                echo "Health check passed"
-                exit 0
-              fi
-              sleep 2
-            done
-            echo "Health check failed after 60s"
-            docker compose logs --tail=50 api
-            exit 1
+            echo "Rolled back to previous image"
+          fi
+          exit 1
+          DEPLOY_SCRIPT
+          )"
+        env:
+          GOOGLE_CALENDAR_CLIENT_ID: ${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}
+          GOOGLE_CALENDAR_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}
+          GOOGLE_CALENDAR_REDIRECT_URI: ${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}
+          GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,56 +62,15 @@ jobs:
       - name: Apply DB migrations (init_db.sql + users v2 schema)
         working-directory: backend
         run: |
-          # 1) init_db.sql 적용 (v1 스키마 — users는 v1, 의존 테이블은 v1 PK 타입)
+          # 1) init_db.sql 적용 (v1 스키마)
           PGPASSWORD=localbiz psql -h localhost -U localbiz -d localbiz \
             -v ON_ERROR_STOP=1 \
             -f scripts/init_db.sql
 
-          # 2) users v1→v2 마이그레이션 (FK 우회 패턴, ERD v6.3 §6 정합)
+          # 2) users v1→v2 마이그레이션
           PGPASSWORD=localbiz psql -h localhost -U localbiz -d localbiz \
-            -v ON_ERROR_STOP=1 << 'SQL'
-          BEGIN;
-
-          -- FK 제거 (의존 테이블 보존)
-          ALTER TABLE user_favorites DROP CONSTRAINT IF EXISTS user_favorites_user_id_fkey;
-          ALTER TABLE reviews        DROP CONSTRAINT IF EXISTS reviews_user_id_fkey;
-          ALTER TABLE conversations  DROP CONSTRAINT IF EXISTS conversations_user_id_fkey;
-
-          -- 의존 컬럼 UUID → BIGINT (data 0 row이므로 USING NULL 안전)
-          ALTER TABLE user_favorites ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
-          ALTER TABLE reviews        ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
-          ALTER TABLE conversations  ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
-
-          -- users v1 DROP + v2 CREATE (ERD v6.3 §6 + 19 불변식 #15)
-          DROP TABLE users;
-          CREATE TABLE users (
-              user_id          BIGSERIAL PRIMARY KEY,
-              email            VARCHAR(200) NOT NULL UNIQUE,
-              password_hash    VARCHAR(200),
-              auth_provider    VARCHAR(20) NOT NULL DEFAULT 'email',
-              google_id        VARCHAR(100) UNIQUE,
-              nickname         VARCHAR(100),
-              created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              is_deleted       BOOLEAN NOT NULL DEFAULT FALSE,
-              CONSTRAINT users_auth_provider_chk CHECK (auth_provider IN ('email','google')),
-              CONSTRAINT users_email_or_google_chk CHECK (
-                  (auth_provider='email'  AND password_hash IS NOT NULL AND google_id IS NULL) OR
-                  (auth_provider='google' AND password_hash IS NULL     AND google_id IS NOT NULL)
-              )
-          );
-          CREATE INDEX users_email_idx ON users(email) WHERE is_deleted = FALSE;
-
-          -- FK 재설정 (운영 ERD 정합)
-          ALTER TABLE user_favorites ADD CONSTRAINT user_favorites_user_id_fkey
-              FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE;
-          ALTER TABLE reviews        ADD CONSTRAINT reviews_user_id_fkey
-              FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE SET NULL;
-          ALTER TABLE conversations  ADD CONSTRAINT conversations_user_id_fkey
-              FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE;
-
-          COMMIT;
-          SQL
+            -v ON_ERROR_STOP=1 \
+            -f scripts/migrate_users_v2.sql
 
       - name: Run validate.sh (6 stages)
         run: ./validate.sh
@@ -120,12 +79,5 @@ jobs:
         run: |
           if grep -l "/Users/ijeong/Desktop" .claude/hooks/*.sh .claude/settings.json validate.sh 2>/dev/null; then
             echo "::error::Absolute path leaked in shared hooks/settings — must use \$CLAUDE_PROJECT_DIR or \$PROJECT_ROOT"
-            exit 1
-          fi
-
-      - name: Check .sisyphus/state/ not committed (gitignore enforcement)
-        run: |
-          if git ls-files .sisyphus/state/ 2>/dev/null | grep -v ".gitkeep"; then
-            echo "::error::.sisyphus/state/ has tracked files — should be gitignored"
             exit 1
           fi

--- a/backend/scripts/migrate_users_v2.sql
+++ b/backend/scripts/migrate_users_v2.sql
@@ -1,0 +1,42 @@
+-- users v1→v2 마이그레이션 (FK 우회 패턴, ERD v6.3 §6 정합)
+BEGIN;
+
+-- FK 제거 (의존 테이블 보존)
+ALTER TABLE user_favorites DROP CONSTRAINT IF EXISTS user_favorites_user_id_fkey;
+ALTER TABLE reviews        DROP CONSTRAINT IF EXISTS reviews_user_id_fkey;
+ALTER TABLE conversations  DROP CONSTRAINT IF EXISTS conversations_user_id_fkey;
+
+-- 의존 컬럼 UUID → BIGINT (data 0 row이므로 USING NULL 안전)
+ALTER TABLE user_favorites ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
+ALTER TABLE reviews        ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
+ALTER TABLE conversations  ALTER COLUMN user_id TYPE BIGINT USING NULL::bigint;
+
+-- users v1 DROP + v2 CREATE (ERD v6.3 §6 + 19 불변식 #15)
+DROP TABLE users;
+CREATE TABLE users (
+    user_id          BIGSERIAL PRIMARY KEY,
+    email            VARCHAR(200) NOT NULL UNIQUE,
+    password_hash    VARCHAR(200),
+    auth_provider    VARCHAR(20) NOT NULL DEFAULT 'email',
+    google_id        VARCHAR(100) UNIQUE,
+    nickname         VARCHAR(100),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    is_deleted       BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT users_auth_provider_chk CHECK (auth_provider IN ('email','google')),
+    CONSTRAINT users_email_or_google_chk CHECK (
+        (auth_provider='email'  AND password_hash IS NOT NULL AND google_id IS NULL) OR
+        (auth_provider='google' AND password_hash IS NULL     AND google_id IS NOT NULL)
+    )
+);
+CREATE INDEX users_email_idx ON users(email) WHERE is_deleted = FALSE;
+
+-- FK 재설정 (운영 ERD 정합)
+ALTER TABLE user_favorites ADD CONSTRAINT user_favorites_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE;
+ALTER TABLE reviews        ADD CONSTRAINT reviews_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE SET NULL;
+ALTER TABLE conversations  ADD CONSTRAINT conversations_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #130

## #️⃣ 작업 내용

> **deploy-dev.yml 전면 재작성**
> - [C1] `appleboy/ssh-action` + SSH key → Workload Identity Federation + `gcloud compute ssh` 전환
> - [H1] `_upsert_env` sed 치환 → `awk` 기반 안전한 env 교체
> - [M1] 헬스체크 실패 시 이전 이미지로 롤백 로직 추가
> - [M3] Docker Compose V2 설치 블록 제거 (서버에 이미 설치됨)
>
> **validate.yml 개선**
> - [M2] 인라인 SQL 42줄 → `scripts/migrate_users_v2.sql` 파일 분리
> - [L1] 미사용 `.sisyphus/state/` 체크 step 제거

## #️⃣ 테스트 결과

> CI validate 통과 확인 필요. CD는 머지 후 자동 배포로 검증.

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료

> - SSH timeout 원인: GCE 에페머럴 IP 변경 (`34.22.91.75` → `34.50.44.75`)
> - WIF 설정: Pool `github-actions`, Provider `github-repo`, SA `github-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)