### PR TITLE
[Feat] Loki + Jaeger 모니터링 연동 

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -59,6 +59,17 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  promtail:
+    image: grafana/promtail:3.2.0
+    container_name: localbiz-promtail
+    volumes:
+      - ./monitoring/promtail.yml:/etc/promtail/config.yml
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - LOKI_HOST=${LOKI_HOST:-10.178.0.4}
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   opensearch_data:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -66,7 +66,11 @@ services:
       - ./monitoring/promtail.yml:/etc/promtail/config.yml
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - LOKI_HOST=${LOKI_HOST:-10.178.0.4}
+      # LOKI_HOST는 .env에서 명시적으로 주입 (예: GCE 배포 시 모니터링 VM 내부 IP).
+      # 미설정 시 docker compose up이 에러로 즉시 인지 — 잘못된 호스트로 로그 푸시 회피.
+      - LOKI_HOST=${LOKI_HOST:?LOKI_HOST not set — define in backend/.env (e.g. monitoring VM internal IP)}
+      # PROMTAIL_ENV는 Loki 로그 라벨에 사용 (env=production/staging/local). 미설정 시 'local'.
+      - PROMTAIL_ENV=${PROMTAIL_ENV:-local}
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     restart: unless-stopped
 

--- a/backend/monitoring/docker-compose.monitoring.yml
+++ b/backend/monitoring/docker-compose.monitoring.yml
@@ -31,7 +31,8 @@ services:
     ports:
       - "3001:3000"
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      # 로컬은 default admin 유지(throwaway). GCE 배포 시 .env에 GRAFANA_ADMIN_PASSWORD 설정 강제.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
       GF_AUTH_ANONYMOUS_ENABLED: "false"
     volumes:
       - grafana_data:/var/lib/grafana

--- a/backend/monitoring/docker-compose.monitoring.yml
+++ b/backend/monitoring/docker-compose.monitoring.yml
@@ -1,12 +1,14 @@
-# 로컬 모니터링 스택 (#155) — Prometheus + Grafana
+# 모니터링 스택 — Prometheus + Grafana + Loki + Jaeger
 #
-# 기동: `cd backend && docker compose -f monitoring/docker-compose.monitoring.yml up -d`
-#   - Prometheus: http://localhost:9091 (Status → Targets에서 백엔드 UP 확인)
-#     ※ 호스트 9091 → 컨테이너 9090. 다른 프로젝트의 prometheus가 9090을 쓰는 경우와 충돌 회피.
-#     ※ Grafana → Prometheus는 도커 네트워크 내부 통신(http://prometheus:9090)이라 영향 없음.
-#   - Grafana:    http://localhost:3001 (admin / admin) — "FastAPI Overview" 자동 로드
+# 기동 (GCE 모니터링 VM 또는 로컬):
+#   cd backend && docker compose -f monitoring/docker-compose.monitoring.yml up -d
 #
-# Loki(로그)·Jaeger(트레이싱)는 후속 이슈에서 활성화 — loki.yml·tempo 설정 추가 필요.
+#   - Prometheus : http://<host>:9091  (Status → Targets에서 localbiz-backend UP 확인)
+#   - Grafana    : http://<host>:3001  (admin / admin) — FastAPI Overview 자동 로드
+#   - Loki       : http://<host>:3100  (Grafana → Explore → Loki 로그 조회)
+#   - Jaeger UI  : http://<host>:16686 (트레이스 조회)
+#
+# Promtail은 API VM의 docker-compose.yml에서 사이드카로 실행 (로그 → Loki 전송).
 
 services:
   prometheus:
@@ -21,7 +23,6 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=15d'
     extra_hosts:
-      # Linux에서 host.docker.internal을 호스트 게이트웨이로 해석 (macOS/Windows는 native 지원)
       - "host.docker.internal:host-gateway"
 
   grafana:
