### PR TITLE
[Feat] 멀티턴 대화 컨텍스트 보강 + REFINE Intent 구현 (#138)

### DIFF
--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -130,10 +130,10 @@ async def _ensure_conversation(pool: Any, thread_id: str, user_id: int) -> None:
 
 
 async def _load_recent_history(pool: Any, thread_id: str) -> list[dict[str, str]]:
-    """intent 분류용 최근 대화 이력 조회 (최근 6턴)."""
+    """최근 대화 이력 조회 (최근 10메시지 = 5턴). 구조화 블록 요약 포함."""
     try:
         rows = await pool.fetch(
-            "SELECT role, blocks FROM messages WHERE thread_id = $1 ORDER BY message_id DESC LIMIT 6",
+            "SELECT role, blocks FROM messages WHERE thread_id = $1 ORDER BY message_id DESC LIMIT 10",
             thread_id,
         )
     except Exception:
@@ -158,6 +158,34 @@ async def _load_recent_history(pool: Any, thread_id: str) -> list[dict[str, str]
                 parts.append(block.get("content", ""))
             elif btype == "text_stream" and role == "assistant":
                 parts.append(block.get("content", ""))
+            elif btype == "places" and role == "assistant":
+                items = block.get("items", [])
+                names = [it.get("name", "") for it in items if isinstance(it, dict) and it.get("name")]
+                if names:
+                    parts.append(f"[장소 {len(names)}건: {', '.join(names[:5])}]")
+            elif btype == "events" and role == "assistant":
+                items = block.get("items", [])
+                titles = [it.get("title", "") for it in items if isinstance(it, dict) and it.get("title")]
+                if titles:
+                    parts.append(f"[행사 {len(titles)}건: {', '.join(titles[:5])}]")
+            elif btype == "course" and role == "assistant":
+                title = block.get("title", "")
+                stops = block.get("stops", [])
+                stop_names = []
+                for stop in stops:
+                    if isinstance(stop, dict):
+                        place = stop.get("place", {})
+                        name = place.get("name", "") if isinstance(place, dict) else ""
+                        if name:
+                            stop_names.append(name)
+                label = title or "코스"
+                if stop_names:
+                    parts.append(f"[{label} ({len(stop_names)}곳): {', '.join(stop_names)}]")
+            elif btype == "chart" and role == "assistant":
+                chart_places = block.get("places", [])
+                cnames = [cp.get("name", "") for cp in chart_places if isinstance(cp, dict) and cp.get("name")]
+                if cnames:
+                    parts.append(f"[비교: {' vs '.join(cnames[:3])}]")
         content = " ".join(p for p in parts if p).strip()
         if content:
             history.append({"role": role, "content": content})
@@ -188,8 +216,12 @@ async def _insert_message(
 # ---------------------------------------------------------------------------
 # Gemini 토큰 스트리밍
 # ---------------------------------------------------------------------------
-async def _stream_gemini(system_prompt: str, user_prompt: str) -> AsyncIterator[str]:
-    """Gemini 2.5 Flash로 토큰 단위 스트리밍.
+async def _stream_gemini(
+    system_prompt: str,
+    user_prompt: str,
+    conversation_history: Optional[list[dict[str, str]]] = None,
+) -> AsyncIterator[str]:
+    """Gemini 2.5 Flash로 토큰 단위 스트리밍. 대화 이력 포함.
 
     Yields:
         각 토큰 문자열 (delta).
@@ -206,8 +238,16 @@ async def _stream_gemini(system_prompt: str, user_prompt: str) -> AsyncIterator[
 
     messages: list[tuple[str, str]] = [
         ("system", system_prompt),
-        ("human", user_prompt),
     ]
+
+    if conversation_history:
+        for msg in conversation_history[-5:]:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            lc_role = "human" if role == "user" else "ai"
+            messages.append((lc_role, content))
+
+    messages.append(("human", user_prompt))
 
     async for chunk in llm.astream(messages):
         content = chunk.content
@@ -341,7 +381,7 @@ async def chat_stream(
                     "query": sub_query,
                     "thread_id": thread_id,
                     "user_id": user_id,
-                    "conversation_history": [],
+                    "conversation_history": conversation_history,
                 }
                 # intent 주입 → intent_router_node가 classify 스킵
                 if intent_value:
@@ -380,7 +420,7 @@ async def chat_stream(
                                 full_text = ""
 
                                 try:
-                                    async for delta in _stream_gemini(system_prompt, user_prompt):
+                                    async for delta in _stream_gemini(system_prompt, user_prompt, conversation_history):
                                         if await request.is_disconnected():
                                             cancelled = True
                                             break

--- a/backend/src/graph/cost_estimate_node.py
+++ b/backend/src/graph/cost_estimate_node.py
@@ -143,6 +143,21 @@ def _build_prompt(
     return "\n".join(lines)
 
 
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """COST_ESTIMATE refinement — 조건 변경 시 전체 재실행."""
+    if refinement.get("action") == "change_condition" and refinement.get("new_condition"):
+        state = dict(state)
+        state["query"] = refinement["new_condition"]
+    state = dict(state)
+    state["previous_blocks"] = None
+    state["refinement"] = None
+    return await cost_estimate_node(state)
+
+
 async def cost_estimate_node(state: dict[str, Any]) -> dict[str, Any]:
     """COST_ESTIMATE 노드 — 비용 견적 text_stream 블록 반환.
 
@@ -152,6 +167,11 @@ async def cost_estimate_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [text_stream]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings  # pyright: ignore[reportMissingImports]
 
     query: str = state.get("query", "")

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -659,6 +659,121 @@ def _build_blocks(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """COURSE_PLAN refinement 처리 — 이전 코스 기반 수정."""
+    if state.get("_refine_depth", 0) > 1:
+        clean = dict(state)
+        clean["previous_blocks"] = None
+        clean["refinement"] = None
+        return await course_plan_node(clean)
+
+    from src.graph.refine_helpers import (  # pyright: ignore[reportMissingImports]
+        apply_add,
+        apply_remove,
+        apply_replace,
+        extract_items_from_blocks,
+    )
+
+    action = refinement.get("action", "regenerate")
+    target_index = refinement.get("target_index")
+    query = state.get("query", "")
+
+    if action in ("regenerate", "change_condition"):
+        if action == "change_condition":
+            new_q = refinement.get("new_condition", query)
+            state = dict(state)
+            state["query"] = new_q
+            state["previous_blocks"] = None
+            state["refinement"] = None
+        return await course_plan_node(state)
+
+    prev_stops = extract_items_from_blocks(previous_blocks, "course")
+    if not prev_stops:
+        return await course_plan_node(state)
+
+    if action == "remove" and target_index is not None:
+        stops = apply_remove(prev_stops, target_index)
+        for i, stop in enumerate(stops, 1):
+            if isinstance(stop, dict):
+                stop["order"] = i
+    elif action in ("replace", "add"):
+        clean_state = dict(state)
+        clean_state["previous_blocks"] = None
+        clean_state["refinement"] = None
+        if action == "replace" and refinement.get("new_condition"):
+            clean_state["query"] = refinement["new_condition"]
+        result = await course_plan_node(clean_state)
+        new_blocks = result.get("response_blocks", [])
+        new_stops = extract_items_from_blocks(new_blocks, "course")
+
+        existing_ids = set()
+        for s in prev_stops:
+            if isinstance(s, dict):
+                p = s.get("place", {})
+                pid = p.get("place_id", "") if isinstance(p, dict) else ""
+                if pid:
+                    existing_ids.add(pid)
+
+        new_candidates = []
+        for s in new_stops:
+            if isinstance(s, dict):
+                p = s.get("place", {})
+                pid = p.get("place_id", "") if isinstance(p, dict) else ""
+                if pid and pid not in existing_ids:
+                    new_candidates.append(s)
+
+        if not new_candidates:
+            stops = prev_stops
+        elif action == "replace" and target_index is not None:
+            stops = apply_replace(prev_stops, target_index, new_candidates[0])
+        else:
+            stops = apply_add(prev_stops, new_candidates[0])
+
+        for i, stop in enumerate(stops, 1):
+            if isinstance(stop, dict):
+                stop["order"] = i
+    else:
+        stops = prev_stops
+
+    course_meta: dict[str, Any] = {}
+    for block in previous_blocks:
+        if isinstance(block, dict) and block.get("type") == "course":
+            course_meta = {
+                "course_id": block.get("course_id"),
+                "title": block.get("title"),
+                "description": block.get("description"),
+            }
+            break
+
+    course_block: dict[str, Any] = {
+        "type": "course",
+        "stops": stops,
+        **course_meta,
+    }
+
+    stop_names = []
+    for s in stops:
+        if isinstance(s, dict):
+            p = s.get("place", {})
+            name = p.get("name", "") if isinstance(p, dict) else ""
+            if name:
+                stop_names.append(name)
+
+    result_summary = ", ".join(stop_names)
+    prompt = (
+        f"사용자 요청: {query}\n\n수정된 코스: {result_summary}\n\n코스 전체의 테마와 매력을 2-3문장으로 요약해주세요."
+    )
+    blocks: list[dict[str, Any]] = [
+        {"type": "text_stream", "system": _COURSE_SYSTEM_PROMPT, "prompt": prompt},
+        course_block,
+    ]
+    return {"response_blocks": blocks}
+
+
 async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
     """COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
 
@@ -668,6 +783,11 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [text_stream, course, map_route]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings
     from src.db.opensearch import get_os_client
     from src.db.postgres import get_pool

--- a/backend/src/graph/event_recommend_node.py
+++ b/backend/src/graph/event_recommend_node.py
@@ -635,6 +635,74 @@ def _build_blocks(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """EVENT_RECOMMEND refinement 처리 — 이전 결과 기반 수정."""
+    if state.get("_refine_depth", 0) > 1:
+        clean = dict(state)
+        clean["previous_blocks"] = None
+        clean["refinement"] = None
+        return await event_recommend_node(clean)
+
+    from src.graph.refine_helpers import (  # pyright: ignore[reportMissingImports]
+        apply_add,
+        apply_remove,
+        apply_replace,
+        extract_items_from_blocks,
+    )
+
+    action = refinement.get("action", "regenerate")
+    target_index = refinement.get("target_index")
+    query = state.get("query", "")
+
+    if action in ("regenerate", "change_condition"):
+        if action == "change_condition":
+            new_q = refinement.get("new_condition", query)
+            state = dict(state)
+            state["query"] = new_q
+            state["previous_blocks"] = None
+            state["refinement"] = None
+        return await event_recommend_node(state)
+
+    prev_items = extract_items_from_blocks(previous_blocks, "events")
+    if not prev_items:
+        return await event_recommend_node(state)
+
+    if action == "remove" and target_index is not None:
+        items = apply_remove(prev_items, target_index)
+    elif action in ("replace", "add"):
+        clean_state = dict(state)
+        clean_state["previous_blocks"] = None
+        clean_state["refinement"] = None
+        if action == "replace" and refinement.get("new_condition"):
+            clean_state["query"] = refinement["new_condition"]
+        result = await event_recommend_node(clean_state)
+        new_blocks = result.get("response_blocks", [])
+        new_items = extract_items_from_blocks(new_blocks, "events")
+        existing_ids = {it.get("event_id", "") for it in prev_items if isinstance(it, dict)}
+        new_candidates = [it for it in new_items if it.get("event_id", "") not in existing_ids]
+
+        if not new_candidates:
+            items = prev_items
+        elif action == "replace" and target_index is not None:
+            items = apply_replace(prev_items, target_index, new_candidates[0])
+        else:
+            items = apply_add(prev_items, new_candidates[0])
+    else:
+        items = prev_items
+
+    blocks: list[dict[str, Any]] = []
+    if items:
+        blocks.append({"type": "events", "items": items, "total_count": len(items)})
+    result_summary = "\n".join(f"- {r.get('title', '')}" for r in items)
+    prompt = f"사용자 요청: {query}\n\n수정된 행사 추천 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
+    blocks.append({"type": "text_stream", "system": _EVENT_RECOMMEND_SYSTEM_PROMPT, "prompt": prompt})
+    return {"response_blocks": blocks}
+
+
 async def event_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     """EVENT_RECOMMEND 노드 — PG 정형 + OS k-NN + LLM Rerank 행사 추천 (Phase 1).
 
@@ -644,6 +712,11 @@ async def event_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [events, text_stream, references?]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings  # pyright: ignore[reportMissingImports]
     from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]

--- a/backend/src/graph/event_search_node.py
+++ b/backend/src/graph/event_search_node.py
@@ -629,6 +629,74 @@ def _build_blocks(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """EVENT_SEARCH refinement 처리 — 이전 결과 기반 수정."""
+    if state.get("_refine_depth", 0) > 1:
+        clean = dict(state)
+        clean["previous_blocks"] = None
+        clean["refinement"] = None
+        return await event_search_node(clean)
+
+    from src.graph.refine_helpers import (  # pyright: ignore[reportMissingImports]
+        apply_add,
+        apply_remove,
+        apply_replace,
+        extract_items_from_blocks,
+    )
+
+    action = refinement.get("action", "regenerate")
+    target_index = refinement.get("target_index")
+    query = state.get("query", "")
+
+    if action in ("regenerate", "change_condition"):
+        if action == "change_condition":
+            new_q = refinement.get("new_condition", query)
+            state = dict(state)
+            state["query"] = new_q
+            state["previous_blocks"] = None
+            state["refinement"] = None
+        return await event_search_node(state)
+
+    prev_items = extract_items_from_blocks(previous_blocks, "events")
+    if not prev_items:
+        return await event_search_node(state)
+
+    if action == "remove" and target_index is not None:
+        items = apply_remove(prev_items, target_index)
+    elif action in ("replace", "add"):
+        clean_state = dict(state)
+        clean_state["previous_blocks"] = None
+        clean_state["refinement"] = None
+        if action == "replace" and refinement.get("new_condition"):
+            clean_state["query"] = refinement["new_condition"]
+        result = await event_search_node(clean_state)
+        new_blocks = result.get("response_blocks", [])
+        new_items = extract_items_from_blocks(new_blocks, "events")
+        existing_ids = {it.get("event_id", "") for it in prev_items if isinstance(it, dict)}
+        new_candidates = [it for it in new_items if it.get("event_id", "") not in existing_ids]
+
+        if not new_candidates:
+            items = prev_items
+        elif action == "replace" and target_index is not None:
+            items = apply_replace(prev_items, target_index, new_candidates[0])
+        else:
+            items = apply_add(prev_items, new_candidates[0])
+    else:
+        items = prev_items
+
+    blocks: list[dict[str, Any]] = []
+    if items:
+        blocks.append({"type": "events", "items": items, "total_count": len(items)})
+    result_summary = "\n".join(f"- {r.get('title', '')}" for r in items)
+    prompt = f"사용자 요청: {query}\n\n수정된 행사 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
+    blocks.append({"type": "text_stream", "system": _EVENT_SEARCH_SYSTEM_PROMPT, "prompt": prompt})
+    return {"response_blocks": blocks}
+
+
 async def event_search_node(state: dict[str, Any]) -> dict[str, Any]:
     """EVENT_SEARCH 노드 — PG 정형 + OS k-NN + LLM Rerank 행사 검색 (Phase 1).
 
@@ -638,6 +706,11 @@ async def event_search_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [events, text_stream, references?]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings  # pyright: ignore[reportMissingImports]
     from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -32,6 +32,7 @@ class IntentType(StrEnum):  # pyright: ignore[reportAttributeAccessIssue]
     COST_ESTIMATE = "COST_ESTIMATE"
     CROWDEDNESS = "CROWDEDNESS"
     IMAGE_SEARCH = "IMAGE_SEARCH"
+    REFINE = "REFINE"
     # Fallback
     GENERAL = "GENERAL"
 
@@ -51,6 +52,7 @@ PHASE1_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportAssi
         IntentType.REVIEW_COMPARE,
         IntentType.CROWDEDNESS,
         IntentType.IMAGE_SEARCH,
+        IntentType.REFINE,
         IntentType.ANALYSIS,
         IntentType.COST_ESTIMATE,
         IntentType.GENERAL,
@@ -72,6 +74,7 @@ _ROUTABLE_INTENTS: frozenset[IntentType] = frozenset(  # pyright: ignore[reportA
         IntentType.REVIEW_COMPARE,
         IntentType.CROWDEDNESS,
         IntentType.IMAGE_SEARCH,
+        IntentType.REFINE,
         IntentType.ANALYSIS,
         IntentType.COST_ESTIMATE,
         IntentType.GENERAL,
@@ -100,6 +103,7 @@ Phase 1 (active):
 - CROWDEDNESS: asking about current crowdedness or population density of an area
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL (http/https link ending in image extension or storage URL) to identify a place or find similar places; also when user refers to a previously sent image ("아까 그 사진", "방금 올린 이미지", "그 사진 어딘지", "이전 사진") without a new URL
+- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘"
 - GENERAL: general conversation, greetings, or anything else
 
 Phase 2 (not yet active, classify as GENERAL for now):
@@ -126,6 +130,7 @@ Phase 1 (active):
 - REVIEW_COMPARE: comparing two or more places by 6 metrics
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL to identify a place or find similar places; also when user refers to a previously sent image without a new URL
+- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘"
 - GENERAL: general conversation, greetings, or anything else
 
 Phase 2 (not yet active, classify as GENERAL for now):

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -520,6 +520,116 @@ def _build_blocks(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """PLACE_RECOMMEND refinement 처리 — 이전 결과 기반 수정."""
+    if state.get("_refine_depth", 0) > 1:
+        clean = dict(state)
+        clean["previous_blocks"] = None
+        clean["refinement"] = None
+        return await place_recommend_node(clean)
+
+    from src.config import get_settings  # pyright: ignore[reportMissingImports]
+    from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
+    from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+    from src.graph.refine_helpers import (  # pyright: ignore[reportMissingImports]
+        apply_add,
+        apply_remove,
+        apply_replace,
+        extract_excluded_ids,
+        extract_items_from_blocks,
+        get_refinement_search_query,
+    )
+
+    action = refinement.get("action", "regenerate")
+    target_index = refinement.get("target_index")
+    query = state.get("query", "")
+    pq = state.get("processed_query") or {}
+
+    if action in ("regenerate", "change_condition"):
+        if action == "change_condition":
+            new_q = refinement.get("new_condition", query)
+            state = dict(state)
+            state["query"] = new_q
+            state["previous_blocks"] = None
+            state["refinement"] = None
+        return await place_recommend_node(state)
+
+    prev_items = extract_items_from_blocks(previous_blocks, "places")
+    if not prev_items:
+        return await place_recommend_node(state)
+
+    settings = get_settings()
+
+    if action == "remove" and target_index is not None:
+        items = apply_remove(prev_items, target_index)
+    elif action in ("replace", "add"):
+        search_query = get_refinement_search_query(refinement, pq, query)
+        district = pq.get("district")
+        category = pq.get("category")
+        keywords = pq.get("keywords", [])
+        neighborhood = pq.get("neighborhood")
+
+        pool = get_pool()
+        pg_results = await _search_pg(pool, district, category, keywords, neighborhood)
+
+        os_results: list[dict[str, Any]] = []
+        if settings.gemini_llm_api_key:
+            try:
+                os_client = get_os_client()
+                os_results = await _search_os_places(os_client, search_query, settings.gemini_llm_api_key, district)
+            except RuntimeError:
+                pass
+
+        merged = _merge_candidates(pg_results, os_results)
+        excluded = extract_excluded_ids(prev_items, "place_id", target_index if action == "replace" else None)
+        new_candidates = [r for r in merged if r.get("place_id", "") not in excluded]
+
+        if not new_candidates:
+            items = prev_items
+        elif action == "replace" and target_index is not None:
+            new_item = new_candidates[0]
+            from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+            attach_map_urls(new_item)
+            items = apply_replace(prev_items, target_index, new_item)
+        else:
+            new_item = new_candidates[0]
+            from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+            attach_map_urls(new_item)
+            items = apply_add(prev_items, new_item)
+    else:
+        items = prev_items
+
+    blocks: list[dict[str, Any]] = []
+    if items:
+        for item in items:
+            from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+            attach_map_urls(item)
+        blocks.append({"type": "places", "items": items, "total_count": len(items)})
+
+    result_summary = "\n".join(
+        f"- {r.get('name', '')} ({r.get('category', '')}, {r.get('district', '')})" for r in items
+    )
+    prompt = f"사용자 요청: {query}\n\n수정된 추천 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
+    blocks.append({"type": "text_stream", "system": _RECOMMEND_SYSTEM_PROMPT, "prompt": prompt})
+
+    markers = [
+        {"place_id": r.get("place_id", ""), "lat": r["lat"], "lng": r["lng"], "label": r.get("name", "")}
+        for r in items
+        if r.get("lat") is not None and r.get("lng") is not None
+    ]
+    if markers:
+        blocks.append({"type": "map_markers", "markers": markers})
+
+    return {"response_blocks": blocks}
+
+
 async def place_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     """PLACE_RECOMMEND 노드 — PG + OS 2채널 + LLM Rerank (Phase 1).
 
@@ -529,6 +639,11 @@ async def place_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [text_stream, places, map_markers, references]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings
     from src.db.opensearch import get_os_client
     from src.db.postgres import get_pool

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -344,6 +344,114 @@ def _build_blocks(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """PLACE_SEARCH refinement 처리 — 이전 결과 기반 수정."""
+    # 재귀 depth 방어 — 무한 재귀 방지
+    if state.get("_refine_depth", 0) > 1:
+        clean = dict(state)
+        clean["previous_blocks"] = None
+        clean["refinement"] = None
+        return await place_search_node(clean)
+
+    from src.config import get_settings  # pyright: ignore[reportMissingImports]
+    from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
+    from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+    from src.graph.refine_helpers import (  # pyright: ignore[reportMissingImports]
+        apply_add,
+        apply_remove,
+        apply_replace,
+        extract_excluded_ids,
+        extract_items_from_blocks,
+        get_refinement_search_query,
+    )
+    from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
+
+    action = refinement.get("action", "regenerate")
+    target_index = refinement.get("target_index")
+    query = state.get("query", "")
+    pq = state.get("processed_query") or {}
+
+    # regenerate / change_condition → 기존 검색 로직 그대로 재실행
+    if action in ("regenerate", "change_condition"):
+        if action == "change_condition":
+            new_q = refinement.get("new_condition", query)
+            state = dict(state)
+            state["query"] = new_q
+            state["previous_blocks"] = None
+            state["refinement"] = None
+        return await place_search_node(state)
+
+    prev_items = extract_items_from_blocks(previous_blocks, "places")
+    if not prev_items:
+        return await place_search_node(state)
+
+    settings = get_settings()
+
+    if action == "remove" and target_index is not None:
+        items = apply_remove(prev_items, target_index)
+    elif action in ("replace", "add"):
+        search_query = get_refinement_search_query(refinement, pq, query)
+        district = pq.get("district")
+        category = pq.get("category")
+        keywords = pq.get("keywords", [])
+        neighborhood = pq.get("neighborhood")
+
+        pool = get_pool()
+        pg_results = await _search_pg(pool, district, category, keywords, neighborhood)
+
+        os_results: list[dict[str, Any]] = []
+        if settings.gemini_llm_api_key:
+            try:
+                os_client = get_os_client()
+                os_results = await _search_os(os_client, search_query, settings.gemini_llm_api_key, district)
+            except RuntimeError:
+                pass
+
+        merged = _merge_results(pg_results, os_results)
+        excluded = extract_excluded_ids(prev_items, "place_id", target_index if action == "replace" else None)
+        new_candidates = [r for r in merged if r.get("place_id", "") not in excluded]
+
+        if not new_candidates:
+            items = prev_items
+        elif action == "replace" and target_index is not None:
+            new_item = new_candidates[0]
+            attach_map_urls(new_item)
+            items = apply_replace(prev_items, target_index, new_item)
+        else:  # add
+            new_item = new_candidates[0]
+            attach_map_urls(new_item)
+            items = apply_add(prev_items, new_item)
+    else:
+        items = prev_items
+
+    # 블록 재구성
+    blocks: list[dict[str, Any]] = []
+    if items:
+        for item in items:
+            attach_map_urls(item)
+        blocks.append({"type": "places", "items": items, "total_count": len(items)})
+
+    result_summary = "\n".join(
+        f"- {r.get('name', '')} ({r.get('category', '')}, {r.get('district', '')})" for r in items
+    )
+    prompt = f"사용자 요청: {query}\n\n수정된 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
+    blocks.append({"type": "text_stream", "system": _PLACE_SEARCH_SYSTEM_PROMPT, "prompt": prompt})
+
+    markers = [
+        {"place_id": r.get("place_id", ""), "lat": r["lat"], "lng": r["lng"], "label": r.get("name", "")}
+        for r in items
+        if r.get("lat") is not None and r.get("lng") is not None
+    ]
+    if markers:
+        blocks.append({"type": "map_markers", "markers": markers})
+
+    return {"response_blocks": blocks}
+
+
 async def place_search_node(state: dict[str, Any]) -> dict[str, Any]:
     """PLACE_SEARCH 노드 — PG + OS 하이브리드 검색.
 
@@ -353,6 +461,11 @@ async def place_search_node(state: dict[str, Any]) -> dict[str, Any]:
     Returns:
         {"response_blocks": [text_stream, places, map_markers]}.
     """
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     from src.config import get_settings  # pyright: ignore[reportMissingImports]
     from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]

--- a/backend/src/graph/query_preprocessor_node.py
+++ b/backend/src/graph/query_preprocessor_node.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # 전처리 생략 대상 intent — GENERAL(대화형) + IMAGE_SEARCH(URL 쿼리, 이미지 노드가 직접 파싱)
+# NOTE: REFINE은 전처리 필요 (new_condition 파싱, district/category 추출에 활용)
 _SKIP_INTENTS: frozenset[str] = frozenset({"GENERAL", "IMAGE_SEARCH"})
 
 _PREPROCESS_SYSTEM_PROMPT = """\

--- a/backend/src/graph/real_builder.py
+++ b/backend/src/graph/real_builder.py
@@ -32,6 +32,7 @@ from src.graph.place_search_node import place_search_node  # pyright: ignore[rep
 from src.graph.query_preprocessor_node import (  # pyright: ignore[reportMissingImports]  # noqa: F401
     query_preprocessor_node,
 )
+from src.graph.refine_node import refine_node  # pyright: ignore[reportMissingImports]
 from src.graph.response_builder_node import response_builder_node  # pyright: ignore[reportMissingImports]
 from src.graph.review_compare_node import review_compare_node  # pyright: ignore[reportMissingImports]
 from src.graph.state import AgentState  # pyright: ignore[reportMissingImports]
@@ -73,6 +74,7 @@ def _route_by_intent(state: AgentState) -> str:
         "IMAGE_SEARCH": "image_search",
         "ANALYSIS": "analysis",
         "COST_ESTIMATE": "cost_estimate",
+        "REFINE": "refine",
     }
     return mapping.get(str(intent), "general")
 
@@ -108,6 +110,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
     graph.add_node("image_search", image_search_node)
     graph.add_node("analysis", analysis_node)
     graph.add_node("cost_estimate", cost_estimate_node)
+    graph.add_node("refine", refine_node)
     graph.add_node("response_builder", response_builder_node)
 
     # 엣지 설정
@@ -132,6 +135,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
             "image_search": "image_search",
             "analysis": "analysis",
             "cost_estimate": "cost_estimate",
+            "refine": "refine",
             "general": "general",
         },
     )
@@ -152,6 +156,7 @@ def build_graph(checkpointer: Optional[Any] = None) -> Any:
         "image_search",
         "analysis",
         "cost_estimate",
+        "refine",
     ]:
         graph.add_edge(node_name, "response_builder")
 

--- a/backend/src/graph/refine_helpers.py
+++ b/backend/src/graph/refine_helpers.py
@@ -1,0 +1,105 @@
+"""REFINE 공통 헬퍼 — 노드별 _handle_refinement에서 공유.
+
+리스트 항목 조작 (replace/remove/add) + 검색 쿼리 생성 유틸.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Optional
+
+
+def apply_remove(items: list[dict[str, Any]], target_index: int) -> list[dict[str, Any]]:
+    """1-indexed target_index 항목 제거. 범위 초과 시 원본 반환."""
+    idx = target_index - 1
+    if idx < 0 or idx >= len(items):
+        return items
+    result = copy.deepcopy(items)
+    result.pop(idx)
+    return result
+
+
+def apply_replace(
+    items: list[dict[str, Any]],
+    target_index: int,
+    new_item: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """1-indexed target_index 항목을 new_item으로 교체. 범위 초과 시 원본 반환."""
+    idx = target_index - 1
+    if idx < 0 or idx >= len(items):
+        return items
+    result = copy.deepcopy(items)
+    result[idx] = new_item
+    return result
+
+
+def apply_add(
+    items: list[dict[str, Any]],
+    new_item: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """new_item을 목록 끝에 추가."""
+    result = copy.deepcopy(items)
+    result.append(new_item)
+    return result
+
+
+def get_refinement_search_query(
+    refinement: dict[str, Any],
+    processed_query: Optional[dict[str, Any]],
+    original_query: str,
+) -> str:
+    """REFINE 수정 요청에서 검색 쿼리를 생성.
+
+    new_condition이 있으면 우선, 없으면 processed_query의 expanded_query,
+    최종 fallback은 original_query.
+    """
+    new_condition = refinement.get("new_condition")
+    if new_condition:
+        return new_condition
+
+    if processed_query:
+        expanded = processed_query.get("expanded_query")
+        if expanded:
+            return expanded
+
+    return original_query
+
+
+def extract_items_from_blocks(
+    blocks: list[dict[str, Any]],
+    block_type: str,
+) -> list[dict[str, Any]]:
+    """이전 응답 블록에서 특정 타입의 items 추출.
+
+    places → items, events → items, course → stops.
+    """
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != block_type:
+            continue
+        if block_type == "course":
+            return block.get("stops", [])
+        return block.get("items", [])
+    return []
+
+
+def extract_excluded_ids(
+    items: list[dict[str, Any]],
+    id_field: str = "place_id",
+    target_index: Optional[int] = None,
+) -> set[str]:
+    """기존 항목들의 ID 집합 반환 (중복 검색 방지용).
+
+    target_index가 주어지면 해당 항목은 제외 (교체 대상이므로).
+    """
+    ids: set[str] = set()
+    for i, item in enumerate(items, 1):
+        if not isinstance(item, dict):
+            continue
+        if target_index is not None and i == target_index:
+            continue
+        item_id = item.get(id_field, "")
+        if item_id:
+            ids.add(item_id)
+    return ids

--- a/backend/src/graph/refine_node.py
+++ b/backend/src/graph/refine_node.py
@@ -1,0 +1,462 @@
+"""REFINE 노드 — 이전 응답 수정 요청 처리.
+
+수정 흐름:
+  1. DB에서 이전 assistant 응답 블록 로드
+  2. 수정 대상 특정 (기본 직전, 명시적 참조 시 Gemini 추론)
+  3. Gemini JSON mode로 수정 지시 파싱 → RefinementInstruction
+  4. state에 previous_blocks + refinement 주입
+  5. 원본 노드 함수 직접 호출
+
+수정 유형 5종:
+  - replace: 특정 항목 교체
+  - remove: 특정 항목 삭제
+  - add: 항목 추가
+  - change_condition: 조건 변경 후 전체 재검색
+  - regenerate: 동일 조건 전체 재생성
+
+불변식 #8: asyncpg $1,$2 바인딩
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RefinementInstruction 스키마
+# ---------------------------------------------------------------------------
+class RefinementInstruction(BaseModel):
+    """Gemini가 파싱한 수정 지시."""
+
+    action: str = "regenerate"  # replace | remove | add | change_condition | regenerate
+    target_index: Optional[int] = None  # 1-indexed
+    target_id: Optional[str] = None  # place_id / event_id
+    new_condition: Optional[str] = None  # 교체/추가/조건변경 시 키워드
+    full_instruction: str = ""  # 원본 수정 요청 텍스트
+
+
+_VALID_ACTIONS = frozenset({"replace", "remove", "add", "change_condition", "regenerate"})
+
+# 구조화 블록 → 원본 intent 매핑
+_BLOCK_TYPE_TO_INTENT: dict[str, str] = {
+    "places": "PLACE_SEARCH",
+    "events": "EVENT_SEARCH",
+    "course": "COURSE_PLAN",
+    "chart": "REVIEW_COMPARE",
+}
+
+
+# ---------------------------------------------------------------------------
+# Gemini 수정 지시 파싱 프롬프트
+# ---------------------------------------------------------------------------
+_PARSE_REFINEMENT_PROMPT = """\
+You are a refinement parser for a Seoul local-life AI chatbot.
+
+The user wants to modify a previous response. Analyze the user's request and the previous response blocks.
+
+Respond in JSON with these fields:
+- "action": one of "replace", "remove", "add", "change_condition", "regenerate"
+  - "replace": swap a specific item for something else
+  - "remove": delete a specific item
+  - "add": add a new item to the list
+  - "change_condition": change the overall search criteria (e.g., different area or category)
+  - "regenerate": redo the entire response from scratch
+- "target_index": 1-indexed position of the item to modify (null if not applicable)
+- "target_id": the ID of the item to modify if identifiable (null if not applicable)
+- "new_condition": the new search keyword or condition for replace/add/change_condition (null if not applicable)
+- "full_instruction": the user's original modification request as-is
+
+Rules:
+- "3번 바꿔줘" with a condition → action=replace, target_index=3
+- "2번 빼줘" → action=remove, target_index=2
+- "하나 더 추가해줘" → action=add
+- "강남 말고 홍대로" → action=change_condition, new_condition includes "홍대"
+- "다시 해줘", "마음에 안 들어" → action=regenerate
+- If ambiguous, default to regenerate.
+
+Always respond with valid JSON only. No markdown, no explanation.
+"""
+
+_IDENTIFY_TARGET_PROMPT = """\
+You are a response identifier for a Seoul local-life AI chatbot.
+
+The user is referring to a previous response in the conversation. Given the conversation history and the user's current query, identify WHICH previous assistant response the user wants to modify.
+
+Previous assistant responses (most recent first):
+{responses_summary}
+
+User query: {query}
+
+Respond in JSON:
+- "target_message_index": 0-indexed position in the responses list above (0 = most recent)
+- "reasoning": brief explanation
+
+If the user is clearly referring to the most recent response, return target_message_index=0.
+Always respond with valid JSON only.
+"""
+
+
+# ---------------------------------------------------------------------------
+# DB 헬퍼
+# ---------------------------------------------------------------------------
+async def _load_previous_assistant_blocks(
+    thread_id: str,
+    limit: int = 5,
+) -> list[list[dict[str, Any]]]:
+    """최근 assistant 응답의 블록 목록을 로드. 최신순.
+
+    Returns:
+        [[blocks of msg1], [blocks of msg2], ...] 최신순. 실패 시 [].
+    """
+    try:
+        from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+
+        pool = get_pool()
+        rows = await pool.fetch(
+            "SELECT blocks FROM messages WHERE thread_id = $1 AND role = 'assistant' ORDER BY message_id DESC LIMIT $2",
+            thread_id,
+            limit,
+        )
+    except Exception:
+        logger.exception("refine_node: 이전 응답 로드 실패 thread_id=%s", thread_id)
+        return []
+
+    result: list[list[dict[str, Any]]] = []
+    for row in rows:
+        blocks = row["blocks"]
+        if isinstance(blocks, str):
+            try:
+                blocks = json.loads(blocks)
+            except Exception:
+                continue
+        if isinstance(blocks, list):
+            result.append(blocks)
+    return result
+
+
+def _detect_original_intent(blocks: list[dict[str, Any]]) -> Optional[str]:
+    """블록 목록에서 원본 intent를 추론.
+
+    intent 블록이 있으면 그 값 사용, 없으면 구조화 블록 타입으로 추론.
+    """
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "intent":
+            return block.get("intent")
+
+    # intent 블록 없으면 구조화 블록으로 추론
+    has_references = any(isinstance(b, dict) and b.get("type") == "references" for b in blocks)
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+        if btype == "places" and has_references:
+            return "PLACE_RECOMMEND"
+        if btype in _BLOCK_TYPE_TO_INTENT:
+            return _BLOCK_TYPE_TO_INTENT[btype]
+
+    return None
+
+
+def _has_explicit_reference(query: str) -> bool:
+    """쿼리에 원거리 참조 키워드가 있는지 간단 체크."""
+    ref_keywords = ["아까", "이전", "전에", "처음", "첫 번째", "그때", "아까 그"]
+    return any(kw in query for kw in ref_keywords)
+
+
+# ---------------------------------------------------------------------------
+# 수정 대상 특정
+# ---------------------------------------------------------------------------
+async def _identify_target(
+    query: str,
+    all_assistant_blocks: list[list[dict[str, Any]]],
+    conversation_history: list[dict[str, str]],
+) -> tuple[list[dict[str, Any]], Optional[str]]:
+    """수정 대상 응답 블록과 원본 intent를 특정.
+
+    기본: 직전 응답. 명시적 참조 시 Gemini 추론.
+
+    Returns:
+        (target_blocks, original_intent). 실패 시 ([], None).
+    """
+    if not all_assistant_blocks:
+        return [], None
+
+    # 기본: 직전 응답
+    if not _has_explicit_reference(query) or len(all_assistant_blocks) == 1:
+        target = all_assistant_blocks[0]
+        return target, _detect_original_intent(target)
+
+    # 명시적 참조 → Gemini 추론
+    try:
+        from langchain_google_genai import ChatGoogleGenerativeAI  # pyright: ignore[reportMissingImports]
+
+        from src.config import get_settings  # pyright: ignore[reportMissingImports]
+
+        settings = get_settings()
+        if not settings.gemini_llm_api_key:
+            target = all_assistant_blocks[0]
+            return target, _detect_original_intent(target)
+
+        # 응답 요약 생성
+        summaries: list[str] = []
+        for i, blocks in enumerate(all_assistant_blocks):
+            intent = _detect_original_intent(blocks)
+            block_types = [b.get("type", "") for b in blocks if isinstance(b, dict)]
+            summaries.append(f"[{i}] intent={intent}, blocks={block_types}")
+
+        prompt = _IDENTIFY_TARGET_PROMPT.format(
+            responses_summary="\n".join(summaries),
+            query=query,
+        )
+
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+        response = await llm.ainvoke([("system", prompt)])
+        text = str(response.content).strip()
+
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+        idx = int(result.get("target_message_index", 0))
+        idx = max(0, min(idx, len(all_assistant_blocks) - 1))
+
+        target = all_assistant_blocks[idx]
+        return target, _detect_original_intent(target)
+
+    except Exception:
+        logger.exception("refine_node: target 추론 실패 → 직전 응답 fallback")
+        target = all_assistant_blocks[0]
+        return target, _detect_original_intent(target)
+
+
+# ---------------------------------------------------------------------------
+# 수정 지시 파싱
+# ---------------------------------------------------------------------------
+async def _parse_refinement(
+    query: str,
+    target_blocks: list[dict[str, Any]],
+) -> RefinementInstruction:
+    """Gemini JSON mode로 수정 지시 파싱.
+
+    실패 시 regenerate fallback.
+    """
+    try:
+        from langchain_google_genai import ChatGoogleGenerativeAI  # pyright: ignore[reportMissingImports]
+
+        from src.config import get_settings  # pyright: ignore[reportMissingImports]
+
+        settings = get_settings()
+        if not settings.gemini_llm_api_key:
+            return RefinementInstruction(action="regenerate", full_instruction=query)
+
+        # 타겟 블록 요약 (토큰 절약)
+        block_summary_parts: list[str] = []
+        for block in target_blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "places":
+                items = block.get("items", [])
+                for i, item in enumerate(items, 1):
+                    if isinstance(item, dict):
+                        block_summary_parts.append(
+                            f"  {i}. {item.get('name', '')} (place_id={item.get('place_id', '')})"
+                        )
+            elif btype == "events":
+                items = block.get("items", [])
+                for i, item in enumerate(items, 1):
+                    if isinstance(item, dict):
+                        block_summary_parts.append(
+                            f"  {i}. {item.get('title', '')} (event_id={item.get('event_id', '')})"
+                        )
+            elif btype == "course":
+                stops = block.get("stops", [])
+                for stop in stops:
+                    if isinstance(stop, dict):
+                        order = stop.get("order", "?")
+                        place = stop.get("place", {})
+                        name = place.get("name", "") if isinstance(place, dict) else ""
+                        pid = place.get("place_id", "") if isinstance(place, dict) else ""
+                        block_summary_parts.append(f"  {order}. {name} (place_id={pid})")
+            elif btype == "chart":
+                places = block.get("places", [])
+                for i, p in enumerate(places, 1):
+                    if isinstance(p, dict):
+                        block_summary_parts.append(f"  {i}. {p.get('name', '')}")
+
+        block_summary = "\n".join(block_summary_parts) if block_summary_parts else "(구조화 블록 없음)"
+        user_prompt = f"이전 응답 항목:\n{block_summary}\n\n사용자 수정 요청: {query}"
+
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=settings.gemini_llm_api_key,
+            temperature=0,
+        )
+        response = await llm.ainvoke(
+            [
+                ("system", _PARSE_REFINEMENT_PROMPT),
+                ("human", user_prompt),
+            ]
+        )
+        text = str(response.content).strip()
+
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        result = json.loads(text)
+
+        action = result.get("action", "regenerate")
+        if action not in _VALID_ACTIONS:
+            action = "regenerate"
+
+        return RefinementInstruction(
+            action=action,
+            target_index=result.get("target_index"),
+            target_id=result.get("target_id"),
+            new_condition=result.get("new_condition"),
+            full_instruction=query,
+        )
+
+    except Exception:
+        logger.exception("refine_node: 수정 지시 파싱 실패 → regenerate fallback")
+        return RefinementInstruction(action="regenerate", full_instruction=query)
+
+
+# ---------------------------------------------------------------------------
+# 원본 노드 함수 매핑
+# ---------------------------------------------------------------------------
+def _get_node_function(original_intent: Optional[str]) -> Any:
+    """원본 intent에 해당하는 노드 함수 반환. 없으면 None."""
+    from src.graph.cost_estimate_node import cost_estimate_node  # pyright: ignore[reportMissingImports]
+    from src.graph.course_plan_node import course_plan_node  # pyright: ignore[reportMissingImports]
+    from src.graph.event_recommend_node import event_recommend_node  # pyright: ignore[reportMissingImports]
+    from src.graph.event_search_node import event_search_node  # pyright: ignore[reportMissingImports]
+    from src.graph.place_recommend_node import place_recommend_node  # pyright: ignore[reportMissingImports]
+    from src.graph.place_search_node import place_search_node  # pyright: ignore[reportMissingImports]
+    from src.graph.review_compare_node import review_compare_node  # pyright: ignore[reportMissingImports]
+
+    mapping: dict[str, Any] = {
+        "PLACE_SEARCH": place_search_node,
+        "PLACE_RECOMMEND": place_recommend_node,
+        "EVENT_SEARCH": event_search_node,
+        "EVENT_RECOMMEND": event_recommend_node,
+        "COURSE_PLAN": course_plan_node,
+        "REVIEW_COMPARE": review_compare_node,
+        "COST_ESTIMATE": cost_estimate_node,
+    }
+    return mapping.get(str(original_intent))
+
+
+# ---------------------------------------------------------------------------
+# 안내 메시지 블록 생성
+# ---------------------------------------------------------------------------
+def _no_previous_response_blocks() -> list[dict[str, Any]]:
+    """이전 응답이 없을 때 안내 텍스트 블록."""
+    return [
+        {
+            "type": "intent",
+            "intent": "REFINE",
+            "confidence": 1.0,
+        },
+        {
+            "type": "text_stream",
+            "system": (
+                "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
+                "자기소개나 인사로 시작하지 말고 바로 본론으로 답변하세요."
+            ),
+            "prompt": (
+                "사용자가 이전 응답을 수정하려 했지만, 수정할 이전 응답이 없습니다. "
+                "장소 검색, 코스 추천 등을 먼저 요청하면 결과를 수정할 수 있다고 안내해주세요. "
+                "1-2문장으로 간결하게."
+            ),
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# LangGraph 노드
+# ---------------------------------------------------------------------------
+async def refine_node(state: dict[str, Any]) -> dict[str, Any]:
+    """REFINE 노드 — 수정 요청 파싱 + 원본 노드 재호출.
+
+    Args:
+        state: AgentState dict.
+
+    Returns:
+        {"response_blocks": [...]} — 원본 노드의 수정된 결과.
+    """
+    thread_id: Optional[str] = state.get("thread_id")
+    query = state.get("query", "")
+    conversation_history = state.get("conversation_history", [])
+
+    logger.info("refine_node: thread_id=%s, query_len=%d", thread_id, len(query))
+
+    if not thread_id:
+        return {"response_blocks": _no_previous_response_blocks()}
+
+    # 1. 이전 응답 블록 로드
+    all_blocks = await _load_previous_assistant_blocks(thread_id)
+    if not all_blocks:
+        return {"response_blocks": _no_previous_response_blocks()}
+
+    # 2. 수정 대상 특정
+    target_blocks, original_intent = await _identify_target(query, all_blocks, conversation_history)
+
+    if not target_blocks or not original_intent:
+        return {"response_blocks": _no_previous_response_blocks()}
+
+    # 3. 수정 지시 파싱
+    refinement = await _parse_refinement(query, target_blocks)
+
+    logger.info(
+        "refine_node: original_intent=%s, action=%s, target_index=%s",
+        original_intent,
+        refinement.action,
+        refinement.target_index,
+    )
+
+    # 4. 원본 노드 함수 가져오기
+    node_fn = _get_node_function(original_intent)
+    if node_fn is None:
+        logger.warning("refine_node: 원본 노드 함수 없음 intent=%s → 안내 메시지", original_intent)
+        return {"response_blocks": _no_previous_response_blocks()}
+
+    # 5. state 복사 + refinement 컨텍스트 주입 → 원본 노드 호출
+    refined_state = dict(state)
+    refined_state["previous_blocks"] = target_blocks
+    refined_state["refinement"] = refinement.model_dump()
+    refined_state["original_intent"] = original_intent
+    refined_state["intent"] = original_intent
+    refined_state["_refine_depth"] = state.get("_refine_depth", 0) + 1
+
+    try:
+        result = await node_fn(refined_state)
+        return result
+    except Exception:
+        logger.exception("refine_node: 원본 노드 재호출 실패 intent=%s → regenerate", original_intent)
+        # fallback: refinement 없이 원본 노드 그대로 실행
+        fallback_state = dict(state)
+        fallback_state["intent"] = original_intent
+        try:
+            return await node_fn(fallback_state)
+        except Exception:
+            logger.exception("refine_node: fallback도 실패")
+            return {"response_blocks": _no_previous_response_blocks()}

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -57,6 +57,10 @@ def _validate_block_order(
     if intent is None:
         return "intent가 None — 블록 순서 검증 스킵"
 
+    # REFINE은 원본 intent의 블록 순서를 따르므로 검증 스킵
+    if intent == "REFINE":
+        return None
+
     expected = _EXPECTED_BLOCK_ORDER.get(intent)
     if expected is None:
         return None

--- a/backend/src/graph/review_compare_node.py
+++ b/backend/src/graph/review_compare_node.py
@@ -143,8 +143,28 @@ def _build_compare_blocks(
     ]
 
 
+async def _handle_refinement(
+    state: dict[str, Any],
+    previous_blocks: list[dict[str, Any]],
+    refinement: dict[str, Any],
+) -> dict[str, Any]:
+    """REVIEW_COMPARE refinement — 비교 대상 변경 시 전체 재실행."""
+    if refinement.get("action") == "change_condition" and refinement.get("new_condition"):
+        state = dict(state)
+        state["query"] = refinement["new_condition"]
+    state = dict(state)
+    state["previous_blocks"] = None
+    state["refinement"] = None
+    return await review_compare_node(state)
+
+
 async def review_compare_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 노드 — REVIEW_COMPARE intent 처리 (Phase 1)."""
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
     query: str = state.get("query", "")
     processed_query: dict[str, Any] = state.get("processed_query") or {}
 

--- a/backend/src/graph/state.py
+++ b/backend/src/graph/state.py
@@ -34,3 +34,6 @@ class AgentState(TypedDict, total=False):
     user_id: Optional[int]
     error: Optional[str]
     conversation_history: list[dict[str, str]]
+    previous_blocks: Optional[list[dict[str, Any]]]
+    refinement: Optional[dict[str, Any]]
+    original_intent: Optional[str]

--- a/backend/tests/test_refine_helpers.py
+++ b/backend/tests/test_refine_helpers.py
@@ -1,0 +1,130 @@
+"""refine_helpers 단위 테스트 — apply_remove, apply_replace, apply_add, extract 유틸."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_SAMPLE_ITEMS: list[dict[str, Any]] = [
+    {"place_id": "p1", "name": "카페A"},
+    {"place_id": "p2", "name": "카페B"},
+    {"place_id": "p3", "name": "카페C"},
+]
+
+
+def test_apply_remove_valid_index() -> None:
+    from src.graph.refine_helpers import apply_remove
+
+    result = apply_remove(_SAMPLE_ITEMS, 2)
+    assert len(result) == 2
+    assert result[0]["place_id"] == "p1"
+    assert result[1]["place_id"] == "p3"
+
+
+def test_apply_remove_out_of_range() -> None:
+    from src.graph.refine_helpers import apply_remove
+
+    result = apply_remove(_SAMPLE_ITEMS, 10)
+    assert len(result) == 3
+
+
+def test_apply_remove_does_not_mutate_original() -> None:
+    from src.graph.refine_helpers import apply_remove
+
+    original = [{"place_id": "p1"}, {"place_id": "p2"}]
+    apply_remove(original, 1)
+    assert len(original) == 2
+
+
+def test_apply_replace_valid_index() -> None:
+    from src.graph.refine_helpers import apply_replace
+
+    new_item = {"place_id": "p_new", "name": "새카페"}
+    result = apply_replace(_SAMPLE_ITEMS, 2, new_item)
+    assert len(result) == 3
+    assert result[1]["place_id"] == "p_new"
+    assert result[0]["place_id"] == "p1"
+    assert result[2]["place_id"] == "p3"
+
+
+def test_apply_replace_out_of_range() -> None:
+    from src.graph.refine_helpers import apply_replace
+
+    result = apply_replace(_SAMPLE_ITEMS, 0, {"place_id": "x"})
+    assert len(result) == 3
+    assert result[0]["place_id"] == "p1"
+
+
+def test_apply_add() -> None:
+    from src.graph.refine_helpers import apply_add
+
+    new_item = {"place_id": "p4", "name": "카페D"}
+    result = apply_add(_SAMPLE_ITEMS, new_item)
+    assert len(result) == 4
+    assert result[3]["place_id"] == "p4"
+
+
+def test_extract_items_from_blocks_places() -> None:
+    from src.graph.refine_helpers import extract_items_from_blocks
+
+    blocks = [
+        {"type": "intent", "intent": "PLACE_SEARCH"},
+        {"type": "places", "items": _SAMPLE_ITEMS},
+    ]
+    items = extract_items_from_blocks(blocks, "places")
+    assert len(items) == 3
+
+
+def test_extract_items_from_blocks_course() -> None:
+    from src.graph.refine_helpers import extract_items_from_blocks
+
+    stops = [{"order": 1, "place": {"name": "A"}}, {"order": 2, "place": {"name": "B"}}]
+    blocks = [{"type": "course", "stops": stops}]
+    result = extract_items_from_blocks(blocks, "course")
+    assert len(result) == 2
+
+
+def test_extract_items_from_blocks_missing() -> None:
+    from src.graph.refine_helpers import extract_items_from_blocks
+
+    blocks = [{"type": "text", "content": "hello"}]
+    result = extract_items_from_blocks(blocks, "places")
+    assert result == []
+
+
+def test_extract_excluded_ids() -> None:
+    from src.graph.refine_helpers import extract_excluded_ids
+
+    ids = extract_excluded_ids(_SAMPLE_ITEMS, "place_id")
+    assert ids == {"p1", "p2", "p3"}
+
+
+def test_extract_excluded_ids_with_target() -> None:
+    from src.graph.refine_helpers import extract_excluded_ids
+
+    ids = extract_excluded_ids(_SAMPLE_ITEMS, "place_id", target_index=2)
+    assert ids == {"p1", "p3"}
+
+
+def test_get_refinement_search_query_new_condition() -> None:
+    from src.graph.refine_helpers import get_refinement_search_query
+
+    q = get_refinement_search_query(
+        {"new_condition": "조용한 카페"},
+        {"expanded_query": "강남 카페"},
+        "원본 쿼리",
+    )
+    assert q == "조용한 카페"
+
+
+def test_get_refinement_search_query_fallback() -> None:
+    from src.graph.refine_helpers import get_refinement_search_query
+
+    q = get_refinement_search_query({}, {"expanded_query": "강남 카페"}, "원본 쿼리")
+    assert q == "강남 카페"
+
+
+def test_get_refinement_search_query_final_fallback() -> None:
+    from src.graph.refine_helpers import get_refinement_search_query
+
+    q = get_refinement_search_query({}, None, "원본 쿼리")
+    assert q == "원본 쿼리"

--- a/backend/tests/test_refine_node.py
+++ b/backend/tests/test_refine_node.py
@@ -1,0 +1,131 @@
+"""refine_node 단위 테스트 — 순수 함수 검증 (DB/Gemini 미의존)."""
+
+from __future__ import annotations
+
+
+def test_detect_original_intent_from_intent_block() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [
+        {"type": "intent", "intent": "PLACE_SEARCH", "confidence": 0.9},
+        {"type": "places", "items": []},
+    ]
+    assert _detect_original_intent(blocks) == "PLACE_SEARCH"
+
+
+def test_detect_original_intent_from_structured_block() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [
+        {"type": "places", "items": [{"place_id": "p1"}]},
+        {"type": "text_stream", "content": "요약"},
+    ]
+    assert _detect_original_intent(blocks) == "PLACE_SEARCH"
+
+
+def test_detect_original_intent_course() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [{"type": "course", "stops": []}]
+    assert _detect_original_intent(blocks) == "COURSE_PLAN"
+
+
+def test_detect_original_intent_events() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [{"type": "events", "items": []}]
+    assert _detect_original_intent(blocks) == "EVENT_SEARCH"
+
+
+def test_detect_original_intent_chart() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [{"type": "chart", "places": []}]
+    assert _detect_original_intent(blocks) == "REVIEW_COMPARE"
+
+
+def test_detect_original_intent_none() -> None:
+    from src.graph.refine_node import _detect_original_intent
+
+    blocks = [{"type": "text_stream", "content": "hello"}]
+    assert _detect_original_intent(blocks) is None
+
+
+def test_has_explicit_reference_true() -> None:
+    from src.graph.refine_node import _has_explicit_reference
+
+    assert _has_explicit_reference("아까 추천해준 카페 목록에서 2번 빼줘")
+    assert _has_explicit_reference("이전 결과에서 바꿔줘")
+    assert _has_explicit_reference("처음 추천한 거")
+
+
+def test_has_explicit_reference_false() -> None:
+    from src.graph.refine_node import _has_explicit_reference
+
+    assert not _has_explicit_reference("3번 장소 바꿔줘")
+    assert not _has_explicit_reference("다시 추천해줘")
+
+
+def test_no_previous_response_blocks() -> None:
+    from src.graph.refine_node import _no_previous_response_blocks
+
+    blocks = _no_previous_response_blocks()
+    assert len(blocks) == 2
+    assert blocks[0]["type"] == "intent"
+    assert blocks[0]["intent"] == "REFINE"
+    assert blocks[1]["type"] == "text_stream"
+
+
+def test_refinement_instruction_defaults() -> None:
+    from src.graph.refine_node import RefinementInstruction
+
+    r = RefinementInstruction()
+    assert r.action == "regenerate"
+    assert r.target_index is None
+    assert r.target_id is None
+    assert r.new_condition is None
+
+
+def test_refinement_instruction_with_values() -> None:
+    from src.graph.refine_node import RefinementInstruction
+
+    r = RefinementInstruction(
+        action="replace",
+        target_index=3,
+        new_condition="조용한 카페",
+        full_instruction="3번 조용한 카페로 바꿔줘",
+    )
+    assert r.action == "replace"
+    assert r.target_index == 3
+    assert r.new_condition == "조용한 카페"
+
+
+def test_get_node_function_valid() -> None:
+    from src.graph.refine_node import _get_node_function
+
+    fn = _get_node_function("PLACE_SEARCH")
+    assert fn is not None
+    assert callable(fn)
+
+
+def test_get_node_function_invalid() -> None:
+    from src.graph.refine_node import _get_node_function
+
+    fn = _get_node_function("NONEXISTENT")
+    assert fn is None
+
+
+def test_get_node_function_all_mapped() -> None:
+    from src.graph.refine_node import _get_node_function
+
+    expected = [
+        "PLACE_SEARCH",
+        "PLACE_RECOMMEND",
+        "EVENT_SEARCH",
+        "EVENT_RECOMMEND",
+        "COURSE_PLAN",
+        "REVIEW_COMPARE",
+        "COST_ESTIMATE",
+    ]
+    for intent in expected:
+        assert _get_node_function(intent) is not None, f"{intent} not mapped"

--- a/docs/2026-05-20-multiturn-context-refine-design.md
+++ b/docs/2026-05-20-multiturn-context-refine-design.md
@@ -1,0 +1,305 @@
+# 멀티턴 대화 컨텍스트 보강 + REFINE Intent 설계서
+
+> 날짜: 2026-05-20
+> 브랜치: feat/#135
+> 상태: 설계 확정 → 구현 대기
+
+## 1. 문제 정의
+
+사용자가 이전 응답(코스, 장소 목록, 행사 등)의 수정을 요청할 때 엉뚱한 응답을 반환함.
+
+**근본 원인 3가지:**
+1. `sse.py:345` — 각 graph 실행 시 `conversation_history: []` 전달
+2. `_stream_gemini()` — 대화 이력 없이 system_prompt + user_prompt만 사용
+3. 각 노드 — 이전 턴의 구조화된 결과(place_id, stops 등)를 참조할 수 없음
+
+## 2. 설계 요건
+
+| 항목 | 결정 |
+|---|---|
+| 컨텍스트 방식 | 구조화된 블록(previous_blocks) 직접 주입 |
+| 라우팅 | 신규 REFINE intent 추가 |
+| 수정 유형 | 부분 교체/삭제/추가, 조건 변경, 전체 재생성 (5종) |
+| 적용 대상 | places, events, course, chart, cost_estimate 등 모든 구조화된 응답 |
+| 실행 방식 | REFINE 노드가 파싱 → 원본 노드 재호출 (방식 1: State 확장) |
+| 대상 특정 | 기본 직전 응답, 명시적 참조 시 Gemini 추론 fallback |
+| 이력 범위 | 최근 5턴(10메시지), 구조화된 블록 포함 |
+
+## 3. 아키텍처
+
+### 3.1 흐름도
+
+```
+사용자: "3번 장소 카페로 바꿔줘"
+  ↓
+SSE handler: _load_recent_history(5턴, 구조화 블록 포함)
+  ↓
+classify_intents → REFINE (confidence 0.9)
+  ↓
+intent_router_node → intent="REFINE"
+  ↓
+query_preprocessor_node (기존 동작)
+  ↓
+refine_node:
+  1. 이전 응답 블록 로드 (DB messages → 직전 assistant blocks)
+  2. Gemini로 수정 지시 파싱 → RefinementInstruction
+  3. 원본 intent 판별 (course → COURSE_PLAN)
+  4. state에 previous_blocks + refinement 주입
+  5. 원본 노드 함수 직접 호출 (course_plan_node(state))
+  ↓
+원본 노드: previous_blocks 유무로 신규/수정 분기
+  - 수정 모드: 이전 결과 기반으로 부분 수정 후 반환
+  ↓
+response_builder → SSE 전송
+```
+
+### 3.2 AgentState 확장
+
+```python
+# src/graph/state.py
+class AgentState(TypedDict, total=False):
+    # 기존 필드
+    query: str
+    intent: Optional[str]
+    processed_query: Optional[dict[str, Any]]
+    response_blocks: Annotated[list[dict[str, Any]], operator.add]
+    thread_id: str
+    user_id: Optional[int]
+    error: Optional[str]
+    conversation_history: list[dict[str, str]]
+
+    # 신규 필드
+    previous_blocks: Optional[list[dict[str, Any]]]  # 이전 응답 블록
+    refinement: Optional[dict[str, Any]]              # 수정 지시 파싱 결과
+    original_intent: Optional[str]                     # 수정 대상 원본 intent
+```
+
+### 3.3 RefinementInstruction 스키마
+
+```python
+# refine_node.py 내부
+class RefinementInstruction(BaseModel):
+    """Gemini가 파싱한 수정 지시."""
+    action: str          # "replace" | "remove" | "add" | "change_condition" | "regenerate"
+    target_index: Optional[int] = None    # 수정 대상 인덱스 (1-indexed, 부분 수정 시)
+    target_id: Optional[str] = None       # 수정 대상 ID (place_id/event_id)
+    new_condition: Optional[str] = None   # 교체/추가 조건 ("카페", "가성비 좋은")
+    full_instruction: str = ""            # 원본 수정 요청 텍스트
+```
+
+### 3.4 REFINE intent 분류
+
+`_CLASSIFY_MULTI_SYSTEM_PROMPT`에 REFINE 추가:
+
+```
+- REFINE: user wants to modify, replace, remove, or regenerate a previous response.
+  Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘",
+  "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로"
+```
+
+### 3.5 refine_node 로직
+
+```python
+async def refine_node(state: dict[str, Any]) -> dict[str, Any]:
+    """REFINE 노드 — 수정 요청 파싱 + 원본 노드 재호출."""
+
+    thread_id = state.get("thread_id")
+    query = state.get("query", "")
+
+    # 1. 이전 응답 블록 로드
+    previous_blocks = await _load_previous_blocks(thread_id)
+
+    # 2. 수정 대상 특정 (기본: 직전, 명시적 참조 시 Gemini 추론)
+    target_blocks, original_intent = await _identify_target(
+        query, previous_blocks, state.get("conversation_history", [])
+    )
+
+    # 3. 수정 지시 파싱
+    refinement = await _parse_refinement(query, target_blocks)
+
+    # 4. state에 주입 + 원본 노드 호출
+    state["previous_blocks"] = target_blocks
+    state["refinement"] = refinement.model_dump()
+    state["original_intent"] = original_intent
+    state["intent"] = original_intent  # 라우팅용
+
+    # 5. 원본 노드 직접 호출
+    node_fn = _get_node_function(original_intent)
+    result = await node_fn(state)
+
+    return result
+```
+
+### 3.6 원본 노드 수정 패턴 (각 노드 공통)
+
+```python
+async def place_search_node(state: dict[str, Any]) -> dict[str, Any]:
+    previous_blocks = state.get("previous_blocks")
+    refinement = state.get("refinement")
+
+    if previous_blocks and refinement:
+        return await _handle_refinement(state, previous_blocks, refinement)
+
+    # 기존 신규 검색 로직 (변경 없음)
+    ...
+```
+
+각 노드의 `_handle_refinement` 구현:
+
+| action | 동작 |
+|---|---|
+| replace | target_index의 항목 제거 → new_condition으로 1건 검색 → 해당 위치에 삽입 |
+| remove | target_index 항목 제거 → 나머지 재구성 |
+| add | new_condition으로 1건 검색 → 기존 목록에 추가 |
+| change_condition | new_condition으로 전체 재검색 (기존 검색 로직 재활용) |
+| regenerate | previous_blocks 무시, 기존 검색 로직 그대로 재실행 |
+
+### 3.7 conversation_history 보강
+
+**SSE 핸들러 변경** (`sse.py`):
+
+```python
+# 변경 전 (line 345)
+"conversation_history": [],
+
+# 변경 후
+"conversation_history": conversation_history,  # _load_recent_history 결과 전달
+```
+
+**_load_recent_history 보강** — 구조화된 블록 요약 포함:
+
+```python
+# 기존: text 블록의 content만 추출
+# 변경: assistant 응답의 구조화된 블록도 요약 포함
+# 예: "[코스: 청담 명품 로드 (5곳) - 갤러리아명품관, 지방시 갤러리아명품관, ...]"
+# 예: "[장소 5건: 스타벅스 강남점, 블루보틀 삼청, ...]"
+```
+
+**_stream_gemini 보강** — 대화 이력 전달:
+
+```python
+# 변경 전
+async def _stream_gemini(system_prompt: str, user_prompt: str) -> AsyncIterator[str]:
+
+# 변경 후
+async def _stream_gemini(
+    system_prompt: str,
+    user_prompt: str,
+    conversation_history: Optional[list[dict[str, str]]] = None,
+) -> AsyncIterator[str]:
+    # messages에 conversation_history 포함
+```
+
+### 3.8 그래프 변경 (real_builder.py)
+
+```python
+# 신규 노드 등록
+from src.graph.refine_node import refine_node
+graph.add_node("refine", refine_node)
+
+# 라우팅 매핑에 추가
+"REFINE": "refine",
+
+# refine → response_builder 엣지
+graph.add_edge("refine", "response_builder")
+```
+
+**주의**: refine_node가 내부에서 원본 노드를 직접 호출하므로, refine → 원본 노드 엣지는 필요 없음. refine_node의 반환값이 곧 response_blocks.
+
+## 4. 수정 대상 파일 목록
+
+| 파일 | 변경 내용 |
+|---|---|
+| `src/graph/state.py` | previous_blocks, refinement, original_intent 필드 추가 |
+| `src/graph/intent_router_node.py` | REFINE intent 추가 (IntentType, 프롬프트, 라우팅) |
+| `src/graph/refine_node.py` | **신규** — 수정 파싱 + 원본 노드 재호출 |
+| `src/graph/real_builder.py` | refine 노드 등록 + 라우팅 |
+| `src/api/sse.py` | conversation_history 전달, _stream_gemini 이력 주입, _load_recent_history 보강 |
+| `src/graph/place_search_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/place_recommend_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/event_search_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/event_recommend_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/course_plan_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/review_compare_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/cost_estimate_node.py` | _handle_refinement 분기 추가 |
+| `src/graph/query_preprocessor_node.py` | REFINE intent 전처리 로직 |
+| `src/models/blocks.py` | 변경 없음 (기존 블록 구조 유지) |
+
+## 5. 수정 유형별 동작 예시
+
+### 5.1 부분 교체 (replace)
+
+```
+사용자: "강남 카페 추천해줘" → places [A, B, C, D, E]
+사용자: "3번 빼고 조용한 곳으로 바꿔줘"
+  → REFINE → action=replace, target_index=3, new_condition="조용한 카페"
+  → place_recommend_node(refinement mode):
+    - C 제거, "조용한 카페 강남" 1건 검색 → F
+    - 결과: [A, B, F, D, E]
+```
+
+### 5.2 부분 삭제 (remove)
+
+```
+사용자: "코스 추천해줘" → course [1,2,3,4,5]
+사용자: "2번 장소 빼줘"
+  → REFINE → action=remove, target_index=2
+  → course_plan_node(refinement mode):
+    - stop 2 제거, 시간/경로 재계산
+    - 결과: [1,3,4,5] (order 재정렬)
+```
+
+### 5.3 부분 추가 (add)
+
+```
+사용자: "행사 검색해줘" → events [A, B, C]
+사용자: "무료 행사 하나 더 추가해줘"
+  → REFINE → action=add, new_condition="무료 행사"
+  → event_search_node(refinement mode):
+    - "무료 행사" 1건 추가 검색 → D
+    - 결과: [A, B, C, D]
+```
+
+### 5.4 조건 변경 (change_condition)
+
+```
+사용자: "강남 맛집 추천해줘" → places [강남 A,B,C,D,E]
+사용자: "강남 말고 홍대 쪽으로"
+  → REFINE → action=change_condition, new_condition="홍대 맛집"
+  → place_recommend_node(refinement mode):
+    - 기존 결과 무시, "홍대 맛집"으로 전체 재검색
+    - 결과: [홍대 F,G,H,I,J]
+```
+
+### 5.5 전체 재생성 (regenerate)
+
+```
+사용자: "코스 추천해줘" → course [1,2,3,4,5]
+사용자: "마음에 안 들어 다시 해줘"
+  → REFINE → action=regenerate
+  → course_plan_node(refinement mode):
+    - previous_blocks 무시, 동일 조건 재실행
+```
+
+## 6. 테스트 계획
+
+| 시나리오 | 검증 항목 |
+|---|---|
+| 장소 추천 → "3번 바꿔줘" | REFINE 분류, replace 동작, 나머지 유지 |
+| 코스 → "2번 빼줘" | remove 후 order 재정렬, 시간 재계산 |
+| 행사 → "하나 더 추가" | add 후 기존 목록 보존 |
+| 장소 → "홍대로 바꿔줘" | change_condition 전체 재검색 |
+| 코스 → "다시 해줘" | regenerate 동일 조건 재실행 |
+| 일반 대화 → "바꿔줘" (맥락 없음) | REFINE 미분류 or 안내 메시지 |
+| 장소 추천 → 코스 추천 → "아까 카페 목록에서 2번 빼줘" | 원거리 참조 Gemini 추론 |
+| conversation_history 주입 확인 | _stream_gemini에 이력 전달 여부 |
+
+## 7. 리스크 및 완화
+
+| 리스크 | 완화 |
+|---|---|
+| REFINE vs 기존 intent 오분류 | 프롬프트에 명확한 예시, confidence threshold |
+| 수정 지시 파싱 실패 | fallback: regenerate로 전체 재실행 |
+| 원본 노드 재호출 시 검색 결과 변동 | 부분 교체 시 변경 대상만 재검색, 나머지 유지 |
+| 토큰 비용 증가 (이력 5턴) | 구조화 블록은 요약 형태로 축약 전달 |
+| 이전 응답 없이 "바꿔줘" 요청 | refine_node에서 감지 → "수정할 이전 응답이 없습니다" 안내 |


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #138

## #️⃣ 작업 내용

> - REFINE intent 신규 추가 — 이전 응답 수정 요청을 전담 처리하는 범용 수정 레이어
> - conversation_history 주입 보강 (5턴, 구조화 블록 요약 포함)
> - _stream_gemini에 대화 이력 전달 (응답 생성 시 맥락 유지)
> - refine_node.py — 수정 요청 파싱 + 원본 노드 재호출 허브
> - refine_helpers.py — apply_remove/replace/add 공통 유틸
> - 7개 노드에 _handle_refinement 분기 (place_search/recommend, event_search/recommend, course_plan, review_compare, cost_estimate)
> - 재귀 depth 방어 코드 추가
> - 수정 유형 5종 지원: 부분 교체/삭제/추가, 조건 변경, 전체 재생성

## #️⃣ 테스트 결과

> - test_refine_helpers: 14 passed
> - test_refine_node: 14 passed
> - 기존 노드 테스트: 87 passed (1 OS환경 error — 변경 무관)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료

> 설계서: `docs/2026-05-20-multiturn-context-refine-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Users can now refine previous responses by requesting modifications to replace, remove, or add items
- Enhanced conversation history for improved context in follow-up interactions
- Refinement capabilities available across place searches, event recommendations, course planning, cost estimates, and review comparisons

**Tests**
- Added comprehensive test coverage for refinement functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->