### PR TITLE
fix: Jaeger service.name 명시 + /health·/metrics trace 제외 (운영 노이즈 회피)

### DIFF
--- a/backend/src/telemetry.py
+++ b/backend/src/telemetry.py
@@ -23,9 +23,13 @@ def setup_tracing(app: FastAPI) -> None:
 
     jaeger_port = int(os.getenv("JAEGER_PORT", "6831"))
     # service.name 미설정 시 Jaeger UI에 'unknown_service'로 표시됨. OTEL_SERVICE_NAME 환경변수 우선, default 'localbiz-api'.
-    service_name = os.getenv("OTEL_SERVICE_NAME", "localbiz-api")
+    # 빈/공백 값은 default로 대체 — env에 빈 문자열만 들어있으면 unknown_service로 다시 떨어지는 함정 회피.
+    service_name = os.getenv("OTEL_SERVICE_NAME", "").strip() or "localbiz-api"
     # /health, /metrics는 GCE 헬스체크·Prometheus scrape로 초마다 호출돼 trace를 도배함 — 분석 노이즈 회피.
-    excluded_urls = os.getenv("OTEL_EXCLUDED_URLS", "/health,/metrics")
+    # 각 항목 trim — env에 `"/health, /metrics"` 형태로 공백 섞여 들어와도 정확히 매칭되도록.
+    excluded_urls = ",".join(
+        u.strip() for u in os.getenv("OTEL_EXCLUDED_URLS", "/health,/metrics").split(",") if u.strip()
+    )
 
     # 1) 의존성 누락은 ImportError로 명확히 구분 — silent fail 회피, 무엇이 빠졌는지 로그에 노출.
     try:

--- a/backend/src/telemetry.py
+++ b/backend/src/telemetry.py
@@ -22,12 +22,17 @@ def setup_tracing(app: FastAPI) -> None:
         return
 
     jaeger_port = int(os.getenv("JAEGER_PORT", "6831"))
+    # service.name 미설정 시 Jaeger UI에 'unknown_service'로 표시됨. OTEL_SERVICE_NAME 환경변수 우선, default 'localbiz-api'.
+    service_name = os.getenv("OTEL_SERVICE_NAME", "localbiz-api")
+    # /health, /metrics는 GCE 헬스체크·Prometheus scrape로 초마다 호출돼 trace를 도배함 — 분석 노이즈 회피.
+    excluded_urls = os.getenv("OTEL_EXCLUDED_URLS", "/health,/metrics")
 
     # 1) 의존성 누락은 ImportError로 명확히 구분 — silent fail 회피, 무엇이 빠졌는지 로그에 노출.
     try:
         from opentelemetry import trace  # pyright: ignore[reportMissingImports]
         from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # pyright: ignore[reportMissingImports]
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pyright: ignore[reportMissingImports]
+        from opentelemetry.sdk.resources import Resource  # pyright: ignore[reportMissingImports]
         from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
         from opentelemetry.sdk.trace.export import BatchSpanProcessor  # pyright: ignore[reportMissingImports]
     except ImportError as exc:
@@ -41,14 +46,22 @@ def setup_tracing(app: FastAPI) -> None:
     # 2) 런타임 초기화 실패는 별도 처리 — host/port를 로그에 포함해 진단 가능.
     try:
         exporter = JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
-        provider = TracerProvider()
+        resource = Resource.create({"service.name": service_name})
+        provider = TracerProvider(resource=resource)
         provider.add_span_processor(BatchSpanProcessor(exporter))
         trace.set_tracer_provider(provider)
-        FastAPIInstrumentor.instrument_app(app)
-        logger.info("Jaeger tracing 활성화: %s:%d", jaeger_host, jaeger_port)
+        FastAPIInstrumentor.instrument_app(app, excluded_urls=excluded_urls)
+        logger.info(
+            "Jaeger tracing 활성화: service=%s host=%s port=%d excluded=%s",
+            service_name,
+            jaeger_host,
+            jaeger_port,
+            excluded_urls,
+        )
     except Exception:
         logger.warning(
-            "Jaeger tracing 초기화 실패 (host=%s, port=%d) — 계속 진행",
+            "Jaeger tracing 초기화 실패 (service=%s host=%s port=%d) — 계속 진행",
+            service_name,
             jaeger_host,
             jaeger_port,
             exc_info=True,


### PR DESCRIPTION
- service.name 누락 → Jaeger UI에 'unknown_service'로 표시되던 이슈 수정 · TracerProvider(resource=Resource.create({"service.name": "localbiz-api"})) · OTEL_SERVICE_NAME 환경변수로 override 가능 (multi-service 확장 대비)
- FastAPIInstrumentor excluded_urls 적용 — /health, /metrics는 초마다 호출돼 Jaeger를 도배하므로 trace 미수집 (Prometheus excluded_handlers와 일관) · OTEL_EXCLUDED_URLS 환경변수로 추가/변경 가능
- startup 로그에 service / excluded 정보 함께 노출 — 진단 편의

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service tracing configuration enhanced with customizable service identification and naming capabilities controlled via environment variables
  * System health check and metrics endpoints are now automatically excluded from tracing data collection by default
  * Service startup logs now provide comprehensive visibility including service identification, host/port configuration, and detailed listing of excluded endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->