### PR TITLE
fix: 장소 추천 의미 키워드 name 매칭 제거 (#181, C3)

### DIFF
--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -95,9 +95,11 @@ async def _search_pg(
         params.append(f"%{neighborhood}%")
         sql += f" AND address ILIKE ${len(params)}"
 
-    if keywords:
-        params.append(f"%{keywords[0]}%")
-        sql += f" AND name ILIKE ${len(params)}"
+    # keywords(의미 조건)는 name ILIKE에서 제외 (C3) — '쉴만한 곳'의 키워드 '휴식'이
+    # 가게 이름 '휴식'을 매칭하는 노이즈 방지. 의미 매칭은 OS k-NN
+    # (_search_os_places / _search_os_reviews)이 담당하며, PG는 정형 필터
+    # (district/category/neighborhood)만 적용한다. neighborhood(위)와 동일한 이유.
+    _ = keywords  # 시그니처 유지 (호출부 호환) — PG 정형 검색에서는 미사용
 
     params.append(_PG_LIMIT)
     sql += f" LIMIT ${len(params)}"


### PR DESCRIPTION
## 관련 이슈
Refs #181 · 디버깅 단계 B의 C3 (C10은 후보 정상화로 개선). **C4(코스 슬롯 오염)는 근본 원인 추가 조사 필요 → 후속 분리.**

## 변경
`place_recommend_node._search_pg`: `keywords[0] → name ILIKE` 필터 제거.
- '명동 쉴만한 곳' → 키워드 '휴식'이 가게 이름 '휴식'을 매칭하던 문제 해소.
- 의미 매칭은 OS k-NN(`_search_os_places`/`_search_os_reviews`)이 담당. PG는 정형 필터(district/category/neighborhood)만 — neighborhood와 동일 패턴.
- 시그니처 불변(호출부 호환).

## 검증
- ruff/format/pyright **0 errors** (line 590 warning은 `_handle_refinement`의 기존 `_merge_candidates` 인자 누락 — 본 변경 무관, dev 기존 이슈).

## 테스트 플랜
- [ ] '명동에 쉴만한 곳' → '휴식' 이름 가게가 아닌 실제 카페/휴식 적합 장소 반환
- [ ] 기존 카테고리/지역 기반 추천 회귀 없음