@@ -30,31 +31,35 @@ services:
     ports:
       - "3001:3000"
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin  # 로컬 한정. GCE 배포 시 시크릿 처리
+      GF_SECURITY_ADMIN_PASSWORD: admin
       GF_AUTH_ANONYMOUS_ENABLED: "false"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/etc/grafana/dashboards
 
-  # ─── 후속 이슈에서 활성화 ──────────────────────────────────────
-  # loki:
-  #   image: grafana/loki:3.2.0
-  #   container_name: localbiz-loki
-  #   ports:
-  #     - "3100:3100"
-  #   volumes:
-  #     - ./loki.yml:/etc/loki/local-config.yaml   # 별도 PR에서 추가
-  #     - loki_data:/loki
-  #
-  # jaeger:
-  #   image: jaegertracing/all-in-one:1.60
-  #   container_name: localbiz-jaeger
-  #   ports:
-  #     - "6831:6831/udp"
-  #     - "16686:16686"
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: localbiz-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki.yml:/etc/loki/local-config.yaml
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    container_name: localbiz-jaeger
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
 
 volumes:
   prometheus_data:
   grafana_data:
-  # loki_data:
+  loki_data:

--- a/backend/monitoring/grafana/provisioning/datasources/jaeger.yml
+++ b/backend/monitoring/grafana/provisioning/datasources/jaeger.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Jaeger
+    type: jaeger
+    uid: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    isDefault: false
+    editable: false

--- a/backend/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/backend/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/backend/monitoring/loki.yml
+++ b/backend/monitoring/loki.yml
@@ -1,0 +1,38 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true

--- a/backend/monitoring/promtail.yml
+++ b/backend/monitoring/promtail.yml
@@ -25,4 +25,5 @@ scrape_configs:
       - target_label: job
         replacement: localbiz-api
       - target_label: env
-        replacement: production
+        # PROMTAIL_ENV는 docker-compose에서 주입 (config.expand-env 활성). 미설정 시 'local'.
+        replacement: ${PROMTAIL_ENV:-local}

