### PR TITLE
fix: EVENT_SEARCH references 블록 events 카드로 통합 (#200)

### DIFF
--- a/backend/src/graph/event_search_node.py
+++ b/backend/src/graph/event_search_node.py
@@ -8,7 +8,8 @@
   4. Rerank 후보 한도 컷 (_MAX_PRERANK) — Naver append 전
   5. PG ∪ OS 병합 < 3건 → Naver 블로그 검색 API fallback (graceful degradation)
   6. LLM Rerank (Gemini Flash — 순위 재배치 + per-event 소개 동시 생성)
-  7. response_blocks: events[] + text_stream(요약) + references[]
+  7. response_blocks: events[] + text_stream(요약)
+     · references 블록은 events 카드 detail_url로 통합 (#200) — FE가 카드 안 하이퍼링크로 렌더링
 
 불변식 #2: event_id == events_vector._id (PG 부재 OS hit는 폐기)
 불변식 #4: PG 2차 보강 쿼리에 is_deleted = FALSE
@@ -600,10 +601,10 @@ def _build_blocks(
     descriptions: list[str],
     pq: Optional[dict[str, Any]] = None,
 ) -> list[dict[str, Any]]:
-    """검색 결과 → events(+description) + text_stream(종합 요약) + references 블록.
+    """검색 결과 → events(+description) + text_stream(종합 요약).
 
     빈 결과(events=[])는 LLM 호출 없이 `_build_empty_blocks`로 즉시 반환 (#151).
-    events 중 source='naver_blog' 항목은 references[] 블록에 추가 노출 (출처 링크).
+    references 블록은 events 카드 detail_url로 통합됨 (#200).
     """
     # 빈 결과는 LLM 호출 없이 정적 안내 1개 (#151)
     if not events:
@@ -676,25 +677,8 @@ def _build_blocks(
         }
     )
 
-    # 3. references 블록 (Naver fallback 결과만 — 출처 링크)
-    references: list[dict[str, Any]] = []
-    for e in events:
-        if e.get("source") == "naver_blog" and e.get("detail_url"):
-            references.append(
-                {
-                    "title": e.get("title", ""),
-                    "url": e["detail_url"],
-                    "source": "naver_blog",
-                }
-            )
-
-    if references:
-        blocks.append(
-            {
-                "type": "references",
-                "items": references,
-            }
-        )
+    # references 블록 제거 (#200) — events 카드와 동일 정보가 중복 표시되던 UX 회귀.
+    # events 카드의 detail_url + source 필드는 유지 — FE가 카드 클릭/상단 하이퍼링크로 통합 렌더링.
 
     return blocks
 
@@ -793,7 +777,7 @@ async def event_search_node(state: dict[str, Any]) -> dict[str, Any]:
         state: AgentState dict (query, processed_query 등).
 
     Returns:
-        {"response_blocks": [events, text_stream, references?]}.
+        {"response_blocks": [events, text_stream]}.
     """
     previous_blocks = state.get("previous_blocks")
     refinement = state.get("refinement")

--- a/backend/tests/test_event_search.py
+++ b/backend/tests/test_event_search.py
@@ -121,7 +121,7 @@ async def test_build_blocks_with_db_events_only() -> None:
 
 
 async def test_build_blocks_with_naver_fallback() -> None:
-    """Naver fallback 결과 포함 시: references 블록 추가."""
+    """Naver fallback 결과 포함 시 — events 카드 안 detail_url/source 유지, references 블록 미전송 (#200)."""
     from src.graph.event_search_node import _build_blocks  # pyright: ignore[reportMissingImports]
 
     merged = _DB_EVENTS + _NAVER_EVENTS
@@ -130,17 +130,19 @@ async def test_build_blocks_with_naver_fallback() -> None:
     block_types = [b["type"] for b in blocks]
     assert "text_stream" in block_types
     assert "events" in block_types
-    assert "references" in block_types
+    # #200: references 블록 미전송 — Naver 결과의 detail_url은 events 카드에 그대로 포함
+    assert "references" not in block_types
 
-    # references는 Naver 결과만 포함
-    refs_block = next(b for b in blocks if b["type"] == "references")
-    assert len(refs_block["items"]) == 1
-    assert refs_block["items"][0]["url"] == "https://blog.naver.com/example"
-    assert refs_block["items"][0]["source"] == "naver_blog"
+    events_block = next(b for b in blocks if b["type"] == "events")
+    items = events_block["items"]
+    # Naver 결과가 events 카드 안에 detail_url + source 유지
+    naver_items = [i for i in items if i.get("source") == "naver_blog"]
+    assert len(naver_items) == 1
+    assert naver_items[0]["detail_url"] == "https://blog.naver.com/example"
 
 
 async def test_build_blocks_empty_results() -> None:
-    """검색 결과 0건: text 블록만 생성 (text_stream/events/references 없음). #151."""
+    """검색 결과 0건: text 블록만 생성 (text_stream/events 없음). #151."""
     from src.graph.event_search_node import _build_blocks  # pyright: ignore[reportMissingImports]
 
     blocks = _build_blocks("결과 없는 쿼리", [], [], pq=None)


### PR DESCRIPTION
#193으로 event_recommend는 처리됐는데 event_search는 동일 패턴이 남아있었음. "홍대 행사들 뭐있어?" 같은 EVENT_SEARCH 쿼리에서 "추천 사유 / 인용" 섹션이 events 카드와 중복 노출되던 회귀를 함께 제거.

변경
- event_search_node.py L679-697 references 블록 생성 코드 제거 · Naver fallback 결과의 detail_url은 events 카드 안 detail_url 필드에 이미 포함 · FE가 카드 클릭/하이퍼링크로 새 탭 열기 (#200 FE 작업)
- docstring 응답 순서 갱신 · 7. events[] + text_stream + references[] → 7. events[] + text_stream · "{response_blocks: [events, text_stream, references?]}" → "[events, text_stream]"

place_recommend의 references는 이번 PR 범위 밖
- 그 블록은 detail_url 재포장이 아니라 place_reviews.summary_text snippet (리뷰 데이터)
- 단순 출처 링크가 아닌 가치 있는 데이터 — 제거 시 사용자 정보 손실
- place 카드 UX 개선은 별도 디자인 결정 + 별도 이슈

테스트 (47 passed)
- test_event_search.py 갱신 2건 · references 블록 미전송 검증 + events 카드 detail_url/source 유지 검증 · docstring 보정 ("text_stream/events/references 없음" → "text_stream/events 없음")

FE 협업 (#200)
- events 카드 onClick → window.open(item.detail_url, '_blank')
- 기존 "추천 사유 / 인용" 섹션 렌더링 제거

19 데이터 모델 불변식
- #10 SSE 이벤트 타입 16종 — references 블록 자체는 유지 (place_recommend 등에서 사용)
- #11 intent별 블록 순서 — EVENT_SEARCH `events → references → done` → `events → done`

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Event search results now display source information directly within each event result, consolidating the reference display for a streamlined presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Techeer-2026-1/Localbiz-Backend/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->