### PR TITLE
[Feat] 코스 종료시간 자동계산 + description 포맷 고정 + error→reask 블록 수정

### DIFF
--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -48,9 +48,9 @@ _CALENDAR_EXTRACT_PROMPT = """\
 {{
   "event_title": "일정 제목 (문자열, 불명확하면 null)",
   "start_time": "ISO 8601 KST 예: 2026-05-02T14:00:00+09:00 (불명확하면 null)",
-  "end_time": "ISO 8601 KST (언급 없으면 null)",
-  "location": "장소명 (언급 없으면 null)",
-  "description": "대화 맥락에서 파악한 장소 설명·코스 메모·특이사항 (없으면 null)",
+  "end_time": "ISO 8601 KST (아래 규칙 참고, 계산 불가능하면 null)",
+  "location": "첫 번째 방문 장소명 또는 대표 장소명 (언급 없으면 null)",
+  "description": "아래 규칙에 따른 코스 메모 (없으면 null)",
   "url": "대화에서 언급된 예약 URL 또는 장소 상세 링크 (없으면 null)"
 }}
 
@@ -60,6 +60,19 @@ _CALENDAR_EXTRACT_PROMPT = """\
 - 시간은 KST(+09:00) 기준. 오전/오후 표현 그대로 반영.
 - 이벤트 제목은 키워드에서 자연스럽게 유추. 예) keywords=["경복궁"] → "경복궁 방문".
 - 캘린더와 무관한 값("바보" 등)은 null 처리.
+
+[end_time 계산 규칙]
+- 대화에 코스 일정(여러 장소 + 체류시간)이 있으면: 각 장소 체류시간을 분 단위로 합산 → start_time에 더해 end_time 계산.
+  예) start_time=13:00, 명동 15분 + 홍대 30분 + 이태원 45분 = 총 90분 → end_time=14:30
+- 단일 장소이고 체류시간 언급이 있으면: start_time + 해당 시간.
+- 체류시간 언급이 전혀 없으면: null (시스템이 1시간 자동 추가).
+
+[description 포맷 규칙]
+- 코스 장소가 2개 이상이면 반드시 아래 형식으로 작성:
+  1 : 장소명 : X분
+  2 : 장소명 : X분
+  3 : 장소명 : X분
+- 단일 장소이거나 장소 목록이 없으면 자유 형식 메모 또는 null.
 """
 
 
@@ -117,7 +130,7 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
     """
     user_id: Optional[int] = state.get("user_id")
     if not user_id:
-        return {"response_blocks": [_error_block("로그인이 필요합니다.")]}
+        return {"response_blocks": [_reask_block("로그인이 필요합니다.")]}
 
     pq: Optional[dict[str, Any]] = state.get("processed_query")
     history: list[dict[str, str]] = state.get("conversation_history") or []
@@ -175,7 +188,7 @@ async def calendar_node(state: AgentState) -> dict[str, Any]:
         )
         status = "created"
     except _CalendarError as e:
-        return {"response_blocks": [_error_block(str(e))]}
+        return {"response_blocks": [_reask_block(str(e))]}
     except Exception:
         logger.exception("calendar_node: 이벤트 생성 실패")
         calendar_link = None

--- a/backend/tests/test_calendar_node.py
+++ b/backend/tests/test_calendar_node.py
@@ -47,7 +47,7 @@ def _make_pool_mock(has_token: bool = True) -> Any:
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_missing_user_id_returns_error() -> None:
-    """user_id 미입력 시 로그인 안내 error 블록 반환."""
+    """user_id 미입력 시 로그인 안내 text_stream 블록 반환."""
     state: dict[str, Any] = {
         "processed_query": {"keywords": ["경복궁"]},
         "conversation_history": [],
@@ -55,8 +55,8 @@ async def test_missing_user_id_returns_error() -> None:
     result = await calendar_node(state)  # type: ignore[arg-type]
     blocks = result["response_blocks"]
     assert len(blocks) == 1
-    assert blocks[0]["type"] == "error"
-    assert "로그인" in blocks[0]["message"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "로그인" in blocks[0]["prompt"]
 
 
 @pytest.mark.asyncio
@@ -126,8 +126,8 @@ async def test_no_oauth_token_returns_error() -> None:
         result = await calendar_node(state)  # type: ignore[arg-type]
 
     blocks = result["response_blocks"]
-    assert blocks[0]["type"] == "error"
-    assert "Google" in blocks[0]["message"]
+    assert blocks[0]["type"] == "text_stream"
+    assert "Google" in blocks[0]["prompt"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> #145 

## #️⃣ 작업 내용

- _CALENDAR_EXTRACT_PROMPT에 end_time 계산 규칙 추가 (코스 체류시간 합산 → start_time 기준 자동 계산, 정보 없으면 null)
- description 포맷 고정: 장소 2개 이상 시 '1 : 장소명 : X분' 형식 강제
- user_id 미입력 및 _CalendarError 시 _error_block → _reask_block 변경 (FE error 이벤트 무시 버그로 인해 응답이 표시되지 않던 문제 수정)
- 테스트 assertions 업데이트 (type: error → text_stream, message → prompt)

## #️⃣ 테스트 결과

- pytest 9/9 통과
  - 실제 Gemini API 호출로 코스 시나리오 직접 검증
    - 입력: 홍대 코스 (AK플라자 15분 + 홍대걷고싶은거리 30분 + 연남동 카페
  45분), 13:00 시작
    - end_time: 14:30 정확 계산 (15+30+45=90분)
    - description 포맷 정상 출력

## #️⃣ 변경 사항 체크리스트

  - [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
  - [x] 문서를 작성하거나 수정했나요? (필요한 경우)
  - [x] 코드 컨벤션에 따라 코드를 작성했나요?
  - [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced calendar event extraction with improved end-time calculation for multi-stop events and better formatting of location descriptions.

* **Bug Fixes**
  * Improved error handling for missing login credentials and authorization issues with better user-facing prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->