### PR TITLE
ci: 모니터링 스택 전용 CD 워크플로 추가 (deploy-monitoring)

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -1,0 +1,71 @@
+name: Deploy Monitoring to GCE (dev)
+
+# 모니터링 스택(Prometheus/Grafana/Loki/Jaeger)은 API VM과 별도인 localbiz-monitoring
+# VM에서 docker-compose.monitoring.yml로 동작한다. deploy-dev.yml은 API VM만 갱신하므로
+# monitoring/ 설정 변경(prometheus.yml, grafana 대시보드/프로비저닝, compose)이 반영되지
+# 않는 문제가 있었다(수동 git pull 필요). 이 워크플로가 그 경로를 자동화한다.
+#
+# 전제조건(첫 실행 전 1회 확인):
+#  - 배포 SA(github-deploy)가 SSH 후 localbiz-monitoring에서 passwordless sudo 가능해야 함
+#    (현 스택은 root 소유 docker + 팀원 홈 repo라 sudo 필수).
+#  - 모니터링 repo 경로 REPO_DIR가 실제 컨테이너 bind-mount 경로와 일치해야 함
+#    (컨테이너가 마운트하는 경로를 갱신해야 효과 발생). 아래 docker inspect로 확인:
+#      sudo docker inspect localbiz-grafana --format '{{range .Mounts}}{{.Source}}{{"\n"}}{{end}}'
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'backend/monitoring/**'
+  workflow_dispatch:  # 수동 트리거 허용(설정 변경 없이 재배포 시)
+
+permissions:
+  contents: read
+  id-token: write  # WIF OIDC
+
+concurrency:
+  group: deploy-monitoring
+  cancel-in-progress: false
+
+env:
+  GCE_INSTANCE: localbiz-monitoring
+  GCE_ZONE: asia-northeast3-a
+  PROJECT_ID: project-e9a9c8f2-70da-411d-a51
+  WIF_PROVIDER: projects/124882044304/locations/global/workloadIdentityPools/github-actions/providers/github-repo
+  SA_EMAIL: github-deploy@project-e9a9c8f2-70da-411d-a51.iam.gserviceaccount.com
+  # 모니터링 스택이 배치된 repo 경로(컨테이너 bind-mount 기준). 변경 시 여기만 수정.
+  REPO_DIR: /home/rkdalstj0417_gmail_com/LocalBiz-Seoul
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.SA_EMAIL }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Pull config & recreate monitoring stack
+        run: |
+          gcloud compute ssh ${{ env.GCE_INSTANCE }} \
+            --zone=${{ env.GCE_ZONE }} --project=${{ env.PROJECT_ID }} --quiet \
+            --command='
+              set -eo pipefail
+              REPO="'"${REPO_DIR}"'"
+              M="$REPO/backend/monitoring"
+              # 다른 유저 소유 repo라 sudo + safe.directory 필요.
+              sudo git config --global --add safe.directory "$REPO"
+              sudo git -C "$REPO" fetch origin dev
+              sudo git -C "$REPO" checkout dev
+              sudo git -C "$REPO" pull origin dev
+              # 프로젝트명 monitoring 고정 — named volume(monitoring_*) 보존.
+              sudo docker compose -p monitoring --project-directory "$M" \
+                -f "$M/docker-compose.monitoring.yml" up -d --force-recreate
+              # 검증: prometheus 타깃 health (재기동 직후 unknown → 곧 up)
+              sleep 12
+              curl -sf http://localhost:9091/api/v1/targets >/dev/null && echo "prometheus reachable" || echo "WARN: prometheus targets API 응답 없음"
+            '


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 별도 이슈 없음 (모니터링 운영 자동화 — #173 후속)

## #️⃣ 작업 내용

모니터링 스택(Prometheus/Grafana/Loki/Jaeger)은 API VM과 **별도 VM(localbiz-monitoring)**에서 동작하는데, 기존 `deploy-dev.yml`은 API VM만 갱신해 `backend/monitoring/**` 변경(대시보드·prometheus.yml 등)이 자동 반영되지 않았다(수동 git pull 필요). 이 PR은 모니터링 전용 CD를 추가한다.

**`deploy-monitoring.yml`**
- 트리거: `push`(dev) + `backend/monitoring/**` 경로 필터, `workflow_dispatch`(수동) 지원.
- 동작: WIF 인증(deploy-dev와 동일 SA) → localbiz-monitoring SSH → repo `git pull origin dev` → `docker compose -p monitoring --force-recreate`(프로젝트명 고정으로 named volume 보존) → prometheus 응답 확인.

**전제조건(워크플로 주석에도 명시, 첫 실행 시 확인 필요)**
- 배포 SA가 localbiz-monitoring에서 passwordless sudo 가능해야 함(현 스택은 root docker + 팀원 홈 repo라 sudo 필수).
- `REPO_DIR`(`/home/rkdalstj0417_gmail_com/LocalBiz-Seoul`)가 컨테이너 bind-mount 경로와 일치해야 효과 발생.

## #️⃣ 테스트 결과

- 워크플로 YAML 문법 검증 통과.
- 수동 배포로 동일 절차(git pull + compose force-recreate) 실제 검증 완료: 모니터링 VM에 #173 반영(로그 패널·타깃 10.178.0.3:8000) 확인. CD는 이 절차를 자동화.
- ⚠️ CD 자체의 첫 GH Actions 실행은 머지 후 1회 검증 필요(SA sudo 권한 확인).

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (수동 절차로 검증)
- [x] 문서를 작성하거나 수정했나요? (워크플로 주석에 전제조건·검증법 명시)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- 배포 SA의 monitoring VM sudo 권한 설정 여부 확인 부탁드립니다.
- 모니터링 스택이 팀원 개인 홈(rkdalstj0417)에 배치된 구조라 `REPO_DIR` 하드코딩이 불가피했습니다 — 추후 `/opt/monitoring` 등 중립 경로로 이전하면 더 견고해집니다(별건).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated deployment workflow for monitoring infrastructure. The workflow handles deployments on development branch updates and includes health checks to verify proper service operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->