### PR TITLE
fix: COURSE_PLAN 데이트코스가 동일 장소·단일 카테고리로만 채워지던 버그 (#175)

### DIFF
--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -299,12 +299,16 @@ _COURSE_EXCLUDE_NAME_SUFFIXES: tuple[str, ...] = ("역",)
 
 
 def _is_excluded_place_name(name: str) -> bool:
-    """코스 stop으로 부적합한 장소명 필터링. substring 패턴 + 끝 글자 패턴."""
-    if not name:
+    """코스 stop으로 부적합한 장소명 필터링. substring 패턴 + 끝 글자 패턴.
+
+    `name` 양끝 공백을 정규화 후 매칭 — "홍대역 " 같은 trailing space로 endswith 우회 방지.
+    """
+    normalized = (name or "").strip()
+    if not normalized:
         return False
-    if any(ex in name for ex in _COURSE_EXCLUDE_NAMES):
+    if any(ex in normalized for ex in _COURSE_EXCLUDE_NAMES):
         return True
-    if name.endswith(_COURSE_EXCLUDE_NAME_SUFFIXES):
+    if normalized.endswith(_COURSE_EXCLUDE_NAME_SUFFIXES):
         return True
     return False
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -74,11 +74,29 @@ async def _embed_query_768d(query: str, api_key: str) -> list[float]:
 # ---------------------------------------------------------------------------
 # ① 카테고리 파싱
 # ---------------------------------------------------------------------------
-def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
-    """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"]."""
-    categories: list[str] = []
+_KNOWN_CATEGORIES = ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]
 
-    _KNOWN_CATEGORIES = ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]
+# 상황 키워드 → 카테고리 조합 매핑 (#175).
+# "데이트코스 짜줘"처럼 명시적 카테고리가 없는 상황어를 카테고리 다양화로 해석.
+# 동일 카테고리 5개만 나오던 회귀(예: 홍대역 5개) 회피의 핵심 룰.
+_SITUATION_CATEGORIES: dict[str, list[str]] = {
+    "데이트": ["카페", "맛집", "공원"],
+    "데이트코스": ["카페", "맛집", "공원"],
+    "여행": ["관광지", "맛집", "쇼핑"],
+    "관광": ["관광지", "맛집", "카페"],
+    "가족": ["맛집", "공원", "문화시설"],
+    "친구": ["카페", "맛집", "술집"],
+    "혼자": ["카페", "맛집", "문화시설"],
+}
+
+
+def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
+    """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"].
+
+    상황 키워드("데이트", "여행" 등)는 _SITUATION_CATEGORIES 매핑으로 다중 카테고리로 변환.
+    명시적 카테고리(_KNOWN_CATEGORIES)가 함께 있으면 그것을 우선.
+    """
+    categories: list[str] = []
 
     # query에서 +, &, 와/과 구분자로 분리 — 첫 매칭 구분자만 사용
     for sep in ["+", "&", "와 ", "과 ", ", "]:
@@ -95,6 +113,14 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
         for keyword in _KNOWN_CATEGORIES:
             if keyword in query and keyword not in categories:
                 categories.append(keyword)
+
+    # 명시적 카테고리가 안 잡혔으면 상황 키워드 매핑 시도 (#175).
+    # "데이트코스", "여행" 같은 상황어 → 카테고리 조합으로 다양화.
+    if not categories:
+        for situation, mapped in _SITUATION_CATEGORIES.items():
+            if situation in query:
+                categories = list(mapped)
+                break
 
     if not categories and pq_category:
         categories = [pq_category]
