### PR TITLE
[Fix] REFINE 분류 프롬프트 부정 예시 추가 — 확인 질문 오분류 방지 (#138)

### DIFF
--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -103,8 +103,8 @@ Phase 1 (active):
 - CROWDEDNESS: asking about current crowdedness or population density of an area
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL (http/https link ending in image extension or storage URL) to identify a place or find similar places; also when user refers to a previously sent image ("아까 그 사진", "방금 올린 이미지", "그 사진 어딘지", "이전 사진") without a new URL
-- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘"
-- GENERAL: general conversation, greetings, or anything else
+- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘". NOT REFINE (classify as GENERAL instead): questions about a previous response ("이게 뭐야?", "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?"), opinions ("좋다", "괜찮네"), or follow-up questions that don't request a change.
+- GENERAL: general conversation, greetings, questions about previous results, or anything else
 
 Phase 2 (not yet active, classify as GENERAL for now):
 - ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
@@ -130,8 +130,8 @@ Phase 1 (active):
 - REVIEW_COMPARE: comparing two or more places by 6 metrics
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL to identify a place or find similar places; also when user refers to a previously sent image without a new URL
-- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘"
-- GENERAL: general conversation, greetings, or anything else
+- REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘". NOT REFINE (classify as GENERAL instead): questions about a previous response ("이게 뭐야?", "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?"), opinions ("좋다", "괜찮네"), or follow-up questions that don't request a change.
+- GENERAL: general conversation, greetings, questions about previous results, or anything else
 
 Phase 2 (not yet active, classify as GENERAL for now):
 - ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)

--- a/backend/tests/test_refine_node.py
+++ b/backend/tests/test_refine_node.py
@@ -129,3 +129,12 @@ def test_get_node_function_all_mapped() -> None:
     ]
     for intent in expected:
         assert _get_node_function(intent) is not None, f"{intent} not mapped"
+
+
+def test_classify_prompts_contain_not_refine_guidance() -> None:
+    """REFINE 부정 예시가 양쪽 분류 프롬프트에 포함되어 있는지 확인."""
+    from src.graph.intent_router_node import _CLASSIFY_MULTI_SYSTEM_PROMPT, _CLASSIFY_SYSTEM_PROMPT
+
+    for prompt in [_CLASSIFY_SYSTEM_PROMPT, _CLASSIFY_MULTI_SYSTEM_PROMPT]:
+        assert "NOT REFINE" in prompt, "프롬프트에 NOT REFINE 부정 예시가 없음"
+        assert "questions about previous results" in prompt or "questions about a previous response" in prompt


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #138

## #️⃣ 작업 내용

> - REFINE intent 분류 프롬프트(단일/복수)에 NOT REFINE 부정 예시 추가
>   - "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?" 등 확인 질문 → GENERAL로 분류
> - GENERAL 설명에 "questions about previous results" 추가
> - 프롬프트 부정 예시 존재 확인 테스트 추가

## #️⃣ 테스트 결과

> 21 passed (1 OS환경 error — 변경 무관)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)