### PR TITLE
[Fix] REFINE 수정 응답 전용 system prompt 적용 (#138)

### DIFF
--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -665,6 +665,8 @@ async def _handle_refinement(
     refinement: dict[str, Any],
 ) -> dict[str, Any]:
     """COURSE_PLAN refinement 처리 — 이전 코스 기반 수정."""
+    from src.graph.refine_helpers import REFINE_SYSTEM_PROMPT as _refine_system  # pyright: ignore[reportMissingImports]
+
     if state.get("_refine_depth", 0) > 1:
         clean = dict(state)
         clean["previous_blocks"] = None
@@ -903,7 +905,7 @@ async def _handle_refinement(
     else:
         prompt = f"사용자 요청: {query}\n\n수정된 코스: {result_summary}\n\n코스 전체의 테마와 매력을 2-3문장으로 요약해주세요."
     blocks: list[dict[str, Any]] = [
-        {"type": "text_stream", "system": _COURSE_SYSTEM_PROMPT, "prompt": prompt},
+        {"type": "text_stream", "system": _refine_system, "prompt": prompt},
         course_block,
     ]
     return {"response_blocks": blocks}

--- a/backend/src/graph/event_recommend_node.py
+++ b/backend/src/graph/event_recommend_node.py
@@ -641,6 +641,8 @@ async def _handle_refinement(
     refinement: dict[str, Any],
 ) -> dict[str, Any]:
     """EVENT_RECOMMEND refinement 처리 — 이전 결과 기반 수정."""
+    from src.graph.refine_helpers import REFINE_SYSTEM_PROMPT  # pyright: ignore[reportMissingImports]
+
     if state.get("_refine_depth", 0) > 1:
         clean = dict(state)
         clean["previous_blocks"] = None
@@ -713,7 +715,7 @@ async def _handle_refinement(
         prompt = f"사용자 요청: {query}\n\n**{added}**을(를) 목록에 추가했습니다.\n수정된 목록:\n{result_summary}\n\n1-2문장으로 요약해주세요."
     else:
         prompt = f"사용자 요청: {query}\n\n수정된 행사 추천 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
-    blocks.append({"type": "text_stream", "system": _EVENT_RECOMMEND_SYSTEM_PROMPT, "prompt": prompt})
+    blocks.append({"type": "text_stream", "system": REFINE_SYSTEM_PROMPT, "prompt": prompt})
     return {"response_blocks": blocks}
 
 

--- a/backend/src/graph/event_search_node.py
+++ b/backend/src/graph/event_search_node.py
@@ -635,6 +635,8 @@ async def _handle_refinement(
     refinement: dict[str, Any],
 ) -> dict[str, Any]:
     """EVENT_SEARCH refinement 처리 — 이전 결과 기반 수정."""
+    from src.graph.refine_helpers import REFINE_SYSTEM_PROMPT  # pyright: ignore[reportMissingImports]
+
     if state.get("_refine_depth", 0) > 1:
         clean = dict(state)
         clean["previous_blocks"] = None
@@ -707,7 +709,7 @@ async def _handle_refinement(
         prompt = f"사용자 요청: {query}\n\n**{added}**을(를) 목록에 추가했습니다.\n수정된 목록:\n{result_summary}\n\n1-2문장으로 요약해주세요."
     else:
         prompt = f"사용자 요청: {query}\n\n수정된 행사 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
-    blocks.append({"type": "text_stream", "system": _EVENT_SEARCH_SYSTEM_PROMPT, "prompt": prompt})
+    blocks.append({"type": "text_stream", "system": REFINE_SYSTEM_PROMPT, "prompt": prompt})
     return {"response_blocks": blocks}
 
 

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -526,6 +526,8 @@ async def _handle_refinement(
     refinement: dict[str, Any],
 ) -> dict[str, Any]:
     """PLACE_RECOMMEND refinement 처리 — 이전 결과 기반 수정."""
+    from src.graph.refine_helpers import REFINE_SYSTEM_PROMPT  # pyright: ignore[reportMissingImports]
+
     if state.get("_refine_depth", 0) > 1:
         clean = dict(state)
         clean["previous_blocks"] = None
@@ -631,7 +633,7 @@ async def _handle_refinement(
         prompt = f"사용자 요청: {query}\n\n**{added}**을(를) 목록에 추가했습니다.\n수정된 목록:\n{result_summary}\n\n1-2문장으로 요약해주세요."
     else:
         prompt = f"사용자 요청: {query}\n\n수정된 추천 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
-    blocks.append({"type": "text_stream", "system": _RECOMMEND_SYSTEM_PROMPT, "prompt": prompt})
+    blocks.append({"type": "text_stream", "system": REFINE_SYSTEM_PROMPT, "prompt": prompt})
 
     markers = [
         {"place_id": r.get("place_id", ""), "lat": r["lat"], "lng": r["lng"], "label": r.get("name", "")}

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -350,6 +350,8 @@ async def _handle_refinement(
     refinement: dict[str, Any],
 ) -> dict[str, Any]:
     """PLACE_SEARCH refinement 처리 — 이전 결과 기반 수정."""
+    from src.graph.refine_helpers import REFINE_SYSTEM_PROMPT  # pyright: ignore[reportMissingImports]
+
     # 재귀 depth 방어 — 무한 재귀 방지
     if state.get("_refine_depth", 0) > 1:
         clean = dict(state)
@@ -453,7 +455,7 @@ async def _handle_refinement(
         prompt = f"사용자 요청: {query}\n\n**{added}**을(를) 목록에 추가했습니다.\n수정된 목록:\n{result_summary}\n\n1-2문장으로 요약해주세요."
     else:
         prompt = f"사용자 요청: {query}\n\n수정된 결과:\n{result_summary}\n\n위 결과를 종합 요약해주세요."
-    blocks.append({"type": "text_stream", "system": _PLACE_SEARCH_SYSTEM_PROMPT, "prompt": prompt})
+    blocks.append({"type": "text_stream", "system": REFINE_SYSTEM_PROMPT, "prompt": prompt})
 
     markers = [
         {"place_id": r.get("place_id", ""), "lat": r["lat"], "lng": r["lng"], "label": r.get("name", "")}

--- a/backend/src/graph/refine_helpers.py
+++ b/backend/src/graph/refine_helpers.py
@@ -1,12 +1,22 @@
 """REFINE 공통 헬퍼 — 노드별 _handle_refinement에서 공유.
 
-리스트 항목 조작 (replace/remove/add) + 검색 쿼리 생성 유틸.
+리스트 항목 조작 (replace/remove/add) + 검색 쿼리 생성 유틸 + 전용 system prompt.
 """
 
 from __future__ import annotations
 
 import copy
 from typing import Any, Optional
+
+REFINE_SYSTEM_PROMPT = (
+    "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
+    "사용자가 이전 응답의 수정을 요청했고, 수정이 완료되었습니다.\n\n"
+    "## 절대 규칙\n"
+    "- 수정된 내용을 1-2문장으로 간결하게 안내하세요.\n"
+    "- 전체 테마나 매력을 개괄하지 마세요.\n"
+    "- 변경된 항목이 무엇인지 명확히 언급하세요.\n"
+    "- 핵심 키워드는 **굵게** 강조하세요."
+)
 
 
 def apply_remove(items: list[dict[str, Any]], target_index: int) -> list[dict[str, Any]]:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #138

## #️⃣ 작업 내용

> - `REFINE_SYSTEM_PROMPT` 신규 추가 (refine_helpers.py) — "수정 결과를 1-2문장으로 간결하게 안내, 전체 개괄 금지"
> - 5개 노드의 _handle_refinement에서 원본 system prompt → REFINE_SYSTEM_PROMPT로 교체

## #️⃣ 테스트 결과

> 88 passed (1 OS환경 error — 변경 무관)

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)