### PR TITLE
fix: 리뷰 비교 한국어 구분자 미지원 수정 (#189)

### DIFF
--- a/backend/src/graph/review_compare_node.py
+++ b/backend/src/graph/review_compare_node.py
@@ -25,10 +25,13 @@ _COMPARE_SYSTEM_PROMPT = """\
 
 def _extract_place_names(processed_query: dict[str, Any], query: str) -> list[str]:
     """vs/VS/와 구분자로 장소명 추출. 2개 미만이면 [] 반환."""
-    for sep in (" vs ", " VS ", " 와 "):
+    # 한국어 비교 구분자 — 부착형('점이랑')까지 포함. 첫 매칭이 2개 이상 분할되면 채택.
+    # REVIEW_COMPARE intent로 이미 분류된 쿼리이므로 과분할 위험은 낮다.
+    for sep in (" vs ", " VS ", "이랑", " 와 ", " 과 ", "하고", " 그리고 ", " 랑 "):
         if sep in query:
             parts = [p.strip() for p in query.split(sep)]
-            parts = [re.sub(r"\s*(비교|compare).*$", "", p, flags=re.IGNORECASE).strip() for p in parts]
+            # 꼬리말(리뷰/비교/compare …) 제거 — '명동점 리뷰 비교해줘' → '명동점'
+            parts = [re.sub(r"\s*(리뷰|비교|compare).*$", "", p, flags=re.IGNORECASE).strip() for p in parts]
             parts = [p for p in parts if p]
             if len(parts) >= 2:
                 return parts


### PR DESCRIPTION
## 관련 이슈
Closes #189 · 디버깅 단계 A 후속 (C1 '리뷰 비교 응답 안 옴' 직접 원인).

## 변경
`review_compare_node._extract_place_names`:
- 구분자에 `이랑`(부착형)·` 과 `·`하고`·` 그리고 `·` 랑 ` 추가 (기존 vs/VS/와).
- 꼬리말 제거 정규식에 `리뷰` 포함 → '명동점 리뷰 비교해줘' → '명동점'.

## 효과
'스타벅스 홍대점이랑 명동점 리뷰 비교해줘' → 두 장소 추출·비교 성공 (기존엔 구분자 미스로 disambiguation).

## 검증
ruff/format/pyright 0 errors. test_review_compare_node 9 passed (1 ERROR는 환경상 pytest-asyncio introspection 버그, 로직 무관).

## 테스트 플랜
- [ ] '스타벅스 홍대점이랑 명동점 리뷰 비교' → 레이더 차트 비교
- [ ] 기존 'A vs B', 'A 와 B' 회귀 없음