### PR TITLE
fix: dev 배포 scp 디스크 풀 교착 해소 — scp 전 선제 정리 (#191)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -133,6 +133,23 @@ jobs:
           GOOGLE_CALENDAR_REDIRECT_URI: ${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
 
+      # ②-c scp 전 선제 디스크 정리 — 디스크 풀 시 scp "write remote Failure" 방지(자가 치유).
+      #     기존 정리는 deploy 스크립트 내부(scp 이후 실행)라, 디스크가 이미 차면 업로드 자체가
+      #     실패해 정리 스크립트가 올라가지도 못하는 교착이 발생한다. ssh --command는 파일을
+      #     올리지 않으므로 디스크 풀에도 동작 → docker 정리로 공간 확보 후 scp가 성공한다.
+      #     docker 정리는 ijeong이 docker 그룹이라 sudo 불필요. journal/apt는 best-effort.
+      - name: Free disk on instance (pre-scp)
+        run: |
+          gcloud compute ssh ijeong@${{ env.GCE_INSTANCE }} \
+            --zone=${{ env.GCE_ZONE }} --project=${{ env.PROJECT_ID }} --quiet \
+            --command='echo "[disk before]"; df -h / | tail -1; \
+              rm -f /tmp/secrets-*.env /tmp/deploy-*.sh 2>/dev/null || true; \
+              docker system prune -af --filter "until=72h" || true; \
+              docker builder prune -af || true; \
+              sudo journalctl --vacuum-size=200M 2>/dev/null || true; \
+              sudo apt-get clean 2>/dev/null || true; \
+              echo "[disk after]"; df -h / | tail -1'
+
       # ③ 서버에 전송 + 실행
       - name: Upload and execute deploy
         run: |


### PR DESCRIPTION
## 관련 이슈
Closes #191.

## 문제
`deploy-dev.yml` 배포 실패: `scp ... /tmp/: write remote Failure` — VM 디스크 풀. 기존 디스크 정리는 배포 스크립트 **내부**(scp 이후)라, 디스크가 차면 스크립트 업로드 자체가 실패하는 **교착**.

## 변경
③ Upload 스텝 앞에 `Free disk on instance (pre-scp)` 스텝 추가:
- `gcloud compute ssh --command`로 원격 정리 (파일 미업로드 → 디스크 풀에도 동작).
- `docker system prune`/`builder prune`(sudo 불필요) + `/tmp` 잔재 제거 + journal/apt best-effort.
- df 전후 출력으로 가시화.

## 효과
**다음 배포부터 자가 치유** — 디스크가 차도 scp 전에 공간 확보. 현재 막힌 배포도 머지 후 dev push로 자동 복구.

## 검증
- [ ] 머지 후 dev 배포 재실행 → 'disk before/after' 로그 + scp 통과 + 헬스체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains no user-facing changes. It includes internal infrastructure improvements to enhance deployment reliability.

* **Chores**
  * Improved deployment process stability through optimized infrastructure maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->