### PR TITLE
[Fix] CD 배포 중복 네트워크 정리 — backend_default ambiguous 해결

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -90,6 +90,11 @@ jobs:
           docker system prune -af --filter "until=72h" || true
           docker builder prune -af || true
 
+          # 중복 네트워크 정리 — #159 이전 동시배포 레이스가 동일 이름(backend_default)
+          # 네트워크를 복수 생성 → "network backend_default is ambiguous" 유발.
+          # 컨테이너 미부착 고아 네트워크를 제거(실행 중 pg/os가 쓰는 네트워크는 보존).
+          docker network prune -f || true
+
           # 잔재 컨테이너 강제 정리 (#148) — 이전 deploy가 중간 실패 시 남긴
           # rename 임시 컨테이너(예: <hash>_localbiz-api)와 이름 충돌 방지.
           docker ps -a --format '{{.Names}}' | grep -E '(^|_)localbiz-api$' | xargs -r docker rm -f 2>/dev/null || true


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> (CD 디버깅 루프 — #158/#164/#165 후속, 4번째 원인)

## #️⃣ 작업 내용
> 컨테이너 생성까지 통과 후 `Error response from daemon: network backend_default is ambiguous (2 matches found on name)`로 실패. #159 이전 동시배포 레이스가 동일 이름 네트워크를 중복 생성한 고아 잔재.
> - `docker network prune -f` 추가 → 컨테이너 미부착 중복 네트워크 제거(실행 중 pg/os 네트워크는 보존)

## #️⃣ 테스트 결과
> YAML 파싱 통과. 머지로 Deploy 런 green 확인 예정.

## #️⃣ 변경 사항 체크리스트
- [x] 테스트 작성/실행
- [ ] 문서
- [x] 코드 컨벤션
- [x] 의존성 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)