### PR TITLE
[Feat] 장소 카드 Google Places 썸네일 이미지 추가

### DIFF
--- a/backend/src/graph/detail_inquiry_node.py
+++ b/backend/src/graph/detail_inquiry_node.py
@@ -83,6 +83,7 @@ def _extract_search_term(
 def _build_detail_blocks(
     query: str,
     place_row: Optional[dict[str, Any]],
+    photo_url: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     """장소 조회 결과 → text_stream + place 블록 생성.
 
@@ -146,6 +147,8 @@ def _build_detail_blocks(
         place_block["lat"] = place_row["lat"]
     if place_row.get("lng") is not None:
         place_block["lng"] = place_row["lng"]
+    if photo_url:
+        place_block["image_url"] = photo_url
 
     from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
 
@@ -204,7 +207,17 @@ async def detail_inquiry_node(state: dict[str, Any]) -> dict[str, Any]:
     pool = get_pool()
     place_row = await _fetch_place(pool, search_term)
 
-    blocks = _build_detail_blocks(query, place_row)
+    # Google Places 썸네일 (단건) — 키/사진 없으면 None
+    photo_url: Optional[str] = None
+    if place_row is not None:
+        from src.config import get_settings  # pyright: ignore[reportMissingImports]
+        from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+        pid = str(place_row.get("place_id", ""))
+        photos = await fetch_image_urls(pool, [pid], get_settings().google_places_api_key)
+        photo_url = photos.get(pid)
+
+    blocks = _build_detail_blocks(query, place_row, photo_url)
 
     if place_row is not None:
         logger.info("detail_inquiry: found place=%s", place_row.get("name", "")[:50])

--- a/backend/src/graph/image_search_node.py
+++ b/backend/src/graph/image_search_node.py
@@ -636,6 +636,8 @@ def _place_to_block(place: dict[str, Any]) -> dict[str, Any]:
         block["lat"] = place["lat"]
     if place.get("lng") is not None:
         block["lng"] = place["lng"]
+    if place.get("image_url"):
+        block["image_url"] = place["image_url"]
     from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
 
     attach_map_urls(block)
@@ -725,6 +727,20 @@ async def _run_knn(
                 "장소명을 직접 알려주시면 더 잘 찾아드릴 수 있다고 안내해주세요."
             )
         ]
+
+    # Google Places 썸네일 주입 (키/사진 없으면 무변경)
+    from src.config import get_settings  # pyright: ignore[reportMissingImports]
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    photo_urls = await fetch_image_urls(
+        pool,
+        [str(p.get("place_id", "")) for p in places],
+        get_settings().google_places_api_key,
+    )
+    for p in places:
+        url = photo_urls.get(str(p.get("place_id", "")))
+        if url:
+            p["image_url"] = url
 
     result_summary = "\n".join(
         f"- {p.get('name', '')} ({p.get('category', '')}, {p.get('district', '')})" for p in places

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -397,6 +397,7 @@ def _build_blocks(
     results: list[dict[str, Any]],
     reasons: dict[str, str],
     review_data_map: dict[str, dict[str, Any]],
+    photo_urls: Optional[dict[str, str]] = None,
 ) -> list[dict[str, Any]]:
     """places(+summary) + text_stream(종합 요약) + map_markers + references 블록 생성.
 
@@ -429,6 +430,10 @@ def _build_blocks(
         reason = reasons.get(pid)
         if reason:
             item["summary"] = reason
+        # Google Places 썸네일 (있을 때만) — 카드 이미지
+        photo_url = (photo_urls or {}).get(str(pid))
+        if photo_url:
+            item["image_url"] = photo_url
         from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
 
         attach_map_urls(item)
@@ -730,8 +735,19 @@ async def place_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     except Exception:
         logger.warning("congestion fetch skipped")
 
+    # Google Places 썸네일 조회 (키 없거나 사진 없으면 빈 dict)
+    photo_urls: dict[str, str] = {}
+    if reranked:
+        from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+        photo_urls = await fetch_image_urls(
+            pool,
+            [str(r.get("place_id", "")) for r in reranked],
+            settings.google_places_api_key,
+        )
+
     # ⑥ 블록 생성
-    blocks = _build_blocks(query, reranked, reasons, review_data_map)
+    blocks = _build_blocks(query, reranked, reasons, review_data_map, photo_urls)
 
     logger.info(
         "place_recommend: pg=%d, os_places=%d, os_reviews=%d, merged=%d, final=%d",

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -255,6 +255,7 @@ def _build_blocks(
     query: str,
     results: list[dict[str, Any]],
     descriptions: dict[str, str],
+    photo_urls: Optional[dict[str, str]] = None,
 ) -> list[dict[str, Any]]:
     """검색 결과 → places(+summary) + text_stream(종합 요약) + map_markers 블록."""
     blocks: list[dict[str, Any]] = []
@@ -283,6 +284,10 @@ def _build_blocks(
         desc = descriptions.get(r.get("place_id", ""))
         if desc:
             item["summary"] = desc
+        # Google Places 썸네일 (있을 때만) — 카드 이미지
+        photo_url = (photo_urls or {}).get(str(r.get("place_id", "")))
+        if photo_url:
+            item["image_url"] = photo_url
         from src.models.blocks import attach_map_urls  # pyright: ignore[reportMissingImports]
 
         attach_map_urls(item)
@@ -540,8 +545,19 @@ async def place_search_node(state: dict[str, Any]) -> dict[str, Any]:
     if results and settings.gemini_llm_api_key:
         descriptions = await _generate_place_descriptions(results, query, settings.gemini_llm_api_key)
 
+    # Google Places 썸네일 조회 (키 없거나 사진 없으면 빈 dict, 카드는 정상 표시)
+    photo_urls: dict[str, str] = {}
+    if results:
+        from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+        photo_urls = await fetch_image_urls(
+            pool,
+            [str(r.get("place_id", "")) for r in results],
+            settings.google_places_api_key,
+        )
+
     # 블록 생성
-    blocks = _build_blocks(query, results, descriptions)
+    blocks = _build_blocks(query, results, descriptions, photo_urls)
 
     logger.info("place_search: pg=%d, os=%d, merged=%d", len(pg_results), len(os_results), len(results))
 

--- a/backend/src/services/place_photo.py
+++ b/backend/src/services/place_photo.py
@@ -1,0 +1,109 @@
+"""Google Places Photo API — 장소 카드 썸네일 URL 조회.
+
+흐름: google_place_id → Place Details(fields=photos) → 첫 사진 name
+→ media(skipHttpRedirect=true) → photoUri(googleusercontent.com, API 키 불포함) 반환.
+
+Phase 1: 런타임 조회 (캐시는 Phase 2). 실패·사진없음·키없음은 조용히 None/제외 —
+카드는 이미지 없이 정상 표시되어야 하므로 절대 예외를 호출부로 던지지 않는다.
+
+불변식: 외부 HTTP는 src.utils.resilience.request_json 사용 (timeout+retry, host-only 로깅 #19).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_PLACES_API_BASE = "https://places.googleapis.com/v1"
+_DEFAULT_MAX_WIDTH = 400
+_PHOTO_TIMEOUT = 8.0
+
+
+async def _fetch_photo_url(google_place_id: str, api_key: str, max_width: int) -> Optional[str]:
+    """단일 google_place_id → 사진 photoUri. 사진 없거나 실패 시 None."""
+    from src.utils.resilience import request_json  # pyright: ignore[reportMissingImports]
+
+    try:
+        details = await request_json(
+            "GET",
+            f"{_PLACES_API_BASE}/places/{google_place_id}?fields=photos&key={api_key}",
+            timeout=_PHOTO_TIMEOUT,
+        )
+    except Exception:
+        logger.info("place_photo: Place Details 조회 실패")
+        return None
+
+    photos = details.get("photos") if isinstance(details, dict) else None
+    if not photos:
+        return None
+    name = photos[0].get("name") if isinstance(photos[0], dict) else None
+    if not name:
+        return None
+
+    try:
+        media = await request_json(
+            "GET",
+            f"{_PLACES_API_BASE}/{name}/media?maxWidthPx={max_width}&skipHttpRedirect=true&key={api_key}",
+            timeout=_PHOTO_TIMEOUT,
+        )
+    except Exception:
+        logger.info("place_photo: media 조회 실패")
+        return None
+
+    if isinstance(media, dict):
+        return media.get("photoUri")
+    return None
+
+
+async def fetch_image_urls(
+    pool: Any,
+    place_ids: list[str],
+    api_key: str,
+    max_width: int = _DEFAULT_MAX_WIDTH,
+) -> dict[str, str]:
+    """내부 place_id 리스트 → {place_id: photoUri}.
+
+    1. places에서 google_place_id 일괄 조회 (NULL/빈값 제외)
+    2. Photos API 병렬 호출 (장소별 Place Details + media)
+    3. 사진이 있는 항목만 반환 — 키가 없는 place_id는 카드에 이미지 미표시
+
+    키 미설정·입력 없음·조회 실패·전부 사진없음이면 빈 dict.
+    절대 예외를 호출부로 전파하지 않는다 (이미지는 보조 정보).
+    """
+    if not place_ids or not api_key:
+        return {}
+
+    try:
+        rows = await pool.fetch(
+            "SELECT place_id, google_place_id FROM places "
+            "WHERE place_id::text = ANY($1::text[]) "
+            "AND google_place_id IS NOT NULL AND google_place_id <> ''",
+            [str(pid) for pid in place_ids],
+        )
+    except Exception:
+        logger.exception("place_photo: google_place_id 조회 실패")
+        return {}
+
+    gpid_by_pid: dict[str, str] = {str(r["place_id"]): r["google_place_id"] for r in rows}
+    if not gpid_by_pid:
+        return {}
+
+    async def _one(pid: str, gpid: str) -> tuple[str, Optional[str]]:
+        return pid, await _fetch_photo_url(gpid, api_key, max_width)
+
+    gathered = await asyncio.gather(
+        *(_one(pid, gpid) for pid, gpid in gpid_by_pid.items()),
+        return_exceptions=True,
+    )
+
+    out: dict[str, str] = {}
+    for item in gathered:
+        if isinstance(item, BaseException):
+            continue
+        pid, url = item
+        if url:
+            out[pid] = url
+    return out

--- a/backend/tests/test_place_photo.py
+++ b/backend/tests/test_place_photo.py
@@ -1,0 +1,108 @@
+"""place_photo 서비스 단위 테스트 — Google Places Photo 조회.
+
+외부 HTTP(request_json) + DB(pool) 모두 mock. 실연결 없음.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pool_with_rows(rows: list[dict[str, Any]]) -> AsyncMock:
+    pool = AsyncMock()
+    pool.fetch = AsyncMock(return_value=rows)
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# fetch_image_urls — 가드
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_image_urls_empty_key() -> None:
+    """키 없으면 빈 dict (외부 호출/DB 조회도 안 함)."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    pool = _pool_with_rows([])
+    result = await fetch_image_urls(pool, ["p1"], api_key="")
+    assert result == {}
+    pool.fetch.assert_not_called()
+
+
+async def test_fetch_image_urls_empty_place_ids() -> None:
+    """place_ids 없으면 빈 dict."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    result = await fetch_image_urls(_pool_with_rows([]), [], api_key="k")
+    assert result == {}
+
+
+async def test_fetch_image_urls_no_google_place_id() -> None:
+    """google_place_id 가진 행이 없으면 빈 dict."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    result = await fetch_image_urls(_pool_with_rows([]), ["p1"], api_key="k")
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_image_urls — 성공
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_image_urls_success() -> None:
+    """google_place_id → Place Details → media → photoUri 매핑."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    pool = _pool_with_rows([{"place_id": "p1", "google_place_id": "gp1"}])
+
+    # request_json: 1) Place Details(photos) 2) media(photoUri)
+    mock_req = AsyncMock(
+        side_effect=[
+            {"photos": [{"name": "places/gp1/photos/ref1"}]},
+            {"photoUri": "https://lh3.googleusercontent.com/abc=s4800-w400"},
+        ]
+    )
+    with patch("src.utils.resilience.request_json", mock_req):
+        result = await fetch_image_urls(pool, ["p1"], api_key="k")
+
+    assert result == {"p1": "https://lh3.googleusercontent.com/abc=s4800-w400"}
+
+
+async def test_fetch_image_urls_no_photos_excluded() -> None:
+    """사진 없는 장소는 결과에서 제외 (에러 아님)."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    pool = _pool_with_rows([{"place_id": "p1", "google_place_id": "gp1"}])
+    mock_req = AsyncMock(return_value={"photos": []})  # Place Details에 photos 없음
+    with patch("src.utils.resilience.request_json", mock_req):
+        result = await fetch_image_urls(pool, ["p1"], api_key="k")
+
+    assert result == {}
+
+
+async def test_fetch_image_urls_http_error_swallowed() -> None:
+    """외부 호출 예외는 삼켜지고 해당 장소만 제외."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    pool = _pool_with_rows([{"place_id": "p1", "google_place_id": "gp1"}])
+    mock_req = AsyncMock(side_effect=Exception("502"))
+    with patch("src.utils.resilience.request_json", mock_req):
+        result = await fetch_image_urls(pool, ["p1"], api_key="k")
+
+    assert result == {}
+
+
+async def test_fetch_image_urls_db_error_swallowed() -> None:
+    """DB 조회 실패 시 빈 dict (예외 전파 안 함)."""
+    from src.services.place_photo import fetch_image_urls  # pyright: ignore[reportMissingImports]
+
+    pool = AsyncMock()
+    pool.fetch = AsyncMock(side_effect=Exception("db down"))
+    result = await fetch_image_urls(pool, ["p1"], api_key="k")
+    assert result == {}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> 장소 카드 이미지 (보류됐던 작업 재개)

## #️⃣ 작업 내용
> 장소 카드(PlaceBlock)에 Google Places 썸네일을 채운다.
> - **신규** `src/services/place_photo.py`: `google_place_id` 일괄 조회 → Place Details(`fields=photos`) → 첫 사진 → media(`skipHttpRedirect=true`) → `photoUri`(googleusercontent, API 키 불포함) 반환. 장소별 병렬 호출, null-safe, 예외 비전파.
> - 4개 노드 연결: `place_search` / `place_recommend` / `detail_inquiry` / `image_search` → 각 카드에 `image_url` 주입
> - 키 미설정·사진 없음·조회 실패 시 이미지 없이 카드 정상 표시 (graceful)

## #️⃣ 테스트 결과
> - 라이브 검증: 실제 키로 경복궁 place_id → photoUri(`https://lh3.googleusercontent.com/...`) 정상 반환 확인
> - 단위 테스트 `tests/test_place_photo.py` 6 케이스 통과 (키없음/입력없음/성공/사진없음/HTTP에러/DB에러)
> - ruff 통과, 4개 노드 import 정상

## #️⃣ 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 📎 참고 자료
> Phase 2(자주 조회되는 photoUri DB 캐시)는 후속. 현재는 런타임 조회라 검색당 장소수×2 API 호출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail images to place cards in search results, place recommendations, image search, and place details views.
  * Images are automatically fetched from Google Places when available.

* **Tests**
  * Added test suite for the new image retrieval functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->