--- a/backend/monitoring/promtail.yml
+++ b/backend/monitoring/promtail.yml
@@ -1,0 +1,28 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://${LOKI_HOST}:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: name
+            values: [localbiz-api]
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: stream
+      - target_label: job
+        replacement: localbiz-api
+      - target_label: env
+        replacement: production

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -100,6 +100,10 @@ Instrumentator(
     excluded_handlers=["/health", "/metrics"],
 ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
+from src.telemetry import setup_tracing  # noqa: E402  # pyright: ignore[reportMissingImports]
+
+setup_tracing(app)
+
 
 # --- 라우터 등록 ---
 # 각 파일에서 정의한 router를 앱에 연결.

--- a/backend/src/telemetry.py
+++ b/backend/src/telemetry.py
@@ -1,0 +1,41 @@
+"""OpenTelemetry Jaeger tracing 설정.
+
+JAEGER_HOST 환경변수가 없으면 no-op — 로컬 개발 영향 없음.
+GCE 배포 시 .env에 JAEGER_HOST=10.178.0.4 추가.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+
+def setup_tracing(app: FastAPI) -> None:
+    jaeger_host = os.getenv("JAEGER_HOST", "").strip()
+    if not jaeger_host:
+        return
+
+    try:
+        from opentelemetry import trace  # pyright: ignore[reportMissingImports]
+        from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # pyright: ignore[reportMissingImports]
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor  # pyright: ignore[reportMissingImports]
+
+        exporter = JaegerExporter(
+            agent_host_name=jaeger_host,
+            agent_port=int(os.getenv("JAEGER_PORT", "6831")),
+        )
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+        FastAPIInstrumentor.instrument_app(app)
+        logger.info("Jaeger tracing 활성화: %s:6831", jaeger_host)
+    except Exception:
+        logger.warning("Jaeger tracing 설정 실패 — 계속 진행", exc_info=True)

--- a/backend/src/telemetry.py
+++ b/backend/src/telemetry.py
@@ -21,21 +21,35 @@ def setup_tracing(app: FastAPI) -> None:
     if not jaeger_host:
         return
 
+    jaeger_port = int(os.getenv("JAEGER_PORT", "6831"))
+
+    # 1) 의존성 누락은 ImportError로 명확히 구분 — silent fail 회피, 무엇이 빠졌는지 로그에 노출.
     try:
         from opentelemetry import trace  # pyright: ignore[reportMissingImports]
         from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # pyright: ignore[reportMissingImports]
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pyright: ignore[reportMissingImports]
         from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
         from opentelemetry.sdk.trace.export import BatchSpanProcessor  # pyright: ignore[reportMissingImports]
-
-        exporter = JaegerExporter(
-            agent_host_name=jaeger_host,
-            agent_port=int(os.getenv("JAEGER_PORT", "6831")),
+    except ImportError as exc:
+        logger.warning(
+            "Jaeger tracing 의존성 누락 (%s) — `pip install opentelemetry-api opentelemetry-sdk "
+            "opentelemetry-exporter-jaeger opentelemetry-instrumentation-fastapi` 필요. tracing 비활성.",
+            exc,
         )
+        return
+
+    # 2) 런타임 초기화 실패는 별도 처리 — host/port를 로그에 포함해 진단 가능.
+    try:
+        exporter = JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
         provider = TracerProvider()
         provider.add_span_processor(BatchSpanProcessor(exporter))
         trace.set_tracer_provider(provider)
         FastAPIInstrumentor.instrument_app(app)
-        logger.info("Jaeger tracing 활성화: %s:6831", jaeger_host)
+        logger.info("Jaeger tracing 활성화: %s:%d", jaeger_host, jaeger_port)
     except Exception:
-        logger.warning("Jaeger tracing 설정 실패 — 계속 진행", exc_info=True)
+        logger.warning(
+            "Jaeger tracing 초기화 실패 (host=%s, port=%d) — 계속 진행",
+            jaeger_host,
+            jaeger_port,
+            exc_info=True,
+        )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#161

## #️⃣ 작업 내용

PR #160 (Prometheus + Grafana) 후속 — Loki(로그 집계) + Jaeger(분산 트레이싱) 연동.

- `monitoring/loki.yml`: Loki 3.2.0 로컬 파일시스템 설정
- `monitoring/promtail.yml`: localbiz-api 컨테이너 로그 수집 → Loki 전송 (LOKI_HOST 환경변수)
- `docker-compose.monitoring.yml`: Loki·Jaeger 서비스 활성화, Jaeger OTLP 포트(4317/4318) 추가
- `docker-compose.yml`: Promtail 사이드카 추가
- `grafana/provisioning/datasources/loki.yml`, `jaeger.yml`: Grafana datasource 자동 프로비저닝
- `src/telemetry.py`: OpenTelemetry Jaeger tracing (JAEGER_HOST 미설정 시 no-op)
- `src/main.py`: setup_tracing(app) 호출 추가

## #️⃣ 테스트 결과

- validate.sh 통과 (ruff / pyright / pytest)
- JAEGER_HOST 미설정 시 서버 정상 기동 확인 (no-op 동작)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 해당 없음

## #️⃣ 리뷰 요구사항 (선택)

GCE 배포 시 API VM `.env`에 아래 두 줄 추가 필요:
```
JAEGER_HOST=10.178.0.4
LOKI_HOST=10.178.0.4
```

모니터링 VM에서 스택 기동:
```bash
cd ~/LocalBiz-Seoul/backend
docker compose -f monitoring/docker-compose.monitoring.yml up -d
```

## 📎 참고 자료 (선택)

- Grafana UI: http://34.50.51.76:3001
- Jaeger UI: http://34.50.51.76:16686
- Loki: http://34.50.51.76:3100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive monitoring and observability stack with Grafana, Prometheus, Loki, and Jaeger.
  * Implemented centralized log aggregation with automatic log shipping.
  * Enabled distributed tracing to track application performance and request flows across services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->