### PR TITLE
[Fix] promtail LOKI_HOST 필수변수가 api 배포 차단 — 기본값+프로파일 분리

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -62,13 +62,18 @@ services:
   promtail:
     image: grafana/promtail:3.2.0
     container_name: localbiz-promtail
+    # monitoring 프로파일 — 메인 api 배포(`docker compose up api`)에 포함되지 않는다.
+    # 모니터링 기동: docker compose --profile monitoring up -d promtail
+    profiles: ["monitoring"]
     volumes:
       - ./monitoring/promtail.yml:/etc/promtail/config.yml
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      # LOKI_HOST는 .env에서 명시적으로 주입 (예: GCE 배포 시 모니터링 VM 내부 IP).
-      # 미설정 시 docker compose up이 에러로 즉시 인지 — 잘못된 호스트로 로그 푸시 회피.
-      - LOKI_HOST=${LOKI_HOST:?LOKI_HOST not set — define in backend/.env (e.g. monitoring VM internal IP)}
+      # LOKI_HOST는 .env에서 주입 (예: GCE 배포 시 모니터링 VM 내부 IP). 미설정 시 127.0.0.1.
+      # 필수(:?) 문법은 compose가 파일 전체를 인터폴레이션할 때 api 단독 배포까지
+      # 막으므로(api deploy는 LOKI_HOST를 모름) 기본값을 둔다. 실제 로그 푸시는
+      # monitoring 프로파일 기동 시 .env의 LOKI_HOST로 결정.
+      - LOKI_HOST=${LOKI_HOST:-127.0.0.1}
       # PROMTAIL_ENV는 Loki 로그 라벨에 사용 (env=production/staging/local). 미설정 시 'local'.
       - PROMTAIL_ENV=${PROMTAIL_ENV:-local}
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> (CD 디버깅 루프 — #158 후속)

## #️⃣ 작업 내용

> feat/#161(모니터링) 머지 후 `backend/docker-compose.yml`의 promtail 서비스가 `${LOKI_HOST:?...}` 필수변수를 써서, api 단독 배포(`docker compose build/up api`)도 compose 전체 파일 인터폴레이션 단계에서 실패함.
> - `LOKI_HOST=${LOKI_HOST:-127.0.0.1}` 기본값으로 변경 → 인터폴레이션 에러 제거
> - promtail에 `profiles: ["monitoring"]` 추가 → 메인 api 배포에서 완전 분리

## #️⃣ 테스트 결과

> 로컬 검증 (LOKI_HOST 미설정 = 서버와 동일 조건):
> - `docker compose config -q` 통과 (이전: `required variable LOKI_HOST is missing` 에러)
> - 기본 프로파일 서비스: postgres / opensearch / api (promtail 제외)
> - monitoring 프로파일: + promtail

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made Promtail monitoring service optional through profile-based configuration.
  * Improved environment variable handling to support deployments without monitoring setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->