### PR TITLE
fix: 모니터링 메트릭·로깅 경로 복구 (별도 VM 토폴로지)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -57,6 +57,8 @@ jobs:
           GOOGLE_CALENDAR_CLIENT_SECRET=${GOOGLE_CALENDAR_CLIENT_SECRET}
           GOOGLE_CALENDAR_REDIRECT_URI=${GOOGLE_CALENDAR_REDIRECT_URI}
           GCS_BUCKET_NAME=${GCS_BUCKET_NAME}
+          LOKI_HOST=10.178.0.4
+          PROMTAIL_ENV=production
           EOF
 
           # 배포 스크립트 — 따옴표 있는 heredoc이므로 치환 없이 그대로 전송.
@@ -106,6 +108,10 @@ jobs:
           # 이름으로 확정 제거한 뒤 강제 재생성하여 "name already in use" 충돌 차단.
           docker rm -f localbiz-api 2>/dev/null || true
           docker compose up -d --no-deps --force-recreate --remove-orphans api
+
+          # promtail 기동 (로그 → Loki, monitoring 프로파일) — #155 로깅 경로 복구.
+          # LOKI_HOST는 위 .env 병합으로 주입됨. api와 분리된 프로파일이라 명시 기동 필요.
+          docker compose --profile monitoring up -d --no-deps promtail || true
 
           # 헬스체크 (최대 60초)
           for i in $(seq 1 30); do

--- a/backend/monitoring/docker-compose.monitoring.yml
+++ b/backend/monitoring/docker-compose.monitoring.yml
@@ -22,8 +22,6 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=15d'
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   grafana:
     image: grafana/grafana:11.2.0

--- a/backend/monitoring/grafana/dashboards/fastapi.json
+++ b/backend/monitoring/grafana/dashboards/fastapi.json
@@ -123,6 +123,25 @@
         "legend": {"displayMode": "list", "placement": "bottom"},
         "tooltip": {"mode": "multi"}
       }
+    },
+    {
+      "id": 5,
+      "type": "logs",
+      "title": "Logs (localbiz-api, via Loki)",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 16},
+      "datasource": {"type": "loki", "uid": "loki"},
+      "targets": [
+        {
+          "expr": "{job=\"localbiz-api\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
     }
   ]
 }

--- a/backend/monitoring/prometheus.yml
+++ b/backend/monitoring/prometheus.yml
@@ -1,8 +1,9 @@
 # Prometheus 스크레이프 설정 (#155)
 #
-# target host.docker.internal:8000 — host-gateway로 해석되어 docker 호스트의 8000 포트
-# (백엔드 uvicorn)로 접근. docker-compose.monitoring.yml의 prometheus 서비스에
-# extra_hosts로 host-gateway 매핑이 있음 (Linux 호환).
+# 모니터링은 별도 VM(localbiz-monitoring 10.178.0.4)에서 동작하므로 백엔드는
+# API VM 내부 IP(10.178.0.3:8000)로 직접 긁는다. host.docker.internal은 같은 호스트
+# 가정이라 별도 VM에서는 모니터링 VM 자신(172.17.0.1)을 가리켜 scrape가 실패한다.
+# VPC 내부 통신 — GCP 방화벽에서 10.178.0.0/24 → tcp:8000 ingress 필요.
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
@@ -10,7 +11,7 @@ global:
 scrape_configs:
   - job_name: 'localbiz-backend'
     static_configs:
-      - targets: ['host.docker.internal:8000']
+      - targets: ['10.178.0.3:8000']
         labels:
           app: localbiz-backend
           env: local


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 별도 이슈 없음 (모니터링 스택 #155/#161 후속 운영 수정)

## #️⃣ 작업 내용

별도 모니터링 VM(`localbiz-monitoring` 10.178.0.4) 토폴로지에서 메트릭·로깅 신호가 끊겨 있던 문제를 복구합니다. (트레이싱은 실측 결과 정상이라 미변경)

**실측 근거 (2026-05-27, 두 VM 라이브 확인)**
- 메트릭 ❌: Prometheus 타깃 `host.docker.internal:8000` → 모니터링 VM 자신(`172.17.0.1:8000`)을 가리켜 `connection refused` (target down). 백엔드 `/metrics`는 정상(200).
- 로깅 ❌: API VM에 promtail 미기동 → Loki labels 비어있음.
- 트레이싱 ✅: Jaeger에 `localbiz-api` 트레이스 수신 중.

**변경**
- `prometheus.yml`: scrape 타깃 → `10.178.0.3:8000`(API VM 내부 IP). 별도 VM이라 host.docker.internal 가정이 깨짐.
- `docker-compose.monitoring.yml`: 불필요해진 prometheus `extra_hosts`(host-gateway) 제거.
- `deploy-dev.yml`: `.env`에 `LOKI_HOST=10.178.0.4`/`PROMTAIL_ENV` 주입 + `--profile monitoring`으로 promtail 기동 추가.
- `fastapi.json`: Loki 로그 패널(`{job="localbiz-api"}`) 추가.

방화벽은 기존 규칙(`allow-fastapi`, `default-allow-internal`, `localbiz-monitoring-allow`)으로 이미 허용돼 추가 변경 없음.

## #️⃣ 테스트 결과

- 변경 4파일 YAML/JSON 문법 검증 통과.
- 배포 후 검증 예정: 모니터링 VM `curl localhost:9091/api/v1/targets`에서 `localbiz-backend` health=`up`, `curl localhost:3100/loki/api/v1/labels`에 `job` 라벨, Grafana 대시보드 메트릭+로그 표시.

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (config 변경, 문법 검증 + 배포 후 런타임 검증)
- [x] 문서를 작성하거나 수정했나요? (주석에 토폴로지 근거 명시)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- `prometheus.yml`/`deploy-dev.yml`의 내부 IP 하드코딩(10.178.0.3 / 10.178.0.4) 방식이 팀 운영 기준에 맞는지 확인 부탁드립니다. (GCE service discovery는 YAGNI로 제외)
- 별건 보안: `allow-fastapi`가 `0.0.0.0/0 → 8000`이라 `/metrics`가 외부 공개 상태 — 후속으로 source를 VPC 내부로 좁히는 것 권장.
