### PR TITLE
Fix/#187

### DIFF
--- a/backend/src/graph/crowdedness_node.py
+++ b/backend/src/graph/crowdedness_node.py
@@ -22,133 +22,124 @@ def _classify_level(ratio: float) -> str:
     return "혼잡"
 
 
-async def _resolve_dong_code(
+async def _resolve_dong_codes(
     pool: Any,
-    neighborhood: str,
-    time_slot: int,
+    neighborhood: Optional[str],
     district: Optional[str],
-) -> Optional[tuple[str, str]]:
-    """neighborhood ILIKE 매칭 → district 대표 dong 집계 fallback → None.
+) -> Optional[tuple[list[str], str]]:
+    """통용 지명/자치구를 행정동 코드 리스트 + 표시명으로 해석한다.
+
+    우선순위:
+        1. neighborhood가 통용 지명 매핑(geo_mapping)에 있으면 패턴 ILIKE로 행정동 매칭
+        2. neighborhood가 실제 행정동명 일부와 일치하면 ILIKE 매칭
+        3. 위 두 가지 실패 시 district의 모든 행정동
+        4. neighborhood 없고 district만 있을 때도 district의 모든 행정동
 
     Returns:
-        (adm_dong_code, resolved_area_name) — ILIKE 성공 시 neighborhood,
-        district fallback 시 district. 둘 다 실패 시 None.
+        ([adm_dong_code, ...], 표시명) 또는 None.
+        표시명은 사용자가 물은 단위(neighborhood 또는 district)와 일치.
     """
-    row = await pool.fetchrow(
-        """
-        SELECT a.adm_dong_code
-        FROM administrative_districts a
-        LEFT JOIN (
-            SELECT adm_dong_code, total_pop
-            FROM population_stats
-            WHERE base_date = (SELECT MAX(base_date) FROM population_stats)
-              AND time_slot = $2
-        ) p USING (adm_dong_code)
-        WHERE a.adm_dong_name ILIKE $1
-        ORDER BY p.total_pop DESC NULLS LAST
-        LIMIT 1
-        """,
-        f"%{neighborhood}%",
-        time_slot,
-    )
-    if row:
-        return row["adm_dong_code"], neighborhood
+    from src.utils.geo_mapping import resolve_dong_patterns  # pyright: ignore[reportMissingImports]
 
-    if not district:
-        return None
+    if neighborhood:
+        patterns = resolve_dong_patterns(neighborhood)
+        if patterns:
+            like_patterns = [f"%{p}%" for p in patterns]
+            rows = await pool.fetch(
+                """
+                SELECT adm_dong_code
+                FROM administrative_districts
+                WHERE adm_dong_name ILIKE ANY($1::text[])
+                """,
+                like_patterns,
+            )
+            if rows:
+                return [r["adm_dong_code"] for r in rows], neighborhood
 
-    row2 = await pool.fetchrow(
-        """
-        SELECT a.adm_dong_code
-        FROM administrative_districts a
-        LEFT JOIN (
-            SELECT adm_dong_code, SUM(total_pop) AS sum_pop
-            FROM population_stats
-            WHERE base_date = (SELECT MAX(base_date) FROM population_stats)
-              AND time_slot = $2
-            GROUP BY adm_dong_code
-        ) p USING (adm_dong_code)
-        WHERE a.district = $1
-        ORDER BY p.sum_pop DESC NULLS LAST
-        LIMIT 1
-        """,
-        district,
-        time_slot,
-    )
-    return (row2["adm_dong_code"], district) if row2 else None
+        rows = await pool.fetch(
+            """
+            SELECT adm_dong_code
+            FROM administrative_districts
+            WHERE adm_dong_name ILIKE $1
+            """,
+            f"%{neighborhood}%",
+        )
+        if rows:
+            return [r["adm_dong_code"] for r in rows], neighborhood
+
+        # Gemini 정규화로 "성수" → "성수동" 같은 변형 입력 방어 — 끝 "동" 떼고 재시도.
+        # 실제 동명은 "성수1가1동"이라 "%성수동%"은 0건이지만 "%성수%"는 매치.
+        if neighborhood.endswith("동") and len(neighborhood) > 1:
+            trimmed = neighborhood[:-1]
+            rows = await pool.fetch(
+                """
+                SELECT adm_dong_code
+                FROM administrative_districts
+                WHERE adm_dong_name ILIKE $1
+                """,
+                f"%{trimmed}%",
+            )
+            if rows:
+                return [r["adm_dong_code"] for r in rows], neighborhood
+
+    if district:
+        rows = await pool.fetch(
+            """
+            SELECT adm_dong_code
+            FROM administrative_districts
+            WHERE district = $1
+            """,
+            district,
+        )
+        if rows:
+            return [r["adm_dong_code"] for r in rows], district
+
+    return None
 
 
 async def _fetch_population(
     pool: Any,
-    dong_code: Optional[str],
-    district: Optional[str],
+    dong_codes: list[str],
     time_slot: int,
 ) -> Optional[dict[str, Any]]:
-    """현재 시간대 인구 + 최근 30일 동일 시간대 평균 조회."""
-    if dong_code:
-        row = await pool.fetchrow(
-            """
-            WITH latest AS (SELECT MAX(base_date) AS d FROM population_stats)
-            SELECT
-                cur.total_pop AS current_pop,
-                l.d AS base_date,
-                COALESCE(
-                    (SELECT AVG(p2.total_pop)
+    """주어진 행정동 코드들의 현재 시간대 인구 SUM + 30일 동일 시간대 평균.
+
+    base_date 는 population_stats 의 최신 일자.
+    avg_pop 은 동일 dong 집합·동일 time_slot 의 일자별 SUM의 30일 평균.
+    """
+    if not dong_codes:
+        return None
+
+    row = await pool.fetchrow(
+        """
+        WITH latest AS (SELECT MAX(base_date) AS d FROM population_stats)
+        SELECT
+            COALESCE(SUM(cur.total_pop), 0) AS current_pop,
+            l.d AS base_date,
+            COALESCE(
+                (SELECT AVG(daily_total)
+                 FROM (
+                     SELECT SUM(p2.total_pop) AS daily_total
                      FROM population_stats p2, latest
-                     WHERE p2.adm_dong_code = $1
+                     WHERE p2.adm_dong_code = ANY($1::text[])
                        AND p2.time_slot = $2
-                       AND p2.base_date >= latest.d - INTERVAL '30 days'),
-                    0
-                ) AS avg_pop
-            FROM population_stats cur, latest l
-            WHERE cur.adm_dong_code = $1
-              AND cur.time_slot = $2
-              AND cur.base_date = l.d
-            LIMIT 1
-            """,
-            dong_code,
-            time_slot,
-        )
-        return dict(row) if row else None
-
-    if district:
-        row = await pool.fetchrow(
-            """
-            WITH latest AS (SELECT MAX(base_date) AS d FROM population_stats)
-            SELECT
-                COALESCE(SUM(cur.total_pop), 0) AS current_pop,
-                l.d AS base_date,
-                COALESCE(
-                    (SELECT AVG(daily_total)
-                     FROM (
-                         SELECT SUM(p2.total_pop) AS daily_total
-                         FROM administrative_districts a2
-                         JOIN population_stats p2 ON p2.adm_dong_code = a2.adm_dong_code
-                         CROSS JOIN latest
-                         WHERE a2.district = $1
-                           AND p2.time_slot = $2
-                           AND p2.base_date >= latest.d - INTERVAL '30 days'
-                         GROUP BY p2.base_date
-                     ) dt),
-                    0
-                ) AS avg_pop
-            FROM administrative_districts a
-            LEFT JOIN population_stats cur
-                ON cur.adm_dong_code = a.adm_dong_code
-               AND cur.time_slot = $2
-               AND cur.base_date = (SELECT d FROM latest)
-            CROSS JOIN latest l
-            WHERE a.district = $1
-            GROUP BY l.d
-            """,
-            district,
-            time_slot,
-        )
-        if not row or row["base_date"] is None:
-            return None
-        return dict(row)
-
-    return None
+                       AND p2.base_date >= latest.d - INTERVAL '30 days'
+                     GROUP BY p2.base_date
+                 ) dt),
+                0
+            ) AS avg_pop
+        FROM population_stats cur, latest l
+        WHERE cur.adm_dong_code = ANY($1::text[])
+          AND cur.time_slot = $2
+          AND cur.base_date = l.d
+        GROUP BY l.d
+        """,
+        dong_codes,
+        time_slot,
+    )
+    if not row or row["base_date"] is None:
+        return None
+    return dict(row)
 
 
 def _build_crowdedness_blocks(
@@ -193,7 +184,11 @@ async def fetch_congestion_by_district(
         or None when population data is unavailable.
     """
     time_slot: int = datetime.now(ZoneInfo("Asia/Seoul")).hour
