### PR TITLE
[Fix] CD 배포 디스크 부족 재발 방지 — Docker prune 추가 (#140)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -65,6 +65,10 @@ jobs:
             rm -f /tmp/secrets.env
           fi
 
+          # Docker 정리 (디스크 부족 방지) — 미사용 이미지/캐시 제거
+          docker system prune -af --filter "until=72h" || true
+          docker builder prune -af || true
+
           # Docker 빌드 + 배포
           docker compose build api
           docker compose up -d --no-deps api


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #140

## #️⃣ 작업 내용

> - deploy-dev.yml 배포 스크립트에 `docker system prune -af --filter "until=72h"` + `docker builder prune -af` 추가
> - 빌드 전 72시간 이상 된 미사용 이미지/캐시 자동 정리

## #️⃣ 테스트 결과

> VM 수동 정리 완료: 3.9GB 회수, 디스크 64% 사용

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)