### PR TITLE
feat: COURSE_PLAN 시간대별 카테고리 시퀀스 + 교차로 stop 제외 (#177)

### DIFF
--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -76,25 +76,26 @@ async def _embed_query_768d(query: str, api_key: str) -> list[float]:
 # ---------------------------------------------------------------------------
 _KNOWN_CATEGORIES = ["카페", "맛집", "음식점", "술집", "주점", "관광지", "공원", "쇼핑", "문화시설"]
 
-# 상황 키워드 → 카테고리 조합 매핑 (#175).
-# "데이트코스 짜줘"처럼 명시적 카테고리가 없는 상황어를 카테고리 다양화로 해석.
-# 동일 카테고리 5개만 나오던 회귀(예: 홍대역 5개) 회피의 핵심 룰.
-_SITUATION_CATEGORIES: dict[str, list[str]] = {
-    "데이트": ["카페", "맛집", "공원"],
-    "데이트코스": ["카페", "맛집", "공원"],
-    "여행": ["관광지", "맛집", "쇼핑"],
+# 상황 키워드 → 시간대별 카테고리 시퀀스 매핑 (#175, #177).
+# 데이트의 자연스러운 흐름 (점심 → 산책 → 디저트 → 팝업 → 저녁)을 stop 순서로 반영.
+# 길이 2+ 시퀀스는 _pick_by_sequence가 카테고리별 1개씩 시퀀스 순서로 선택 — Greedy NN 대체.
+_SITUATION_SEQUENCES: dict[str, list[str]] = {
+    "데이트": ["음식점", "공원", "카페", "쇼핑", "술집"],
+    "데이트코스": ["음식점", "공원", "카페", "쇼핑", "술집"],
+    "여행": ["관광지", "맛집", "카페", "쇼핑"],
     "관광": ["관광지", "맛집", "카페"],
-    "가족": ["맛집", "공원", "문화시설"],
-    "친구": ["카페", "맛집", "술집"],
-    "혼자": ["카페", "맛집", "문화시설"],
+    "가족": ["맛집", "공원", "문화시설", "카페"],
+    "친구": ["카페", "음식점", "술집"],
+    "혼자": ["카페", "문화시설", "음식점"],
 }
 
 
 def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     """쿼리에서 복수 카테고리 추출. "카페+맛집" → ["카페", "맛집"].
 
-    상황 키워드("데이트", "여행" 등)는 _SITUATION_CATEGORIES 매핑으로 다중 카테고리로 변환.
+    상황 키워드("데이트", "여행" 등)는 _SITUATION_SEQUENCES 매핑으로 시간대별 시퀀스로 변환.
     명시적 카테고리(_KNOWN_CATEGORIES)가 함께 있으면 그것을 우선.
+    반환 list는 시퀀스 순서 그대로 — 코스 stop 순서에 사용됨 (#177).
     """
     categories: list[str] = []
 
@@ -114,10 +115,10 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
             if keyword in query and keyword not in categories:
                 categories.append(keyword)
 
-    # 명시적 카테고리가 안 잡혔으면 상황 키워드 매핑 시도 (#175).
-    # "데이트코스", "여행" 같은 상황어 → 카테고리 조합으로 다양화.
+    # 명시적 카테고리가 안 잡혔으면 상황 키워드 매핑 시도 (#175/#177).
+    # 매칭된 시퀀스를 그대로 사용 — 시간대별 흐름이 stop 순서에 반영됨.
     if not categories:
-        for situation, mapped in _SITUATION_CATEGORIES.items():
+        for situation, mapped in _SITUATION_SEQUENCES.items():
             if situation in query:
                 categories = list(mapped)
                 break
@@ -128,7 +129,7 @@ def _parse_categories(query: str, pq_category: Optional[str]) -> list[str]:
     if not categories:
         categories = ["맛집"]
 
-    return categories[:3]  # 최대 3 카테고리
+    return categories[:_MAX_STOPS]  # 최대 stop 개수까지 — 시퀀스 매칭 시 전체 시퀀스 보존
 
 
 # ---------------------------------------------------------------------------
@@ -292,6 +293,12 @@ _COURSE_EXCLUDE_NAMES = [
     "터미널",
     "공항",
     "정류장",
+    # 교차로·도로 결절점 — 코스 stop 부적합 (#177)
+    "사거리",
+    "삼거리",
+    "교차로",
+    "로터리",
+    "오거리",
 ]
 
 # 이름 끝 글자 매칭으로 제외할 패턴 (#175). "역" 같은 1자 substring은 "역삼동" 등에 오탐 — endswith로 안전 처리.
@@ -417,6 +424,57 @@ def _greedy_nn_route(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
         route.append(c)
 
     return route
+
+
+def _pick_by_sequence(
+    candidates: list[dict[str, Any]],
+    sequence: list[str],
+    max_stops: int = _MAX_STOPS,
+) -> list[dict[str, Any]]:
+    """시퀀스 순서대로 각 카테고리에서 LLM rerank 최상위 후보 1개씩 선택 (#177).
+
+    데이트의 자연 흐름(점심 → 산책 → 디저트 → 팝업 → 저녁)을 stop 순서로 강제.
+    `candidates`는 _llm_rerank_candidates로 이미 정렬된 상태를 가정 — 앞에서부터 최상위.
+
+    동작:
+      - sequence 각 카테고리마다 candidates를 앞에서부터 스캔, 첫 매칭(category substring 포함)을 picked
+      - 후보 없는 카테고리는 skip — 시퀀스가 깨지지 않게 빈자리는 잔여 candidates로 채움
+      - place_id 기준 중복 제거 (이미 _search_by_categories에서 제거되지만 안전망)
+
+    Returns:
+        max_stops 이하의 stop list (시퀀스 순서 우선, 부족분은 잔여로 채움).
+    """
+    picked: list[dict[str, Any]] = []
+    seen_pids: set[str] = set()
+
+    for cat in sequence:
+        if len(picked) >= max_stops:
+            break
+        for c in candidates:
+            pid = str(c.get("place_id") or "")
+            if pid and pid in seen_pids:
+                continue
+            c_cat = c.get("category") or ""
+            # 부분 일치 — "음식점" 시퀀스 카테고리에 "한식음식점" 같은 세분 카테고리도 매칭.
+            if cat in c_cat:
+                picked.append(c)
+                if pid:
+                    seen_pids.add(pid)
+                break
+
+    # 시퀀스로 못 채운 슬롯은 잔여 candidates로 안전망 (LLM rerank 순서 유지).
+    if len(picked) < max_stops:
+        for c in candidates:
+            if len(picked) >= max_stops:
+                break
+            pid = str(c.get("place_id") or "")
+            if pid and pid in seen_pids:
+                continue
+            picked.append(c)
+            if pid:
+                seen_pids.add(pid)
+
+    return picked[:max_stops]
 
 
 # ---------------------------------------------------------------------------
@@ -1040,8 +1098,13 @@ async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
     # 안전망: LLM이 제외 대상을 포함시킨 경우 다시 제거
     candidates = [c for c in candidates if not _is_excluded_place_name(c.get("name") or "")]
 
-    # ③ Greedy NN 경로 최적화
-    route = _greedy_nn_route(candidates)
+    # ③ 코스 순서 결정 — 다중 카테고리(시퀀스) vs 단일 카테고리(거리)
+    # 다중 카테고리: _pick_by_sequence로 시간대별 흐름 강제 (점심·산책·디저트·팝업·저녁 #177)
+    # 단일 카테고리("성수 카페 코스" 등): 기존 Greedy NN으로 거리 기반 정렬 — 회귀 없음
+    if len(categories) >= 2:
+        route = _pick_by_sequence(candidates, categories)
+    else:
+        route = _greedy_nn_route(candidates)
 
     # ④ LLM 코스 구성
     title, description, stop_details = await _llm_course_compose(route, query)

--- a/backend/tests/test_course_plan_node.py
+++ b/backend/tests/test_course_plan_node.py
@@ -79,38 +79,38 @@ async def test_parse_categories_fallback() -> None:
 # #175 상황 키워드 → 카테고리 조합 매핑
 # ---------------------------------------------------------------------------
 async def test_parse_categories_situation_date() -> None:
-    """'데이트코스' 상황 키워드 → 카페·맛집·공원 다중 카테고리 (#175 회귀 회피)."""
+    """'데이트코스' 상황 키워드 → 시간대별 시퀀스 (음식점·공원·카페·쇼핑·술집) #177."""
     from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
 
     result = _parse_categories("이번주 토요일 홍대 데이트코스 짜줘", None)
-    assert result == ["카페", "맛집", "공원"]
+    assert result == ["음식점", "공원", "카페", "쇼핑", "술집"]
 
 
 async def test_parse_categories_situation_overrides_pq_category() -> None:
-    """상황 키워드가 pq_category(단일)보다 우선 — 데이트 의도면 다양화 (#175)."""
+    """상황 키워드가 pq_category(단일)보다 우선 — 데이트 의도면 시퀀스 적용 (#175/#177)."""
     from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
 
     result = _parse_categories("강남 데이트 코스", "카페")
-    assert result == ["카페", "맛집", "공원"]
+    assert result == ["음식점", "공원", "카페", "쇼핑", "술집"]
 
 
 async def test_parse_categories_explicit_category_wins_over_situation() -> None:
-    """쿼리에 명시적 카테고리가 있으면 상황 키워드보다 우선."""
+    """쿼리에 명시적 카테고리가 있으면 상황 키워드보다 우선 (단일 카테고리 의도)."""
     from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
 
     # "데이트"가 있어도 명시적 "카페"가 있으면 단일 카테고리 사용
     result = _parse_categories("홍대 카페 데이트 코스", None)
     assert "카페" in result
-    # 상황 매핑 ["카페","맛집","공원"] 전체로 확장되지 않고 명시 카테고리만
+    # 시퀀스로 확장되지 않고 명시 카테고리만 — 단일 케이스는 Greedy NN 경로
     assert result == ["카페"]
 
 
 async def test_parse_categories_situation_travel() -> None:
-    """'여행' 상황 키워드 → 관광지·맛집·쇼핑."""
+    """'여행' 상황 키워드 → 관광지·맛집·카페·쇼핑 시퀀스 (#177)."""
     from src.graph.course_plan_node import _parse_categories  # pyright: ignore[reportMissingImports]
 
     result = _parse_categories("부산 여행 코스 추천", None)
-    assert result == ["관광지", "맛집", "쇼핑"]
+    assert result == ["관광지", "맛집", "카페", "쇼핑"]
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +155,92 @@ async def test_excluded_place_name_normalizes_whitespace() -> None:
     assert _is_excluded_place_name(" 홍대역") is True  # leading space
     assert _is_excluded_place_name("  강남역  ") is True  # 양쪽
     assert _is_excluded_place_name("   ") is False  # 공백만
+
+
+async def test_excluded_place_name_intersections() -> None:
+    """교차로·사거리·로터리 — 코스 stop 부적합 (#177 운영 회귀)."""
+    from src.graph.course_plan_node import _is_excluded_place_name  # pyright: ignore[reportMissingImports]
+
+    assert _is_excluded_place_name("홍대삼거리") is True
+    assert _is_excluded_place_name("강남사거리") is True
+    assert _is_excluded_place_name("홍대입구역사거리R") is True  # substring "사거리"
+    assert _is_excluded_place_name("종로 교차로") is True
+    assert _is_excluded_place_name("광화문 로터리") is True
+    assert _is_excluded_place_name("청량리오거리") is True
+
+
+# ---------------------------------------------------------------------------
+# #177 _pick_by_sequence — 시간대별 카테고리 시퀀스
+# ---------------------------------------------------------------------------
+async def test_pick_by_sequence_orders_by_categories() -> None:
+    """시퀀스 순서대로 각 카테고리 1개씩 picked — 데이트 흐름 (#177)."""
+    from src.graph.course_plan_node import _pick_by_sequence  # pyright: ignore[reportMissingImports]
+
+    candidates = [
+        {"place_id": "p1", "name": "카페A", "category": "카페"},
+        {"place_id": "p2", "name": "맛집A", "category": "음식점"},
+        {"place_id": "p3", "name": "술집A", "category": "술집"},
+        {"place_id": "p4", "name": "공원A", "category": "공원"},
+        {"place_id": "p5", "name": "쇼핑A", "category": "쇼핑"},
+        {"place_id": "p6", "name": "카페B", "category": "카페"},
+    ]
+    sequence = ["음식점", "공원", "카페", "쇼핑", "술집"]
+    result = _pick_by_sequence(candidates, sequence)
+
+    names = [r["name"] for r in result]
+    # 시퀀스 순서대로 각 카테고리 첫 매칭
+    assert names == ["맛집A", "공원A", "카페A", "쇼핑A", "술집A"]
+
+
+async def test_pick_by_sequence_skips_missing_categories_and_fills() -> None:
+    """후보 없는 카테고리는 skip · max_stops까지 잔여 후보로 안전망 (#177)."""
+    from src.graph.course_plan_node import _pick_by_sequence  # pyright: ignore[reportMissingImports]
+
+    candidates = [
+        {"place_id": "p1", "name": "맛집A", "category": "음식점"},
+        {"place_id": "p2", "name": "맛집B", "category": "음식점"},
+        {"place_id": "p3", "name": "카페A", "category": "카페"},
+    ]
+    sequence = ["음식점", "공원", "카페", "쇼핑", "술집"]
+    result = _pick_by_sequence(candidates, sequence)
+
+    names = [r["name"] for r in result]
+    # 공원·쇼핑·술집은 후보 없음 → 시퀀스에서 음식점·카페만 picked
+    # 그 후 잔여(맛집B)로 안전망 채움 — 총 3개
+    assert names == ["맛집A", "카페A", "맛집B"]
+
+
+async def test_pick_by_sequence_partial_category_match() -> None:
+    """카테고리 substring 매칭 — '음식점' 시퀀스가 '한식음식점' 같은 세분 카테고리도 매칭."""
+    from src.graph.course_plan_node import _pick_by_sequence  # pyright: ignore[reportMissingImports]
+
+    candidates = [
+        {"place_id": "p1", "name": "한식집", "category": "한식음식점"},
+        {"place_id": "p2", "name": "분위기카페", "category": "디저트카페"},
+    ]
+    sequence = ["음식점", "카페"]
+    result = _pick_by_sequence(candidates, sequence)
+
+    names = [r["name"] for r in result]
+    assert names == ["한식집", "분위기카페"]
+
+
+async def test_pick_by_sequence_deduplicates_by_place_id() -> None:
+    """같은 place_id는 시퀀스에서 한 번만 picked — 중복 제거 안전망."""
+    from src.graph.course_plan_node import _pick_by_sequence  # pyright: ignore[reportMissingImports]
+
+    # 같은 p1이 음식점과 카페 둘 다 매칭 가능한 케이스
+    candidates = [
+        {"place_id": "p1", "name": "복합공간", "category": "음식점/카페"},
+        {"place_id": "p2", "name": "공원A", "category": "공원"},
+        {"place_id": "p3", "name": "카페A", "category": "카페"},
+    ]
+    sequence = ["음식점", "공원", "카페"]
+    result = _pick_by_sequence(candidates, sequence)
+
+    names = [r["name"] for r in result]
+    # p1이 음식점에 picked → 카페에는 다시 안 잡혀서 p3가 picked
+    assert names == ["복합공간", "공원A", "카페A"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#175 머지 후 운영 검증에서 발견된 후속 회귀 해결.

증상
- "홍대 데이트코스" → 5곳 다 다양해졌지만 카테고리 순서가 무작위
- "홍대삼거리", "홍대입구역사거리R" 등 교차로가 음식점으로 잡힘
- 데이트의 자연 흐름(점심·산책·디저트·팝업·저녁)이 결과에 반영 안 됨

변경

① 시간대별 카테고리 시퀀스 도입 (_SITUATION_SEQUENCES)
- 데이트/데이트코스: [음식점, 공원, 카페, 쇼핑, 술집]
- 여행: [관광지, 맛집, 카페, 쇼핑] / 관광: [관광지, 맛집, 카페]
- 가족: [맛집, 공원, 문화시설, 카페]
- 친구: [카페, 음식점, 술집] / 혼자: [카페, 문화시설, 음식점]

② _pick_by_sequence 신규 함수
- 시퀀스 순서대로 각 카테고리에서 LLM rerank 최상위 1개씩 picked
- 카테고리 substring 매칭 (예: "음식점" 시퀀스가 "한식음식점" 매칭)
- 후보 없는 카테고리는 skip · max_stops 미달 시 잔여로 안전망
- place_id 중복 제거 (안전망)

③ 메인 함수 분기
- 다중 카테고리(2+) → _pick_by_sequence (시간대 흐름 강제)
- 단일 카테고리("홍대 카페 코스") → 기존 _greedy_nn_route (회귀 없음)

④ _COURSE_EXCLUDE_NAMES 확장 — 교차로 결절점 제외
- 사거리 / 삼거리 / 교차로 / 로터리 / 오거리 추가
- "홍대삼거리", "홍대입구역사거리R" 같은 ETL 잔재 회피

⑤ _parse_categories 반환 한도: 3 → _MAX_STOPS (5)
- 시퀀스 매칭 시 전체 시퀀스(최대 5개) 보존되도록

테스트 (총 25 passed)
- 기존 #175 테스트 5개 기대값을 새 시퀀스에 맞춰 갱신
- _pick_by_sequence 신규 4개: 순서/skip+안전망/substring 매칭/중복 제거
- _is_excluded_place_name 신규 1개: 교차로·삼거리·로터리·오거리

별도 이슈 (이 PR 범위 밖)
- places 테이블 데이터 cleanup — "홍대", "홍대입구역사거리R" 같은 비-stop row가 음식점 카테고리에 들어있는 건 ETL 단계 문제. 코드 휴리스틱으로 단일 지역명 ("홍대" 단독) 막는 건 false positive 큼 → 데이터 정제 별도 이슈 필요.

19 데이터 모델 불변식 영향 없음 (Phase 1 COURSE_PLAN 정확도·UX 한정).

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