-    pop = await _fetch_population(pool, None, district, time_slot)
+    resolution = await _resolve_dong_codes(pool, None, district)
+    if resolution is None:
+        return None
+    dong_codes, _ = resolution
+    pop = await _fetch_population(pool, dong_codes, time_slot)
     if pop is None:
         return None
     current_pop = int(pop.get("current_pop") or 0)
@@ -233,20 +228,12 @@ async def crowdedness_node(state: dict[str, Any]) -> dict[str, Any]:
     pool = get_pool()
     time_slot: int = datetime.now(ZoneInfo("Asia/Seoul")).hour
 
-    dong_code: Optional[str] = None
-    area_name: str = district or ""  # type: ignore[assignment]
-    if neighborhood:
-        resolution = await _resolve_dong_code(pool, neighborhood, time_slot, district)
-        if resolution is None:
-            return _no_location()
-        dong_code, area_name = resolution
+    resolution = await _resolve_dong_codes(pool, neighborhood, district)
+    if resolution is None:
+        return _no_location()
+    dong_codes, area_name = resolution
 
-    pop = await _fetch_population(
-        pool,
-        dong_code,
-        district if dong_code is None else None,
-        time_slot,
-    )
+    pop = await _fetch_population(pool, dong_codes, time_slot)
 
     if pop is None:
         return {

--- a/backend/src/graph/crowdedness_node.py
+++ b/backend/src/graph/crowdedness_node.py
@@ -193,7 +193,10 @@ async def fetch_congestion_by_district(
         return None
     current_pop = int(pop.get("current_pop") or 0)
     avg_pop = float(pop.get("avg_pop") or 0)
-    level_ko = "보통" if avg_pop == 0 else _classify_level(current_pop / avg_pop)
+    # baseline 없으면 places 카드에 misleading 등급 붙이지 않음 — congestion 필드 자체 생략.
+    if avg_pop == 0:
+        return None
+    level_ko = _classify_level(current_pop / avg_pop)
     base_date = pop.get("base_date")
     updated_at = base_date.isoformat() if base_date is not None else ""
     return {
@@ -250,5 +253,20 @@ async def crowdedness_node(state: dict[str, Any]) -> dict[str, Any]:
     avg_pop = float(pop.get("avg_pop") or 0)
     base_date = pop.get("base_date")
 
-    level = "보통" if avg_pop == 0 else _classify_level(current_pop / avg_pop)
+    # 30일 동일 시간대 baseline이 없으면 비율 비교 불가 — "보통" 폴백 대신 정직하게 미산정 안내.
+    if avg_pop == 0:
+        return {
+            "response_blocks": [
+                {
+                    "type": "text_stream",
+                    "system": "당신은 서울 로컬 라이프 AI 챗봇입니다. 자기소개나 인사로 시작하지 말고 바로 본론으로 답변하세요.",
+                    "prompt": (
+                        f"{area_name} 현재 생활인구는 {current_pop:,}명입니다. "
+                        f"다만 동일 시간대 30일 비교 데이터가 부족해 혼잡도 등급은 산정하지 못했습니다."
+                    ),
+                }
+            ]
+        }
+
+    level = _classify_level(current_pop / avg_pop)
     return {"response_blocks": _build_crowdedness_blocks(level, current_pop, avg_pop, area_name, base_date)}

--- a/backend/src/graph/crowdedness_node.py
+++ b/backend/src/graph/crowdedness_node.py
@@ -50,8 +50,10 @@ async def _resolve_dong_codes(
                 SELECT adm_dong_code
                 FROM administrative_districts
                 WHERE adm_dong_name ILIKE ANY($1::text[])
+                  AND ($2::text IS NULL OR district = $2)
                 """,
                 like_patterns,
+                district,
             )
             if rows:
                 return [r["adm_dong_code"] for r in rows], neighborhood
@@ -61,8 +63,10 @@ async def _resolve_dong_codes(
             SELECT adm_dong_code
             FROM administrative_districts
             WHERE adm_dong_name ILIKE $1
+              AND ($2::text IS NULL OR district = $2)
             """,
             f"%{neighborhood}%",
+            district,
         )
         if rows:
             return [r["adm_dong_code"] for r in rows], neighborhood
@@ -76,8 +80,10 @@ async def _resolve_dong_codes(
                 SELECT adm_dong_code
                 FROM administrative_districts
                 WHERE adm_dong_name ILIKE $1
+                  AND ($2::text IS NULL OR district = $2)
                 """,
                 f"%{trimmed}%",
+                district,
             )
             if rows:
                 return [r["adm_dong_code"] for r in rows], neighborhood
@@ -106,6 +112,7 @@ async def _fetch_population(
 
     base_date 는 population_stats 의 최신 일자.
     avg_pop 은 동일 dong 집합·동일 time_slot 의 일자별 SUM의 30일 평균.
+    단, 최신일(base_date) 자체는 baseline 에서 제외해 현재 스냅샷 오염을 막는다.
     """
     if not dong_codes:
         return None
@@ -124,6 +131,7 @@ async def _fetch_population(
                      WHERE p2.adm_dong_code = ANY($1::text[])
                        AND p2.time_slot = $2
                        AND p2.base_date >= latest.d - INTERVAL '30 days'
+                       AND p2.base_date < latest.d
                      GROUP BY p2.base_date
                  ) dt),
                 0

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -142,7 +142,8 @@ Phase 1 (active):
 - REVIEW_COMPARE: comparing two or more places by 6 metrics
 - CROWDEDNESS: asking about current crowdedness, busyness, or population density of an area.
   Accept noun-phrase queries without verbs (e.g. "홍대 혼잡도", "강남 사람 많아?", "지금 이태원").
-  Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구".
+  Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구", "지금 ~ 어때".
+  Example: "현재 홍대 혼잡도", "강남역 사람 많아?", "이태원 지금 붐비나?", "성수동 한산해?" → CROWDEDNESS.
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL to identify a place or find similar places; also when user refers to a previously sent image without a new URL
 - REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘". NOT REFINE (classify as GENERAL instead): questions about a previous response ("이게 뭐야?", "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?"), opinions ("좋다", "괜찮네"), or follow-up questions that don't request a change.

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -100,7 +100,10 @@ Phase 1 (active):
 - CALENDAR: adding an event to calendar
 - FAVORITE: bookmarking or favoriting something
 - REVIEW_COMPARE: comparing two or more places by 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
-- CROWDEDNESS: asking about current crowdedness or population density of an area
+- CROWDEDNESS: asking about current crowdedness, busyness, or population density of an area.
+  Accept noun-phrase queries without verbs (e.g. "홍대 혼잡도", "강남 사람 많아?", "지금 이태원").
+  Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구", "지금 ~ 어때".
+  Example: "현재 홍대 혼잡도", "강남역 사람 많아?", "이태원 지금 붐비나?", "성수동 한산해?" → CROWDEDNESS.
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL (http/https link ending in image extension or storage URL) to identify a place or find similar places; also when user refers to a previously sent image ("아까 그 사진", "방금 올린 이미지", "그 사진 어딘지", "이전 사진") without a new URL
 - REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘". NOT REFINE (classify as GENERAL instead): questions about a previous response ("이게 뭐야?", "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?"), opinions ("좋다", "괜찮네"), or follow-up questions that don't request a change.
@@ -137,6 +140,9 @@ Phase 1 (active):
 - CALENDAR: adding an event to calendar
 - FAVORITE: bookmarking or favoriting something
 - REVIEW_COMPARE: comparing two or more places by 6 metrics
+- CROWDEDNESS: asking about current crowdedness, busyness, or population density of an area.
+  Accept noun-phrase queries without verbs (e.g. "홍대 혼잡도", "강남 사람 많아?", "지금 이태원").
+  Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구".
 - COST_ESTIMATE: asking about expected cost or price range for a place, restaurant, or activity
 - IMAGE_SEARCH: user sends an image URL to identify a place or find similar places; also when user refers to a previously sent image without a new URL
 - REFINE: user wants to modify, replace, remove, add to, or regenerate a previous response. Examples: "3번 장소 바꿔줘", "그거 말고 다른 거", "카페 빼줘", "다시 추천해줘", "강남 말고 홍대로", "마음에 안 들어", "2번 행사 다른 걸로", "하나 더 추가해줘". NOT REFINE (classify as GENERAL instead): questions about a previous response ("이게 뭐야?", "씨엘이 홍대 씨엘인 거 아니야?", "여기 맛있어?", "몇 시에 문 닫아?"), opinions ("좋다", "괜찮네"), or follow-up questions that don't request a change.

--- a/backend/src/utils/geo_mapping.py
+++ b/backend/src/utils/geo_mapping.py
@@ -1,7 +1,9 @@
-"""동네명 → 자치구 매핑 유틸.
+"""동네명 → 자치구 / 행정동 매핑 유틸.
 
-query_preprocessor, place_search, place_recommend, course_plan 등
-여러 노드에서 공유하는 neighborhood→district 추론 테이블.
+query_preprocessor, place_search, place_recommend, course_plan,
+crowdedness 등 여러 노드에서 공유.
+- NEIGHBORHOOD_TO_DISTRICT: 통용명 → 자치구
+- NEIGHBORHOOD_TO_DONG_PATTERNS: 통용명 → 행정동명 부분일치 패턴 (혼잡도 집계용)
 """
 
 from __future__ import annotations
@@ -119,4 +121,71 @@ def resolve_district(neighborhood: Optional[str]) -> Optional[str]:
     for key, district in NEIGHBORHOOD_TO_DISTRICT.items():
         if key in neighborhood:
             return district
+    return None
+
+
+# 통용명 → 행정동명 부분일치 패턴.
+# administrative_districts.adm_dong_name 에 통용명("홍대")이 그대로 안 나타나는
+# 케이스만 정의. 통용명과 동명이 같은 경우(예: "이태원" → "이태원1동")는
+# ILIKE '%이태원%' 가 자체 처리하므로 생략.
+NEIGHBORHOOD_TO_DONG_PATTERNS: dict[str, list[str]] = {
+    # 마포구
+    "홍대": ["서교", "동교", "연남"],
+    "홍대입구": ["서교", "동교", "연남"],
+    "홍대앞": ["서교", "동교", "연남"],
+    "연트럴파크": ["연남"],
+    # 강남구
+    "강남": ["역삼"],
+    "강남역": ["역삼"],
+    "가로수길": ["신사"],
+    # 용산구
+    "경리단길": ["이태원"],
+    "해방촌": ["용산2"],
+    # 광진구
+    "건대": ["화양"],
+    "건대입구": ["화양"],
+    # 종로구
+    "북촌": ["가회", "삼청"],
+    "서촌": ["청운효자"],
+    "익선동": ["종로1"],
+    "인사동": ["종로1"],
+    "광화문": ["사직"],
+    "경복궁": ["사직"],
+    # 성동구
+    "서울숲": ["성수1가"],
+    # 서대문구
+    "이대": ["대신"],
+    # 관악구
+    "서울대입구": ["행운", "낙성대"],
+    # 강서구
+    "마곡": ["공항"],
+}
+
+
+def resolve_dong_patterns(neighborhood: Optional[str]) -> Optional[list[str]]:
+    """통용 지명을 행정동명 부분일치 패턴 리스트로 변환한다.
+
+    Args:
+        neighborhood: 통용명 (예: "홍대", "강남역")
+
+    Returns:
+        패턴 리스트 (예: ["서교", "동교", "연남"]) 또는 None.
+        반환된 패턴은 SQL `adm_dong_name ILIKE '%pattern%'` 매칭에 사용.
+    """
+    if not neighborhood:
+        return None
+    neighborhood = neighborhood.strip()
+    if not neighborhood:
+        return None
+    # Gemini가 통용명에 "동"을 붙여 정규화하는 케이스 방어 — "성수동" 입력도 "성수"로 lookup.
+    candidates = [neighborhood]
+    if neighborhood.endswith("동") and len(neighborhood) > 1:
+        candidates.append(neighborhood[:-1])
+    for cand in candidates:
+        if cand in NEIGHBORHOOD_TO_DONG_PATTERNS:
+            return NEIGHBORHOOD_TO_DONG_PATTERNS[cand]
+    for key, patterns in NEIGHBORHOOD_TO_DONG_PATTERNS.items():
+        for cand in candidates:
+            if key in cand:
+                return patterns
     return None

--- a/backend/tests/test_crowdedness_node.py
+++ b/backend/tests/test_crowdedness_node.py
@@ -1,13 +1,13 @@
-"""crowdedness_node 단위 테스트 — 14개 케이스.
+"""crowdedness_node 단위 테스트.
 
-순수 함수 직접 호출 + AsyncMock으로 pool.fetchrow mock.
+순수 함수 직접 호출 + AsyncMock으로 pool.fetch/fetchrow mock.
 DB 실연결 없음.
 """
 
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,8 +46,6 @@ async def test_classify_level_혼잡_high_ratio() -> None:
 
 async def test_classify_level_zero_avg() -> None:
     """avg_pop=0 이면 노드가 _classify_level 을 호출하지 않고 '보통' 반환."""
-    from unittest.mock import AsyncMock, MagicMock, patch
-
     from src.graph.crowdedness_node import crowdedness_node  # pyright: ignore[reportMissingImports]
 
     pop_row: dict[str, Any] = {
@@ -56,13 +54,12 @@ async def test_classify_level_zero_avg() -> None:
         "avg_pop": 0,
     }
     pool = MagicMock()
-    pool.fetchrow = AsyncMock(return_value={"adm_dong_code": "1162010100"})
 
     with (
         patch("src.db.postgres.get_pool", return_value=pool),
         patch(
-            "src.graph.crowdedness_node._resolve_dong_code",
-            AsyncMock(return_value=("1162010100", "홍대")),
+            "src.graph.crowdedness_node._resolve_dong_codes",
+            AsyncMock(return_value=(["1162010100"], "홍대")),
         ),
         patch(
             "src.graph.crowdedness_node._fetch_population",
@@ -74,61 +71,176 @@ async def test_classify_level_zero_avg() -> None:
     blocks = result["response_blocks"]
     assert len(blocks) == 1
     assert "보통" in blocks[0]["prompt"]
+    assert "홍대" in blocks[0]["prompt"]
 
 
 # ---------------------------------------------------------------------------
-# _resolve_dong_code
+# _resolve_dong_codes
 # ---------------------------------------------------------------------------
 
 
-async def test_resolve_dong_code_neighborhood_match() -> None:
-    from src.graph.crowdedness_node import _resolve_dong_code  # pyright: ignore[reportMissingImports]
+async def test_resolve_dong_codes_neighborhood_pattern_match() -> None:
+    """통용명 매핑(geo_mapping)으로 행정동 다건 매칭. area_name=neighborhood."""
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
 
     pool = MagicMock()
-    pool.fetchrow = AsyncMock(return_value={"adm_dong_code": "1162010100"})
-
-    result = await _resolve_dong_code(pool, "홍대", 14, None)
-    assert result == ("1162010100", "홍대")
-    pool.fetchrow.assert_called_once()
-
-
-async def test_resolve_dong_code_multiple_matches() -> None:
-    """N건 매칭 — SQL LIMIT 1이 처리하므로 fetchrow 는 항상 단건 반환."""
-    from src.graph.crowdedness_node import _resolve_dong_code  # pyright: ignore[reportMissingImports]
-
-    pool = MagicMock()
-    pool.fetchrow = AsyncMock(return_value={"adm_dong_code": "1162010200"})
-
-    result = await _resolve_dong_code(pool, "홍대", 14, "마포구")
-    assert result == ("1162010200", "홍대")
-    assert pool.fetchrow.call_count == 1
-
-
-async def test_resolve_dong_code_district_fallback() -> None:
-    """ILIKE 0건 → district 집계 fallback — area_name이 district로 바뀜."""
-    from src.graph.crowdedness_node import _resolve_dong_code  # pyright: ignore[reportMissingImports]
-
-    pool = MagicMock()
-    pool.fetchrow = AsyncMock(
-        side_effect=[
-            None,
-            {"adm_dong_code": "1162099999"},
+    pool.fetch = AsyncMock(
+        return_value=[
+            {"adm_dong_code": "1144051000"},
+            {"adm_dong_code": "1144052000"},
+            {"adm_dong_code": "1144064000"},
         ]
     )
 
-    result = await _resolve_dong_code(pool, "우주정거장", 14, "마포구")
-    assert result == ("1162099999", "마포구")
-    assert pool.fetchrow.call_count == 2
+    result = await _resolve_dong_codes(pool, "홍대", "마포구")
+    assert result is not None
+    codes, area_name = result
+    assert area_name == "홍대"
+    assert len(codes) == 3
+    # 첫 호출이 NEIGHBORHOOD_TO_DONG_PATTERNS 경로 — 단 한 번에 매칭
+    assert pool.fetch.call_count == 1
 
 
-async def test_resolve_dong_code_none() -> None:
-    """ILIKE + district 모두 0건 → None."""
-    from src.graph.crowdedness_node import _resolve_dong_code  # pyright: ignore[reportMissingImports]
+async def test_resolve_dong_codes_neighborhood_ilike_match() -> None:
+    """통용명 매핑에 없는 입력 → ILIKE 직접 매칭으로 행정동명 부분일치."""
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
 
     pool = MagicMock()
-    pool.fetchrow = AsyncMock(side_effect=[None, None])
+    pool.fetch = AsyncMock(return_value=[{"adm_dong_code": "1117060500"}, {"adm_dong_code": "1117060600"}])
 
-    result = await _resolve_dong_code(pool, "우주정거장", 14, "화성구")
+    # "이태원"은 NEIGHBORHOOD_TO_DONG_PATTERNS에 없어 패턴 fetch 자체가 스킵됨
+    # 직접 ILIKE 만 호출됨 → 단 한 번
+    result = await _resolve_dong_codes(pool, "이태원", "용산구")
+    assert result is not None
+    codes, area_name = result
+    assert area_name == "이태원"
+    assert codes == ["1117060500", "1117060600"]
+    assert pool.fetch.call_count == 1
+
+
+async def test_resolve_dong_codes_dong_suffix_trim() -> None:
+    """Gemini가 "성수" → "성수동"으로 정규화한 입력 — "동" 떼고 재시도해서 매칭.
+
+    실제 동명("성수1가1동")은 "성수동" ILIKE에 매치 안 되지만 "성수" trim 후 매치.
+    """
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(
+        side_effect=[
+            [],  # 1차: ILIKE '%성수동%' → 0건
+            [
+                {"adm_dong_code": "1120069000"},
+                {"adm_dong_code": "1120070000"},
+            ],  # 2차: ILIKE '%성수%' → 매치
+        ]
+    )
+
+    result = await _resolve_dong_codes(pool, "성수동", None)
+    assert result is not None
+    codes, area_name = result
+    # area_name은 사용자가 입력한 원본 보존 (Gemini 정규화 결과 그대로)
+    assert area_name == "성수동"
+    assert codes == ["1120069000", "1120070000"]
+    assert pool.fetch.call_count == 2
+
+
+async def test_resolve_dong_codes_district_fallback() -> None:
+    """neighborhood 매칭 모두 실패 → district의 모든 동. area_name=district."""
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(
+        side_effect=[
+            [],  # ILIKE 직접 매칭 (neighborhood가 매핑에 없는 경우)
+            [
+                {"adm_dong_code": "1144051000"},
+                {"adm_dong_code": "1144052000"},
+            ],
+        ]
+    )
+
+    result = await _resolve_dong_codes(pool, "우주정거장", "마포구")
+    assert result is not None
+    codes, area_name = result
+    assert area_name == "마포구"
+    assert len(codes) == 2
+
+
+async def test_resolve_dong_codes_district_only() -> None:
+    """neighborhood 없이 district만 → district의 모든 동."""
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(return_value=[{"adm_dong_code": "1144051000"}])
+
+    result = await _resolve_dong_codes(pool, None, "마포구")
+    assert result is not None
+    codes, area_name = result
+    assert area_name == "마포구"
+    assert codes == ["1144051000"]
+
+
+async def test_resolve_dong_codes_none() -> None:
+    """모든 매칭 실패 → None.
+
+    "우주정거장"은 패턴 매핑에 없으므로 패턴 fetch는 스킵.
+    직접 ILIKE 1회 + district fallback 1회 = 총 2회.
+    """
+    from src.graph.crowdedness_node import _resolve_dong_codes  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetch = AsyncMock(side_effect=[[], []])
+
+    result = await _resolve_dong_codes(pool, "우주정거장", "화성구")
+    assert result is None
+    assert pool.fetch.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _fetch_population
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_population_empty_codes() -> None:
+    """빈 dong_codes → None (DB 미호출)."""
+    from src.graph.crowdedness_node import _fetch_population  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock()
+
+    result = await _fetch_population(pool, [], 14)
+    assert result is None
+    pool.fetchrow.assert_not_called()
+
+
+async def test_fetch_population_sum() -> None:
+    """다건 dong → SUM 결과 반환."""
+    from src.graph.crowdedness_node import _fetch_population  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "current_pop": 50000,
+            "base_date": date(2026, 5, 5),
+            "avg_pop": 47000.0,
+        }
+    )
+
+    result = await _fetch_population(pool, ["1144051000", "1144052000"], 14)
+    assert result is not None
+    assert result["current_pop"] == 50000
+    assert result["avg_pop"] == 47000.0
+
+
+async def test_fetch_population_no_data() -> None:
+    """일치 데이터 없음 → None."""
+    from src.graph.crowdedness_node import _fetch_population  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+
+    result = await _fetch_population(pool, ["1144051000"], 14)
     assert result is None
 
 
@@ -154,7 +266,7 @@ async def test_build_blocks_stale() -> None:
     """base_date 4일 전 — stale 경고 포함."""
     from src.graph.crowdedness_node import _build_crowdedness_blocks  # pyright: ignore[reportMissingImports]
 
-    stale_date = date(2026, 5, 1)  # 4일 전 (today=2026-05-05)
+    stale_date = date(2026, 5, 1)
     with patch("src.graph.crowdedness_node.datetime") as mock_dt:
         mock_dt.now.return_value.date.return_value = date(2026, 5, 5)
         blocks = _build_crowdedness_blocks("보통", 2000, 2100.0, "이태원", stale_date)
@@ -181,11 +293,13 @@ async def test_node_skips_db_when_no_location() -> None:
     from src.graph.crowdedness_node import crowdedness_node  # pyright: ignore[reportMissingImports]
 
     pool = MagicMock()
+    pool.fetch = AsyncMock()
     pool.fetchrow = AsyncMock()
 
-    with patch("src.db.postgres.get_pool", return_value=pool):  # type: ignore[attr-defined]
+    with patch("src.db.postgres.get_pool", return_value=pool):
         result = await crowdedness_node({"processed_query": {}})
 
+    pool.fetch.assert_not_called()
     pool.fetchrow.assert_not_called()
     assert "지역을 인식하지 못했습니다" in result["response_blocks"][0]["prompt"]
 
@@ -209,22 +323,69 @@ async def test_node_uses_kst_hour() -> None:
 
     captured_time_slot: list[int] = []
 
-    async def mock_resolve(p: Any, neighborhood: str, time_slot: int, district: Any) -> Optional[tuple[str, str]]:
+    async def mock_fetch_pop(p: Any, dong_codes: list[str], time_slot: int) -> dict[str, Any]:
         captured_time_slot.append(time_slot)
-        return ("1162010100", neighborhood)
-
-    pop_row: dict[str, Any] = {
-        "current_pop": 3000,
-        "base_date": date(2026, 5, 5),
-        "avg_pop": 2500.0,
-    }
+        return {
+            "current_pop": 3000,
+            "base_date": date(2026, 5, 5),
+            "avg_pop": 2500.0,
+        }
 
     with (
         patch("src.graph.crowdedness_node.datetime", FrozenDatetime),
-        patch("src.graph.crowdedness_node._resolve_dong_code", mock_resolve),
-        patch("src.graph.crowdedness_node._fetch_population", AsyncMock(return_value=pop_row)),
+        patch(
+            "src.graph.crowdedness_node._resolve_dong_codes",
+            AsyncMock(return_value=(["1144051000"], "홍대")),
+        ),
+        patch("src.graph.crowdedness_node._fetch_population", mock_fetch_pop),
         patch("src.db.postgres.get_pool", return_value=pool),
-    ):  # type: ignore[attr-defined]
+    ):
         await crowdedness_node({"processed_query": {"neighborhood": "홍대", "district": None}})
 
     assert captured_time_slot == [14]
+
+
+async def test_node_neighborhood_preserves_label() -> None:
+    """통용명("홍대") 입력 시 응답 area_name이 자치구로 광역화되지 않음."""
+    from src.graph.crowdedness_node import crowdedness_node  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+    pop_row: dict[str, Any] = {
+        "current_pop": 60000,
+        "base_date": date(2026, 5, 5),
+        "avg_pop": 55000.0,
+    }
+
+    with (
+        patch(
+            "src.graph.crowdedness_node._resolve_dong_codes",
+            AsyncMock(return_value=(["1144051000", "1144052000", "1144064000"], "홍대")),
+        ),
+        patch("src.graph.crowdedness_node._fetch_population", AsyncMock(return_value=pop_row)),
+        patch("src.db.postgres.get_pool", return_value=pool),
+    ):
+        result = await crowdedness_node({"processed_query": {"neighborhood": "홍대", "district": "마포구"}})
+
+    prompt = result["response_blocks"][0]["prompt"]
+    assert "홍대의 현재 혼잡도" in prompt
+    assert "마포구의 현재 혼잡도" not in prompt
+    assert "60,000" in prompt
+
+
+async def test_node_no_data_message() -> None:
+    """resolution 성공 + 인구 데이터 없음 → '생활인구 데이터가 없습니다' 메시지."""
+    from src.graph.crowdedness_node import crowdedness_node  # pyright: ignore[reportMissingImports]
+
+    pool = MagicMock()
+
+    with (
+        patch(
+            "src.graph.crowdedness_node._resolve_dong_codes",
+            AsyncMock(return_value=(["1144051000"], "홍대")),
+        ),
+        patch("src.graph.crowdedness_node._fetch_population", AsyncMock(return_value=None)),
+        patch("src.db.postgres.get_pool", return_value=pool),
+    ):
+        result = await crowdedness_node({"processed_query": {"neighborhood": "홍대", "district": None}})
+
+    assert "생활인구 데이터가 없습니다" in result["response_blocks"][0]["prompt"]

--- a/backend/tests/test_crowdedness_node.py
+++ b/backend/tests/test_crowdedness_node.py
@@ -45,7 +45,7 @@ async def test_classify_level_혼잡_high_ratio() -> None:
 
 
 async def test_classify_level_zero_avg() -> None:
-    """avg_pop=0 이면 노드가 _classify_level 을 호출하지 않고 '보통' 반환."""
+    """avg_pop=0 — 등급 산정 불가 안내 (보통 폴백 금지). current_pop은 그대로 노출."""
     from src.graph.crowdedness_node import crowdedness_node  # pyright: ignore[reportMissingImports]
 
     pop_row: dict[str, Any] = {
@@ -70,8 +70,13 @@ async def test_classify_level_zero_avg() -> None:
 
     blocks = result["response_blocks"]
     assert len(blocks) == 1
-    assert "보통" in blocks[0]["prompt"]
-    assert "홍대" in blocks[0]["prompt"]
+    prompt = blocks[0]["prompt"]
+    assert "홍대" in prompt
+    assert "1,000" in prompt
+    assert "산정하지 못했" in prompt
+    # 보통/한산/혼잡 등급 폴백 금지
+    assert "**보통**" not in prompt
+    assert "혼잡도는" not in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
  - **라벨/데이터 일관성**: 통용 지명("홍대")
  입력이 자치구("마포구") 라벨로 광역화되던
  불일치 해결. `_resolve_dong_codes` 단일
  경로로 통합 — `NEIGHBORHOOD_TO_DONG_PATTERNS`
   기반 패턴 ILIKE 매칭 + Gemini
  정규화("성수"→"성수동") 방어 (`동` suffix
  trim).
  - **Intent 라우팅 robustness**:
  `intent_router` CROWDEDNESS 프롬프트
  강화(명사구 쿼리·트리거 키워드 예시),
  multi-intent 프롬프트에 누락된 CROWDEDNESS
  항목 추가.
  - **`avg_pop=0` 무조건 '보통' 폴백 제거 (line
   266 회귀)**: 30일 동일 시간대 baseline이
  없을 때 misleading한 "보통" 등급 대신
  `"{area} 현재 생활인구는 N명입니다. 다만 동일
   시간대 30일 비교 데이터가 부족해 혼잡도
  등급은 산정하지 못했습니다."` 안내.
  `fetch_congestion_by_district`도 동일
  조건에서 `None` 반환 → places 카드에 잘못된
  congestion 미부착.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Crowdedness now aggregates population across multiple administrative areas for more accurate local estimates.
  * Intent detection for crowdedness queries expanded with broader keyword recognition and acceptance of noun-phrase queries (including Korean examples).
  * When comparative baseline data is missing, the system explicitly indicates it cannot compute congestion rather than defaulting to "보통".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->