@@ -207,7 +233,11 @@ async def _search_by_categories(
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    seen: set[str] = set()
+    # place_id 중복 + (name, district) 중복 둘 다 제거 (#175).
+    # 같은 이름의 장소가 출구별·중복 적재로 다른 place_id를 갖는 경우 회피
+    # (예: 홍대역 출구별 5개 row가 코스 stop 5개를 다 차지하던 회귀).
+    seen_ids: set[str] = set()
+    seen_name_district: set[tuple[str, str]] = set()
     merged: list[dict[str, Any]] = []
     for result in results:
         if isinstance(result, BaseException):
@@ -215,9 +245,17 @@ async def _search_by_categories(
             continue
         for place in result:
             pid = place.get("place_id", "")
-            if pid and pid not in seen:
-                seen.add(pid)
-                merged.append(place)
+            name = (place.get("name") or "").strip()
+            district_key = (place.get("district") or "").strip()
+            name_key = (name, district_key)
+            if not pid or pid in seen_ids:
+                continue
+            if name and name_key in seen_name_district:
+                continue
+            seen_ids.add(pid)
+            if name:
+                seen_name_district.add(name_key)
+            merged.append(place)
 
     return merged
 
@@ -239,7 +277,8 @@ JSON으로만 응답하세요:
 상위 10개만 포함하세요. 편의점·마트는 ranked_ids에 포함하지 마세요.
 """
 
-# 코스 추천에서 제외할 장소명 패턴 (편의점·마트·매점)
+# 코스 추천에서 제외할 장소명 패턴 (편의점·마트·매점·교통결절점).
+# substring 매칭이라 단순 단어만 — "역"처럼 다른 단어에 끼는 글자는 _COURSE_EXCLUDE_NAME_SUFFIXES로 분리.
 _COURSE_EXCLUDE_NAMES = [
     "GS25",
     "CU",
@@ -250,7 +289,24 @@ _COURSE_EXCLUDE_NAMES = [
     "매점",
     "마트",
     "관공서",
+    "터미널",
+    "공항",
+    "정류장",
 ]
+
+# 이름 끝 글자 매칭으로 제외할 패턴 (#175). "역" 같은 1자 substring은 "역삼동" 등에 오탐 — endswith로 안전 처리.
+_COURSE_EXCLUDE_NAME_SUFFIXES: tuple[str, ...] = ("역",)
+
+
+def _is_excluded_place_name(name: str) -> bool:
+    """코스 stop으로 부적합한 장소명 필터링. substring 패턴 + 끝 글자 패턴."""
+    if not name:
+        return False
+    if any(ex in name for ex in _COURSE_EXCLUDE_NAMES):
+        return True
+    if name.endswith(_COURSE_EXCLUDE_NAME_SUFFIXES):
+        return True
+    return False
 
 
 async def _llm_rerank_candidates(
@@ -964,7 +1020,7 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
         }
 
     # ②-b 편의점·마트 사전 필터링 + LLM Rerank
-    candidates = [c for c in candidates if not any(ex in (c.get("name") or "") for ex in _COURSE_EXCLUDE_NAMES)]
+    candidates = [c for c in candidates if not _is_excluded_place_name(c.get("name") or "")]
     if not candidates:
         return {
             "response_blocks": [
@@ -978,7 +1034,7 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
         }
     candidates = await _llm_rerank_candidates(candidates, query, categories)
     # 안전망: LLM이 제외 대상을 포함시킨 경우 다시 제거
-    candidates = [c for c in candidates if not any(ex in (c.get("name") or "") for ex in _COURSE_EXCLUDE_NAMES)]
+    candidates = [c for c in candidates if not _is_excluded_place_name(c.get("name") or "")]
 
     # ③ Greedy NN 경로 최적화
     route = _greedy_nn_route(candidates)

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -147,6 +147,16 @@ async def test_excluded_place_name_no_false_positive_yeoksam() -> None:
     assert _is_excluded_place_name("") is False
 
 
+async def test_excluded_place_name_normalizes_whitespace() -> None:
+    """trailing/leading whitespace로 endswith 우회 방지 — CodeRabbit fix (#175)."""
+    from src.graph.course_plan_node import _is_excluded_place_name  # pyright: ignore[reportMissingImports]
+
+    assert _is_excluded_place_name("홍대역 ") is True  # trailing space
+    assert _is_excluded_place_name(" 홍대역") is True  # leading space
+    assert _is_excluded_place_name("  강남역  ") is True  # 양쪽
+    assert _is_excluded_place_name("   ") is False  # 공백만
+
+
 # ---------------------------------------------------------------------------
 # _haversine_m 테스트
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -59,11 +59,11 @@ async def test_parse_categories_plus() -> None:
     assert "맛집" in result
 
 
-async def test_parse_categories_single() -> None:
-    """단일 카테고리 — processed_query에서 가져옴."""
+async def test_parse_categories_single_pq_fallback() -> None:
+    """명시적 카테고리·상황 키워드 모두 없으면 pq_category 단일 사용."""
     from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
 
-    result = _parse_categories("강남 데이트 코스", "카페")
+    result = _parse_categories("강남 코스", "카페")
     assert result == ["카페"]
 
 
@@ -73,6 +73,78 @@ async def test_parse_categories_fallback() -> None:
 
     result = _parse_categories("좋은 곳 추천", None)
     assert result == ["맛집"]
+
+
+# ---------------------------------------------------------------------------
+# #175 상황 키워드 → 카테고리 조합 매핑
+# ---------------------------------------------------------------------------
+async def test_parse_categories_situation_date() -> None:
+    """'데이트코스' 상황 키워드 → 카페·맛집·공원 다중 카테고리 (#175 회귀 회피)."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("이번주 토요일 홍대 데이트코스 짜줘", None)
+    assert result == ["카페", "맛집", "공원"]
+
+
+async def test_parse_categories_situation_overrides_pq_category() -> None:
+    """상황 키워드가 pq_category(단일)보다 우선 — 데이트 의도면 다양화 (#175)."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("강남 데이트 코스", "카페")
+    assert result == ["카페", "맛집", "공원"]
+
+
+async def test_parse_categories_explicit_category_wins_over_situation() -> None:
+    """쿼리에 명시적 카테고리가 있으면 상황 키워드보다 우선."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    # "데이트"가 있어도 명시적 "카페"가 있으면 단일 카테고리 사용
+    result = _parse_categories("홍대 카페 데이트 코스", None)
+    assert "카페" in result
+    # 상황 매핑 ["카페","맛집","공원"] 전체로 확장되지 않고 명시 카테고리만
+    assert result == ["카페"]
+
+
+async def test_parse_categories_situation_travel() -> None:
+    """'여행' 상황 키워드 → 관광지·맛집·쇼핑."""
+    from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
+
+    result = _parse_categories("부산 여행 코스 추천", None)
+    assert result == ["관광지", "맛집", "쇼핑"]
+
+
+# ---------------------------------------------------------------------------
+# #175 _is_excluded_place_name — 교통결절점 제외 (오탐 회피 포함)
+# ---------------------------------------------------------------------------
+async def test_excluded_place_name_station_suffix() -> None:
+    """'홍대역' 같은 역 끝 이름은 코스 stop으로 제외 (#175)."""
+    from src.graph.course_plan_node import _is_excluded_place_name  # pyright: ignore[reportMissingImports]
+
+    assert _is_excluded_place_name("홍대역") is True
+    assert _is_excluded_place_name("강남역") is True
+    assert _is_excluded_place_name("압구정로데오역") is True
+
+
+async def test_excluded_place_name_substring_terminal() -> None:
+    """터미널·정류장·공항은 substring 매칭으로 제외."""
+    from src.graph.course_plan_node import _is_excluded_place_name  # pyright: ignore[reportMissingImports]
+
+    assert _is_excluded_place_name("강남고속버스터미널") is True
+    assert _is_excluded_place_name("홍대 버스정류장") is True
+    assert _is_excluded_place_name("김포공항 라운지") is True
+
+
+async def test_excluded_place_name_no_false_positive_yeoksam() -> None:
+    """'역삼동'·'역사' 같은 단어가 끼어도 substring 오탐 없어야 함 (#175)."""
+    from src.graph.course_plan_node import _is_excluded_place_name  # pyright: ignore[reportMissingImports]
+
+    # endswith("역") 체크라 "역삼" 끝남 → False
+    assert _is_excluded_place_name("역삼맛집") is False
+    # "역사관" — 끝이 "관"이라 False
+    assert _is_excluded_place_name("서울역사박물관") is False
+    # 일반 음식점·카페는 그대로
+    assert _is_excluded_place_name("홍대 감성카페") is False
+    assert _is_excluded_place_name("") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
증상
- "이번주 토요일 홍대 데이트코스 짜줘" → 5곳 다 동일 (홍대역·관광 카테고리 단일)
- 데이트코스의 다양성·맥락 모두 깨짐

3가지 원인 동시 해결

① 상황 키워드 → 카테고리 조합 매핑 (_SITUATION_CATEGORIES)
- 데이트/여행/관광/가족/친구/혼자 등 상황어 → 다중 카테고리 조합
- _parse_categories 우선순위: 명시적 카테고리 > 상황 키워드 > pq_category > "맛집"
- "홍대 데이트코스" → ["카페", "맛집", "공원"] (이전엔 단일 카테고리)

② (name, district) 중복 제거 키 추가
- 같은 이름 장소가 출구별·중복 ETL로 다른 place_id를 갖는 경우 회피
- 이전: place_id 단독 → 홍대역 5개 row가 stop 5개를 다 차지
- 이후: place_id + (name, district) 동시 키

③ _COURSE_EXCLUDE_NAMES 확장 + endswith 패턴 분리
- substring: 터미널/공항/정류장 추가
- endswith: "역" 끝 패턴은 별도 처리 (_COURSE_EXCLUDE_NAME_SUFFIXES) · "홍대역"·"강남역" 매칭, "역삼맛집"·"서울역사박물관" 오탐 회피
- 헬퍼 _is_excluded_place_name으로 두 군데 필터링 로직 통일

테스트 추가 (총 9개)
- _parse_categories: 상황 키워드 회귀 / pq_category fallback / 명시 카테고리 우선 / 여행 매핑
- _is_excluded_place_name: 역 endswith / 터미널·공항 substring / 오탐 회피 (역삼맛집·서울역사박물관)
- 기존 10개 + 신규 9개 = 19 passed

19 데이터 모델 불변식 영향 없음 — Phase 1 COURSE_PLAN 정확도 개선 한정.

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search result de-duplication to eliminate duplicate place entries.
  * Enhanced location filtering to exclude irrelevant places from course results.

* **Tests**
  * Added comprehensive test coverage for category parsing and place filtering logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->