### PR TITLE
[Fix] 다중 의도 분류 SEARCH↔RECOMMEND 오분류 교정 (#156)

### DIFF
--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -109,6 +109,15 @@ Phase 1 (active):
 Phase 2 (not yet active, classify as GENERAL for now):
 - ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
 
+SEARCH vs RECOMMEND (important):
+- Use PLACE_SEARCH / EVENT_SEARCH when the user looks something up with concrete criteria
+  already in mind — a location, a category, a name, or verbs like "찾아줘", "알려줘", "있어?",
+  "어디야", "보여줘". Example: "강남 맛집 찾아줘", "주말 전시회 알려줘" → *_SEARCH.
+- Use PLACE_RECOMMEND / EVENT_RECOMMEND ONLY when the user explicitly asks for a suggestion and
+  leaves the choice open — "추천", "추천해줘", "갈 만한 곳", "괜찮은 데", "뭐가 좋아?".
+  Example: "홍대 카페 추천해줘" → PLACE_RECOMMEND.
+- When ambiguous between SEARCH and RECOMMEND, prefer SEARCH.
+
 Respond in JSON: {"intent": "INTENT_NAME", "confidence": 0.0-1.0}
 """
 
@@ -135,6 +144,15 @@ Phase 1 (active):
 
 Phase 2 (not yet active, classify as GENERAL for now):
 - ANALYSIS: analyzing a single place with 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
+
+SEARCH vs RECOMMEND (important):
+- Use PLACE_SEARCH / EVENT_SEARCH when the user looks something up with concrete criteria
+  already in mind — a location, a category, a name, or verbs like "찾아줘", "알려줘", "있어?",
+  "어디야", "보여줘". Example: "강남 맛집 찾아줘", "주말 전시회 알려줘" → *_SEARCH.
+- Use PLACE_RECOMMEND / EVENT_RECOMMEND ONLY when the user explicitly asks for a suggestion and
+  leaves the choice open — "추천", "추천해줘", "갈 만한 곳", "괜찮은 데", "뭐가 좋아?".
+  Example: "홍대 카페 추천해줘" → PLACE_RECOMMEND.
+- When ambiguous between SEARCH and RECOMMEND, prefer SEARCH.
 
 Rules:
 - If the query has ONE purpose, return ONE intent. Example: "카페에서 전시회 가는 코스" → COURSE_PLAN only.

--- a/backend/tests/test_multi_intent.py
+++ b/backend/tests/test_multi_intent.py
@@ -207,3 +207,21 @@ async def test_intent_router_node_no_injection() -> None:
     mock_classify.assert_called_once_with("안녕", None)
     assert result["intent"] == "GENERAL"
     assert result["response_blocks"][0]["intent"] == "GENERAL"
+
+
+# ---------------------------------------------------------------------------
+# 프롬프트 가드 — SEARCH vs RECOMMEND 판별 규칙 존재 확인
+# ---------------------------------------------------------------------------
+
+
+async def test_classify_prompts_have_search_recommend_guidance() -> None:
+    """'찾아줘/알려줘'(SEARCH)를 RECOMMEND로 오분류하던 문제 교정 규칙 보존.
+
+    라이브 검증(2026-05-25)에서 EVENT_SEARCH/PLACE_SEARCH 쿼리가 RECOMMEND로
+    오분류되어 프롬프트에 판별 규칙을 추가했다. 실수로 제거되지 않도록 가드한다.
+    """
+    from src.graph import intent_router_node as mod  # pyright: ignore[reportMissingImports]
+
+    for prompt in (mod._CLASSIFY_MULTI_SYSTEM_PROMPT, mod._CLASSIFY_SYSTEM_PROMPT):
+        assert "SEARCH vs RECOMMEND" in prompt
+        assert "prefer SEARCH" in prompt


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #156

## #️⃣ 작업 내용

> - 다중 의도 분류 프롬프트(`_CLASSIFY_MULTI_SYSTEM_PROMPT`)에 **SEARCH↔RECOMMEND 판별 규칙** 추가
>   - "찾아줘/알려줘/있어?/어디야/보여줘" + 구체 조건 → `*_SEARCH`
>   - "추천/추천해줘/갈 만한 곳/뭐가 좋아?" (열린 제안) → `*_RECOMMEND`
>   - 모호하면 SEARCH 우선
> - 단일 의도 fallback 프롬프트(`_CLASSIFY_SYSTEM_PROMPT`)에도 동일 규칙 적용 (일관성)
> - 규칙 silent 제거 방지 가드 테스트 1개 추가

## #️⃣ 테스트 결과

> - **라이브 검증 (실제 Gemini, 13케이스)**: 보강 전 3건 오분류(`전시회 알려줘`→RECOMMEND, `맛집 찾아주고`→RECOMMEND, `근처 전시 있으면`→RECOMMEND) → 보강 후 **13/13 정확**, 회귀 0건 (`추천해줘` 계열은 RECOMMEND 유지)
> - ruff 통과, 그래프/intent 테스트 30개 통과 (신규 가드 포함)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료

> 다중 의도 기능 본 작업: 3cfb934 (feat: SSE 중첩된 요청 대응 (Multi-Intent))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced intent classification to more accurately distinguish between user searches (looking for specific items/events) and recommendation requests (asking for suggestions).

* **Tests**
  * Added regression test to ensure search vs. recommendation classification guidance remains consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->