### PR TITLE
[Feat] Observability Phase 1 — 전 LangGraph 노드 OpenTelemetry tracing 확장 (#202)

### DIFF
--- a/backend/src/graph/_tracing.py
+++ b/backend/src/graph/_tracing.py
@@ -1,0 +1,106 @@
+"""LangGraph 노드용 OpenTelemetry tracing 헬퍼.
+
+- `traced_node(name)` 데코레이터: 노드 진입 시 `node.<name>` span 시작, state에서
+  intent/thread_id/user_id 속성 부착, 결과 list 길이를 `response_blocks.added`로 기록.
+- `traced_call(name, **attrs)` async 컨텍스트: 노드 내부 외부 호출(LLM/DB/HTTP)에
+  sub-span 부착.
+
+`telemetry.setup_tracing()`이 호출되지 않은 환경(`JAEGER_HOST` 미설정 로컬·테스트)에서는
+OTel가 NoOp tracer를 반환 — span 생성·attribute 부착이 모두 no-op이라 성능 영향 0.
+
+Phase 3(메트릭) 진입 시 `traced_node`/`traced_call` 내부에서 `langgraph_node_latency_seconds`,
+`langgraph_os_query_latency_seconds` 등 Prometheus 히스토그램 observe 후크를 추가한다.
+현재 파일은 tracing 전용 — metric hook은 의도적으로 미포함.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from functools import wraps
+from typing import Any
+
+from opentelemetry import trace  # pyright: ignore[reportMissingImports]
+from opentelemetry.trace import Span, StatusCode  # pyright: ignore[reportMissingImports]
+
+# 모든 그래프 노드 span을 단일 tracer name으로 통합 — Jaeger UI에서
+# service.name(localbiz-api)·tracer name(localbiz.graph) 단위 필터를 일관되게 사용.
+_tracer = trace.get_tracer("localbiz.graph")
+
+
+def _attach_state_attrs(span: Span, state: Any) -> None:
+    """state dict에서 intent/thread_id/user_id를 span 속성으로 부착.
+
+    state가 dict가 아니거나 키가 누락이어도 silent하게 skip — tracing이 노드 실행을
+    절대 깨트리지 않도록.
+    """
+    if not isinstance(state, dict):
+        return
+    intent = state.get("intent")
+    if intent is not None and intent != "":
+        span.set_attribute("intent", str(intent))
+    thread_id = state.get("thread_id")
+    if thread_id is not None:
+        span.set_attribute("thread_id", str(thread_id))
+    user_id = state.get("user_id")
+    if user_id is not None:
+        span.set_attribute("user_id", str(user_id))
+
+
+def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """LangGraph 노드 진입에 `node.<name>` span을 부착하는 데코레이터.
+
+    노드 함수 시그니처(`async def f(state, ...)`)를 보존하며, state에서
+    intent/thread_id/user_id를 추출해 span 속성으로 부착한다. 노드가 list를 반환하면
+    그 길이를 `response_blocks.added` 속성으로 기록(어느 노드가 출력을 생성·스킵했는지
+    Jaeger UI에서 한눈에 확인).
+
+    예외 발생 시 `record_exception` + status=ERROR 부착 후 원래 예외를 재발생.
+
+    Args:
+        name: span 이름 suffix. 최종 span 이름은 `node.<name>`.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(fn)
+        async def wrapper(state: Any, *args: Any, **kwargs: Any) -> Any:
+            with _tracer.start_as_current_span(f"node.{name}") as span:
+                _attach_state_attrs(span, state)
+                try:
+                    result = await fn(state, *args, **kwargs)
+                    if isinstance(result, list):
+                        span.set_attribute("response_blocks.added", len(result))
+                    return result
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_status(StatusCode.ERROR, str(exc))
+                    raise
+
+        return wrapper
+
+    return decorator
+
+
+@asynccontextmanager
+async def traced_call(name: str, **attrs: Any) -> AsyncIterator[Span]:
+    """노드 내부 외부 호출(LLM/DB/HTTP)에 sub-span을 부착하는 async 컨텍스트.
+
+    예외 발생 시 `record_exception` + status=ERROR 후 원래 예외를 재발생.
+    attribute 값이 None이면 부착 skip — 호출부에서 `index=None` 같은 미상 값을
+    그대로 넘겨도 안전.
+
+    Args:
+        name: span 이름. 권장 명명: `<system>.<op>` — 예: `os.places_vector.knn`,
+            `pg.places.search`, `gemini.booking_grounding`, `naver.event_search`.
+        **attrs: span attribute로 즉시 부착할 키-값 쌍.
+    """
+    with _tracer.start_as_current_span(name) as span:
+        for k, v in attrs.items():
+            if v is not None:
+                span.set_attribute(k, str(v))
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise

--- a/backend/src/graph/_tracing.py
+++ b/backend/src/graph/_tracing.py
@@ -1,16 +1,20 @@
 """LangGraph 노드용 OpenTelemetry tracing 헬퍼.
 
 - `traced_node(name)` 데코레이터: 노드 진입 시 `node.<name>` span 시작, state에서
-  intent/thread_id/user_id 속성 부착, 결과 list 길이를 `response_blocks.added`로 기록.
+  intent/thread_id/user_id 속성 부착, 결과의 `response_blocks` 길이를 attribute로 기록.
+  노드 반환 타입이 dict(`{"response_blocks": [...]}`)이거나 list 어느 쪽이든 처리.
 - `traced_call(name, **attrs)` async 컨텍스트: 노드 내부 외부 호출(LLM/DB/HTTP)에
   sub-span 부착.
+
+예외 처리는 OTel SDK 기본 동작(`record_exception=True`, `set_status_on_exception=True`)에
+일임 — 명시적 `record_exception`/`set_status` 호출 시 중복 이벤트/상태 갱신이 발생하므로
+수동 호출을 두지 않는다.
 
 `telemetry.setup_tracing()`이 호출되지 않은 환경(`JAEGER_HOST` 미설정 로컬·테스트)에서는
 OTel가 NoOp tracer를 반환 — span 생성·attribute 부착이 모두 no-op이라 성능 영향 0.
 
-Phase 3(메트릭) 진입 시 `traced_node`/`traced_call` 내부에서 `langgraph_node_latency_seconds`,
-`langgraph_os_query_latency_seconds` 등 Prometheus 히스토그램 observe 후크를 추가한다.
-현재 파일은 tracing 전용 — metric hook은 의도적으로 미포함.
+Phase 3(메트릭) 진입 시 `traced_node` 내부에서 `langgraph_node_latency_seconds` 등
+Prometheus 히스토그램 observe 후크를 추가한다. 현재 파일은 tracing 전용.
 """
 
 from __future__ import annotations
@@ -18,10 +22,10 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from functools import wraps
-from typing import Any
+from typing import Any, Optional
 
 from opentelemetry import trace  # pyright: ignore[reportMissingImports]
-from opentelemetry.trace import Span, StatusCode  # pyright: ignore[reportMissingImports]
+from opentelemetry.trace import Span  # pyright: ignore[reportMissingImports]
 
 # 모든 그래프 노드 span을 단일 tracer name으로 통합 — Jaeger UI에서
 # service.name(localbiz-api)·tracer name(localbiz.graph) 단위 필터를 일관되게 사용.
@@ -47,15 +51,35 @@ def _attach_state_attrs(span: Span, state: Any) -> None:
         span.set_attribute("user_id", str(user_id))
 
 
+def _count_response_blocks(result: Any) -> Optional[int]:
+    """노드 반환값에서 response_blocks 길이를 추출. 측정 불가하면 None.
+
+    LangGraph 노드는 두 가지 형태로 반환한다:
+      - dict (`{"response_blocks": [...], ...}`) — analysis/calendar/cost_estimate 등 대부분
+      - list (`[block, block, ...]`) — Annotated[list, operator.add]로 reduce되는 케이스
+
+    어느 쪽도 아니면 None 반환 — attribute 부착 생략.
+    """
+    if isinstance(result, dict):
+        blocks = result.get("response_blocks")
+        if isinstance(blocks, list):
+            return len(blocks)
+        return None
+    if isinstance(result, list):
+        return len(result)
+    return None
+
+
 def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """LangGraph 노드 진입에 `node.<name>` span을 부착하는 데코레이터.
 
     노드 함수 시그니처(`async def f(state, ...)`)를 보존하며, state에서
-    intent/thread_id/user_id를 추출해 span 속성으로 부착한다. 노드가 list를 반환하면
-    그 길이를 `response_blocks.added` 속성으로 기록(어느 노드가 출력을 생성·스킵했는지
-    Jaeger UI에서 한눈에 확인).
+    intent/thread_id/user_id를 추출해 span 속성으로 부착한다. 노드가 추가한
+    response_blocks 길이를 `response_blocks.added` 속성으로 기록(어느 노드가 출력을
+    생성·스킵했는지 Jaeger UI에서 한눈에 확인).
 
-    예외 발생 시 `record_exception` + status=ERROR 부착 후 원래 예외를 재발생.
+    예외 발생 시 OTel SDK가 자동으로 `record_exception` + status=ERROR 처리 — 수동
+    호출 시 중복되므로 두지 않는다.
 
     Args:
         name: span 이름 suffix. 최종 span 이름은 `node.<name>`.
@@ -66,15 +90,11 @@ def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]
         async def wrapper(state: Any, *args: Any, **kwargs: Any) -> Any:
             with _tracer.start_as_current_span(f"node.{name}") as span:
                 _attach_state_attrs(span, state)
-                try:
-                    result = await fn(state, *args, **kwargs)
-                    if isinstance(result, list):
-                        span.set_attribute("response_blocks.added", len(result))
-                    return result
-                except Exception as exc:
-                    span.record_exception(exc)
-                    span.set_status(StatusCode.ERROR, str(exc))
-                    raise
+                result = await fn(state, *args, **kwargs)
+                block_count = _count_response_blocks(result)
+                if block_count is not None:
+                    span.set_attribute("response_blocks.added", block_count)
+                return result
 
         return wrapper
 
@@ -85,7 +105,7 @@ def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]
 async def traced_call(name: str, **attrs: Any) -> AsyncIterator[Span]:
     """노드 내부 외부 호출(LLM/DB/HTTP)에 sub-span을 부착하는 async 컨텍스트.
 
-    예외 발생 시 `record_exception` + status=ERROR 후 원래 예외를 재발생.
+    예외 처리는 OTel SDK 기본값(`record_exception`+`set_status_on_exception`)에 일임.
     attribute 값이 None이면 부착 skip — 호출부에서 `index=None` 같은 미상 값을
     그대로 넘겨도 안전.
 
@@ -98,9 +118,4 @@ async def traced_call(name: str, **attrs: Any) -> AsyncIterator[Span]:
         for k, v in attrs.items():
             if v is not None:
                 span.set_attribute(k, str(v))
-        try:
-            yield span
-        except Exception as exc:
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
-            raise
+        yield span

--- a/backend/src/graph/analysis_node.py
+++ b/backend/src/graph/analysis_node.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 # 불변식 #6: 6지표 키 고정 (이름·개수 변경 금지)
@@ -176,6 +178,7 @@ def _build_analysis_blocks(
     ]
 
 
+@traced_node("analysis")
 async def analysis_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 노드 — ANALYSIS intent 처리 (Phase 1)."""
     query: str = state.get("query", "")

--- a/backend/src/graph/booking_node.py
+++ b/backend/src/graph/booking_node.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from cachetools import TTLCache
 
 from src.config import get_settings  # pyright: ignore[reportMissingImports]
+from src.graph._tracing import traced_call, traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.state import AgentState  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ _BOOKING_SYSTEM = (
 )
 
 
+@traced_node("booking")
 async def booking_node(state: AgentState) -> dict[str, Any]:
     """BOOKING intent 노드.
 
@@ -97,13 +99,18 @@ async def _search_booking_info(
     prompt = f"{_BOOKING_SYSTEM}\n\n사용자가 '{place_name}'{cat_ctx}{date_ctx} 예약을 원해."
 
     try:
-        resp = await client.aio.models.generate_content(
+        async with traced_call(
+            "gemini.booking_grounding",
             model="gemini-2.5-flash",
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                tools=[types.Tool(google_search=types.GoogleSearch())],
-            ),
-        )
+            purpose="booking_grounding",
+        ):
+            resp = await client.aio.models.generate_content(
+                model="gemini-2.5-flash",
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    tools=[types.Tool(google_search=types.GoogleSearch())],
+                ),
+            )
         return resp.text or f"'{place_name}' 예약 정보를 찾지 못했어요. 직접 검색하거나 전화 문의해 주세요."
     except Exception:
         logger.warning("booking_node: grounding 실패 place=%s", place_name)

--- a/backend/src/graph/calendar_node.py
+++ b/backend/src/graph/calendar_node.py
@@ -22,6 +22,7 @@ from cachetools import TTLCache
 
 from src.config import get_settings  # pyright: ignore[reportMissingImports]
 from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.state import AgentState  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,7 @@ async def _load_history_from_db(thread_id: str) -> list[dict[str, str]]:
     return history
 
 
+@traced_node("calendar")
 async def calendar_node(state: AgentState) -> dict[str, Any]:
     """CALENDAR intent 노드 — Google Calendar 이벤트 생성.
 

--- a/backend/src/graph/cost_estimate_node.py
+++ b/backend/src/graph/cost_estimate_node.py
@@ -18,6 +18,8 @@ import re
 from datetime import date, timedelta
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _NAVER_BLOG_URL = "https://openapi.naver.com/v1/search/blog.json"
@@ -158,6 +160,7 @@ async def _handle_refinement(
     return await cost_estimate_node(state)
 
 
+@traced_node("cost_estimate")
 async def cost_estimate_node(state: dict[str, Any]) -> dict[str, Any]:
     """COST_ESTIMATE 노드 — 비용 견적 text_stream 블록 반환.
 

--- a/backend/src/graph/course_plan_node.py
+++ b/backend/src/graph/course_plan_node.py
@@ -24,6 +24,8 @@ import math
 import uuid
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _COURSE_SYSTEM_PROMPT = (
@@ -1025,6 +1027,7 @@ async def _handle_refinement(
     return {"response_blocks": blocks}
 
 
+@traced_node("course_plan")
 async def course_plan_node(state: dict[str, Any]) -> dict[str, Any]:
     """COURSE_PLAN 노드 — 카테고리별 병렬 검색 → Greedy NN → LLM 코스 구성 (Phase 1).
 

--- a/backend/src/graph/crowdedness_node.py
+++ b/backend/src/graph/crowdedness_node.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _STALE_THRESHOLD_DAYS = 3
@@ -214,6 +216,7 @@ async def fetch_congestion_by_district(
     }
 
 
+@traced_node("crowdedness")
 async def crowdedness_node(state: dict[str, Any]) -> dict[str, Any]:
     """CROWDEDNESS intent 처리 노드. Phase: P1."""
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]

--- a/backend/src/graph/detail_inquiry_node.py
+++ b/backend/src/graph/detail_inquiry_node.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _DETAIL_INQUIRY_SYSTEM_PROMPT = (
@@ -181,6 +183,7 @@ async def _fetch_place(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+@traced_node("detail_inquiry")
 async def detail_inquiry_node(state: dict[str, Any]) -> dict[str, Any]:
     """DETAIL_INQUIRY 노드 — 장소 상세 단건 조회 + Gemini 소개.
 

--- a/backend/src/graph/event_recommend_node.py
+++ b/backend/src/graph/event_recommend_node.py
@@ -42,6 +42,7 @@ import re
 from datetime import date
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.event_filters import is_real_event  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
@@ -737,6 +738,7 @@ async def _handle_refinement(
     return {"response_blocks": blocks}
 
 
+@traced_node("event_recommend")
 async def event_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     """EVENT_RECOMMEND 노드 — PG 정형 + OS k-NN + LLM Rerank 행사 추천 (Phase 1).
 

--- a/backend/src/graph/event_search_node.py
+++ b/backend/src/graph/event_search_node.py
@@ -34,14 +34,10 @@ import re
 from datetime import date
 from typing import Any, Optional
 
-from opentelemetry import trace  # pyright: ignore[reportMissingImports]
-
+from src.graph._tracing import traced_call, traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.event_filters import is_real_event  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
-
-# tracer는 JAEGER_HOST 미설정 환경(로컬·테스트)에서도 no-op으로 동작 — telemetry.py 활성 시 자동으로 export.
-tracer = trace.get_tracer(__name__)
 
 _EVENT_SEARCH_SYSTEM_PROMPT = (
     "당신은 서울 로컬 라이프 AI 챗봇 'AnyWay'입니다. "
@@ -94,7 +90,7 @@ async def _embed_query_768d(query: str, api_key: str) -> list[float]:
     """Gemini embedding-001 768d 단건 임베딩. 불변식 #7."""
     from src.utils.resilience import request_json  # pyright: ignore[reportMissingImports]
 
-    with tracer.start_as_current_span("event.search.embed_query") as span:
+    async with traced_call("event.search.embed_query") as span:
         span.set_attribute("event.embed.model", "gemini-embedding-001")
         span.set_attribute("event.embed.query_length", len(query))
 
@@ -144,7 +140,7 @@ async def _search_os_events(
     from src.utils.resilience import retry_call  # pyright: ignore[reportMissingImports]
 
     try:
-        with tracer.start_as_current_span("event.search.opensearch") as span:
+        async with traced_call("event.search.opensearch") as span:
             span.set_attribute("event.os.index", "events_vector")
             span.set_attribute("event.os.k", _OS_CANDIDATE_K)
             span.set_attribute("event.os.min_score", _OS_MIN_SCORE)
@@ -299,7 +295,7 @@ async def _search_pg(
     sql = sql + " ORDER BY date_start ASC LIMIT $" + str(len(params))
 
     try:
-        with tracer.start_as_current_span("event.search.postgres") as span:
+        async with traced_call("event.search.postgres") as span:
             span.set_attribute("event.pg.filter_district", district or "")
             span.set_attribute("event.pg.filter_category", category or "")
             span.set_attribute("event.pg.filter_keyword_count", len(keywords))
@@ -350,7 +346,7 @@ async def _search_naver(
     }
 
     try:
-        with tracer.start_as_current_span("event.search.naver_fallback") as span:
+        async with traced_call("event.search.naver_fallback") as span:
             span.set_attribute("event.naver.display", _NAVER_DISPLAY)
             span.set_attribute("event.naver.query_length", len(query))
             data = await request_json("GET", _NAVER_BLOG_URL, headers=headers, params=params, timeout=_NAVER_TIMEOUT)
@@ -426,7 +422,7 @@ async def _merge_candidates(
 
     if os_ids:
         try:
-            with tracer.start_as_current_span("event.search.merge.pg_enrich") as span:
+            async with traced_call("event.search.merge.pg_enrich") as span:
                 span.set_attribute("event.merge.os_ids_count", len(os_ids))
                 rows = await pool.fetch(
                     "SELECT event_id, title, category, place_name, address, district, "
@@ -502,7 +498,7 @@ async def _llm_rerank(
     user_prompt = f"사용자 조건: {query}\n키워드: {', '.join(keywords)}\n\n후보 행사:\n" + "\n".join(candidate_lines)
 
     try:
-        with tracer.start_as_current_span("event.search.llm_rerank") as span:
+        async with traced_call("event.search.llm_rerank") as span:
             span.set_attribute("event.llm.model", "gemini-2.5-flash")
             span.set_attribute("event.llm.candidates", len(candidates))
             llm = ChatGoogleGenerativeAI(
@@ -770,6 +766,7 @@ async def _handle_refinement(
     return {"response_blocks": blocks}
 
 
+@traced_node("event_search")
 async def event_search_node(state: dict[str, Any]) -> dict[str, Any]:
     """EVENT_SEARCH 노드 — PG 정형 + OS k-NN + LLM Rerank 행사 검색 (Phase 1).
 

--- a/backend/src/graph/general_node.py
+++ b/backend/src/graph/general_node.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 # 시스템 프롬프트 — GENERAL intent 전용
@@ -26,6 +28,7 @@ _SYSTEM_PROMPT = (
 )
 
 
+@traced_node("general")
 async def general_node(state: dict[str, Any]) -> dict[str, Any]:
     """GENERAL intent 노드 — text_stream 블록 생성.
 

--- a/backend/src/graph/image_search_node.py
+++ b/backend/src/graph/image_search_node.py
@@ -32,6 +32,8 @@ import logging
 import re
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 _URL_RE = re.compile(r"https?://\S+")
 # "여기 어딘지" 류 — 특정 장소 식별 의도
 _IDENTIFY_RE = re.compile(
@@ -985,6 +987,7 @@ async def _handle_candidates(
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+@traced_node("image_search")
 async def image_search_node(state: dict[str, Any]) -> dict[str, Any]:
     """IMAGE_SEARCH 노드 — 이미지 URL에서 장소 식별.
 

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -10,6 +10,8 @@ import logging
 from enum import StrEnum  # pyright: ignore[reportAttributeAccessIssue]
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 
@@ -348,6 +350,7 @@ async def classify_intent(
         return (_GENERAL_FALLBACK, 0.0)
 
 
+@traced_node("intent_router")
 async def intent_router_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 노드 함수 — intent 분류 결과를 state에 기록.
 

--- a/backend/src/graph/place_recommend_node.py
+++ b/backend/src/graph/place_recommend_node.py
@@ -23,6 +23,8 @@ import asyncio
 import logging
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _RECOMMEND_SYSTEM_PROMPT = (
@@ -647,6 +649,7 @@ async def _handle_refinement(
     return {"response_blocks": blocks}
 
 
+@traced_node("place_recommend")
 async def place_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     """PLACE_RECOMMEND 노드 — PG + OS 2채널 + LLM Rerank (Phase 1).
 

--- a/backend/src/graph/place_search_node.py
+++ b/backend/src/graph/place_search_node.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _PLACE_SEARCH_SYSTEM_PROMPT = (
@@ -465,6 +467,7 @@ async def _handle_refinement(
     return {"response_blocks": blocks}
 
 
+@traced_node("place_search")
 async def place_search_node(state: dict[str, Any]) -> dict[str, Any]:
     """PLACE_SEARCH 노드 — PG + OS 하이브리드 검색.
 

--- a/backend/src/graph/query_preprocessor_node.py
+++ b/backend/src/graph/query_preprocessor_node.py
@@ -15,6 +15,8 @@ import re
 from datetime import date
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 # ISO date "YYYY-MM-DD" 형식 검증 정규식 (Gemini 응답 후처리)
@@ -241,6 +243,7 @@ async def _load_history_from_db(thread_id: str) -> list[dict[str, str]]:
     return history
 
 
+@traced_node("query_preprocessor")
 async def query_preprocessor_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 공통 쿼리 전처리 노드 (불변식 #12).
 

--- a/backend/src/graph/refine_node.py
+++ b/backend/src/graph/refine_node.py
@@ -25,6 +25,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 
@@ -397,6 +399,7 @@ def _no_previous_response_blocks() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 # LangGraph 노드
 # ---------------------------------------------------------------------------
+@traced_node("refine")
 async def refine_node(state: dict[str, Any]) -> dict[str, Any]:
     """REFINE 노드 — 수정 요청 파싱 + 원본 노드 재호출.
 

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -81,6 +83,7 @@ def _validate_block_order(
 # ---------------------------------------------------------------------------
 # 노드 함수
 # ---------------------------------------------------------------------------
+@traced_node("response_builder")
 async def response_builder_node(state: dict[str, Any]) -> dict[str, Any]:
     """response_blocks에 done 블록 추가 + 블록 순서 검증.
 

--- a/backend/src/graph/review_compare_node.py
+++ b/backend/src/graph/review_compare_node.py
@@ -13,6 +13,8 @@ import logging
 import re
 from typing import Any
 
+from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+
 logger = logging.getLogger(__name__)
 
 _COMPARE_SYSTEM_PROMPT = """\
@@ -171,6 +173,7 @@ async def _handle_refinement(
     return await review_compare_node(state)
 
 
+@traced_node("review_compare")
 async def review_compare_node(state: dict[str, Any]) -> dict[str, Any]:
     """LangGraph 노드 — REVIEW_COMPARE intent 처리 (Phase 1)."""
     previous_blocks = state.get("previous_blocks")

--- a/backend/src/observability/__init__.py
+++ b/backend/src/observability/__init__.py
@@ -1,0 +1,6 @@
+"""Observability 패키지 — tracing/logging/metrics 공통 헬퍼.
+
+Phase 1: tracing 컨텍스트(`context.py`).
+Phase 2: 구조화 로깅(`logging.py`) — 미작성.
+Phase 3: Prometheus 메트릭(`metrics.py`) + LangChain LLM callback(`llm_callback.py`) — 미작성.
+"""

--- a/backend/src/observability/context.py
+++ b/backend/src/observability/context.py
@@ -1,0 +1,17 @@
+"""Request-scoped ContextVar — 노드·외부 호출·로그가 동일 trace_id 외 식별자(request_id/user_id/thread_id)를 공유하기 위한 컨텍스트.
+
+SSE 핸들러 진입 시 set, 종료 시 reset. asyncio TaskGroup·anyio TaskGroup에서 자동 inherit.
+
+Phase 1에서는 정의만 두고 SSE 핸들러 주입은 Phase 2(로깅 PR)에서 동시에 들어간다 —
+Phase 2의 `TraceContextFilter`가 이 ContextVar를 읽어 로그 레코드에 주입.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Optional
+
+# 모듈 import 시점에 기본값 None으로 초기화. 진입부에서 set, 종료에서 reset 권장.
+request_id_var: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+user_id_var: ContextVar[Optional[int]] = ContextVar("user_id", default=None)
+thread_id_var: ContextVar[Optional[str]] = ContextVar("thread_id", default=None)

--- a/backend/tests/test_graph_tracing.py
+++ b/backend/tests/test_graph_tracing.py
@@ -75,6 +75,22 @@ class TestTracedNode:
         assert attrs.get("user_id") == "7"
         assert attrs.get("response_blocks.added") == 2
 
+    async def test_attaches_response_blocks_when_dict_returned(self) -> None:
+        """노드가 dict(`{"response_blocks": [...]}`)를 반환해도 length 부착.
+
+        실제 analysis/calendar/cost_estimate/booking 등 대부분 노드의 반환 형태 회귀.
+        """
+        exporter = _fresh_exporter()
+
+        @traced_node("analysis_like")
+        async def fn(state: dict[str, Any]) -> dict[str, Any]:
+            return {"response_blocks": [{"type": "text_stream"}, {"type": "analysis_sources"}, {"type": "done"}]}
+
+        await fn({"intent": "ANALYSIS"})
+        spans = exporter.get_finished_spans()
+        attrs = spans[0].attributes or {}
+        assert attrs.get("response_blocks.added") == 3
+
     async def test_missing_state_keys_silent(self) -> None:
         """state dict에 키가 없거나 빈 값이면 attribute 생략 — KeyError·NoneError 금지."""
         exporter = _fresh_exporter()

--- a/backend/tests/test_graph_tracing.py
+++ b/backend/tests/test_graph_tracing.py
@@ -1,0 +1,144 @@
+"""Tests for `src.graph._tracing` — `traced_node` 데코레이터 + `traced_call` 컨텍스트.
+
+InMemorySpanExporter로 span 생성·attribute·status를 직접 검증.
+
+NOTE: fixture 패턴(autouse/module-scope)을 사용하면 pytest-asyncio 0.x의
+hookwrapper teardown에서 `OSError: could not get source code`가 발생하는 케이스가 있다
+— 그래서 모듈-레벨 export·테스트당 `_clear()` 호출의 단순 패턴을 사용한다.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+from opentelemetry import trace  # pyright: ignore[reportMissingImports]
+from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # pyright: ignore[reportMissingImports]
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # pyright: ignore[reportMissingImports]
+    InMemorySpanExporter,
+)
+
+from src.graph._tracing import traced_call, traced_node
+
+# 모듈-import 시점에 TracerProvider + InMemorySpanExporter 1회 세팅.
+# `set_tracer_provider`는 첫 호출만 적용되므로, 이미 세팅된 경우 우리 exporter를 추가만 한다.
+_exporter = InMemorySpanExporter()
+_current_provider = trace.get_tracer_provider()
+if isinstance(_current_provider, TracerProvider):
+    _current_provider.add_span_processor(SimpleSpanProcessor(_exporter))
+else:
+    _provider = TracerProvider()
+    _provider.add_span_processor(SimpleSpanProcessor(_exporter))
+    trace.set_tracer_provider(_provider)
+
+
+def _fresh_exporter() -> InMemorySpanExporter:
+    """누적된 span을 비우고 exporter를 반환."""
+    _exporter.clear()
+    return _exporter
+
+
+# ---------------------------------------------------------------------------
+# traced_node
+# ---------------------------------------------------------------------------
+class TestTracedNode:
+    async def test_passes_through_when_state_not_dict(self) -> None:
+        """state가 dict가 아니어도 노드는 정상 통과·span은 생성."""
+        exporter = _fresh_exporter()
+
+        @traced_node("noop")
+        async def fn(state: Any) -> list[dict[str, str]]:
+            return [{"type": "text"}]
+
+        result = await fn("not-a-dict")
+        assert result == [{"type": "text"}]
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "node.noop"
+
+    async def test_attaches_state_attributes(self) -> None:
+        """state에서 intent/thread_id/user_id + response_blocks.added 부착."""
+        exporter = _fresh_exporter()
+
+        @traced_node("place_search")
+        async def fn(state: dict[str, Any]) -> list[dict[str, Any]]:
+            return [{"type": "places"}, {"type": "map_markers"}]
+
+        await fn({"intent": "PLACE_SEARCH", "thread_id": "t-1", "user_id": 7})
+
+        spans = exporter.get_finished_spans()
+        assert spans[0].name == "node.place_search"
+        attrs = spans[0].attributes or {}
+        assert attrs.get("intent") == "PLACE_SEARCH"
+        assert attrs.get("thread_id") == "t-1"
+        assert attrs.get("user_id") == "7"
+        assert attrs.get("response_blocks.added") == 2
+
+    async def test_missing_state_keys_silent(self) -> None:
+        """state dict에 키가 없거나 빈 값이면 attribute 생략 — KeyError·NoneError 금지."""
+        exporter = _fresh_exporter()
+
+        @traced_node("general")
+        async def fn(state: dict[str, Any]) -> None:
+            return None
+
+        await fn({"intent": ""})  # 빈 intent는 부착하지 않음
+        spans = exporter.get_finished_spans()
+        attrs = spans[0].attributes or {}
+        assert "intent" not in attrs
+        assert "thread_id" not in attrs
+        assert "user_id" not in attrs
+
+    async def test_exception_sets_error_status(self) -> None:
+        """노드 예외 → status=ERROR + exception event 기록 + 예외 재발생."""
+        exporter = _fresh_exporter()
+
+        @traced_node("boom")
+        async def fn(state: dict[str, Any]) -> None:
+            raise RuntimeError("kaboom")
+
+        with pytest.raises(RuntimeError, match="kaboom"):
+            await fn({"intent": "X"})
+
+        spans = exporter.get_finished_spans()
+        assert spans[0].status.status_code.name == "ERROR"
+        assert any(ev.name == "exception" for ev in spans[0].events)
+
+
+# ---------------------------------------------------------------------------
+# traced_call
+# ---------------------------------------------------------------------------
+class TestTracedCall:
+    async def test_basic_attributes(self) -> None:
+        exporter = _fresh_exporter()
+        async with traced_call("os.places_vector.knn", index="places_vector", op="knn") as span:
+            assert span is not None
+
+        spans = exporter.get_finished_spans()
+        assert spans[0].name == "os.places_vector.knn"
+        attrs = spans[0].attributes or {}
+        assert attrs.get("index") == "places_vector"
+        assert attrs.get("op") == "knn"
+
+    async def test_none_attrs_skipped(self) -> None:
+        """attribute 값이 None이면 부착 skip — 호출부에서 미상 값 그대로 넘겨도 안전."""
+        exporter = _fresh_exporter()
+        none_attr: Optional[str] = None
+        async with traced_call("pg.places.search", op="search", note=none_attr):
+            pass
+        spans = exporter.get_finished_spans()
+        attrs = spans[0].attributes or {}
+        assert attrs.get("op") == "search"
+        assert "note" not in attrs
+
+    async def test_exception_recorded(self) -> None:
+        exporter = _fresh_exporter()
+        with pytest.raises(ValueError, match="bad"):
+            async with traced_call("gemini.classify"):
+                raise ValueError("bad")
+
+        spans = exporter.get_finished_spans()
+        assert spans[0].name == "gemini.classify"
+        assert spans[0].status.status_code.name == "ERROR"
+        assert any(ev.name == "exception" for ev in spans[0].events)

--- a/docs/2026-06-01-observability-overhaul-plan.md
+++ b/docs/2026-06-01-observability-overhaul-plan.md
@@ -22,7 +22,7 @@ LocalBiz 백엔드는 Jaeger·Prometheus·Loki 인프라가 모두 떠 있고 de
 ### Goals
 - 모든 LangGraph 노드(18개)에 진입 span. 무거운 노드는 외부 호출(LLM/asyncpg/OS/Naver/OSRM/Google) sub-span까지.
 - 로그를 JSON 구조화 + `trace_id`/`span_id`/`thread_id`/`user_id`/`request_id` 자동 주입 → Grafana Loki 패널에서 한 클릭으로 Jaeger trace 점프.
-- 비즈니스 메트릭 8종 추가: intent 카운트, 노드 latency 히스토그램, LLM 호출 latency + 토큰 카운트, asyncpg 풀 게이지, OS 쿼리 latency, Naver fallback 카운터, OS k-NN empty 카운터, SSE 활성 세션 게이지.
+- 비즈니스 메트릭 9종 추가(§3.3 표 기준): intent 카운트, 노드 latency 히스토그램, LLM 호출 횟수·latency·토큰 카운트(3종), asyncpg 풀 게이지, OS 쿼리 latency, fallback 카운터, SSE 활성 세션 게이지.
 - Grafana 대시보드 1개 추가: "LangGraph Overview" (노드별 latency p50/p95/p99, intent 분포, LLM 토큰 사용량, fallback rate).
 
 ### Non-Goals (별건 처리)

--- a/docs/2026-06-01-observability-overhaul-plan.md
+++ b/docs/2026-06-01-observability-overhaul-plan.md
@@ -1,0 +1,269 @@
+# Observability Overhaul — Tracing + Logging + Metrics 통합 plan
+
+**Date:** 2026-06-01
+**Owner:** 이정 (BE/PM)
+**Status:** DRAFT (대기 → APPROVED 시 구현 착수)
+**Related:** `~/.claude/plans/polymorphic-wishing-peach.md`(노드 트레이싱 plan, 본 plan에 흡수), 메모 `project_monitoring_tracing.md`
+
+---
+
+## 1. Context
+
+LocalBiz 백엔드는 Jaeger·Prometheus·Loki 인프라가 모두 떠 있고 dev에 배포까지 완료됐지만(PR #173/#174), **앱 측 계측이 절반만 들어가 있어 운영 가시성이 깨져 있다.** 현 상태:
+
+- **Tracing**: `FastAPIInstrumentor`로 HTTP 진입 span은 자동 발급. 그래프 18개 노드 중 `event_search_node` 1개만 수동 sub-span 6개. 나머지 17개 노드는 Jaeger에 ASGI span만 보이고 어디서 시간이 새는지 모름.
+- **Metrics**: `prometheus_fastapi_instrumentator`로 HTTP RPS/latency/status는 자동. **커스텀 메트릭 0건** — intent 분포, 노드 latency, LLM 호출/토큰, asyncpg 풀, OpenSearch 쿼리, fallback 카운터, SSE 세션 모두 없음.
+- **Logging**: `logging.basicConfig(INFO, "%(levelname)s %(name)s: %(message)s")` 평문. Loki까지 적재는 되지만 `trace_id`/`thread_id`/`user_id`/`request_id` 미주입 → Loki ↔ Jaeger 점프 불가능, 사용자 단위 디버깅 불가.
+
+목표는 *프로덕션 사고가 났을 때 Grafana 한 화면에서 "어느 intent의 어느 노드에서 어느 외부 호출이 느려졌고 그 사용자가 누구인지"까지 추적 가능* 한 수준.
+
+## 2. Goals / Non-Goals
+
+### Goals
+- 모든 LangGraph 노드(18개)에 진입 span. 무거운 노드는 외부 호출(LLM/asyncpg/OS/Naver/OSRM/Google) sub-span까지.
+- 로그를 JSON 구조화 + `trace_id`/`span_id`/`thread_id`/`user_id`/`request_id` 자동 주입 → Grafana Loki 패널에서 한 클릭으로 Jaeger trace 점프.
+- 비즈니스 메트릭 8종 추가: intent 카운트, 노드 latency 히스토그램, LLM 호출 latency + 토큰 카운트, asyncpg 풀 게이지, OS 쿼리 latency, Naver fallback 카운터, OS k-NN empty 카운터, SSE 활성 세션 게이지.
+- Grafana 대시보드 1개 추가: "LangGraph Overview" (노드별 latency p50/p95/p99, intent 분포, LLM 토큰 사용량, fallback rate).
+
+### Non-Goals (별건 처리)
+- `allow-fastapi` 방화벽 VPC 내부 제한 — 별도 보안 PR.
+- 알람·SLO 룰 — Phase 4에서 별도 plan.
+- 비용 예산 알람(Gemini 토큰 비용) — 메트릭 적재까지만, 알람은 후속.
+- Phase 6 KAIROS 통합 — 본 plan 범위 외.
+
+## 3. Architecture
+
+### 3.1 Tracing 계층
+
+```
+SSE handler (auto span "POST /sse")
+  └─ intent_router  ┬─ traced_node("intent.classify")
+                    └─ LLM span ("gemini.classify")
+  └─ query_preprocessor
+                    ├─ traced_node("query.preprocess")
+                    └─ LLM span ("gemini.json_parse")
+  └─ {각 intent 노드}
+                    ├─ traced_node("place_recommend") 등
+                    ├─ DB span ("pg.places.search")
+                    ├─ OS span ("os.places_vector.knn")
+                    ├─ LLM span ("gemini.rerank")
+                    └─ external span ("naver.fallback")
+  └─ response_builder traced_node("response.build")
+```
+
+신규 모듈 `src/graph/_tracing.py`:
+
+```python
+# 골자
+from functools import wraps
+from opentelemetry import trace
+
+_tracer = trace.get_tracer("localbiz.graph")
+
+def traced_node(name: str):
+    def deco(fn):
+        @wraps(fn)
+        async def wrapper(state, *args, **kwargs):
+            with _tracer.start_as_current_span(f"node.{name}") as span:
+                span.set_attribute("intent", state.get("intent", "unknown"))
+                span.set_attribute("thread_id", state.get("thread_id", ""))
+                span.set_attribute("user_id", state.get("user_id", 0))
+                try:
+                    result = await fn(state, *args, **kwargs)
+                    span.set_attribute("response_blocks.added", len(result) if isinstance(result, list) else 0)
+                    return result
+                except Exception as exc:
+                    span.record_exception(exc)
+                    span.set_status(trace.StatusCode.ERROR, str(exc))
+                    raise
+        return wrapper
+    return deco
+```
+
+- `JAEGER_HOST` 미설정 시에도 OTel SDK가 NoOp tracer 반환 → 로컬·테스트 영향 0.
+- 외부 호출 span 헬퍼는 같은 모듈에 `traced_call(name, **attrs)` 컨텍스트 매니저로 제공해 `event_search_node` 기존 패턴과 통합.
+
+### 3.2 Logging 계층
+
+신규 모듈 `src/observability/logging.py`:
+
+```python
+# 골자 — python-json-logger 의존성 추가
+from pythonjsonlogger import jsonlogger
+from opentelemetry import trace
+
+class TraceContextFilter(logging.Filter):
+    def filter(self, record):
+        ctx = trace.get_current_span().get_span_context()
+        record.trace_id = format(ctx.trace_id, "032x") if ctx.is_valid else None
+        record.span_id = format(ctx.span_id, "016x") if ctx.is_valid else None
+        # FastAPI ContextVar에서 request_id/user_id/thread_id 주입
+        return True
+
+def configure_logging():
+    handler = logging.StreamHandler()
+    handler.setFormatter(jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s",
+        rename_fields={"asctime": "ts", "levelname": "level", "name": "logger"},
+    ))
+    handler.addFilter(TraceContextFilter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+    # 소음 모듈 quiet-down
+    for noisy in ("httpx", "httpcore", "asyncpg", "opentelemetry.exporter"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+```
+
+- `main.py`의 `logging.basicConfig` 호출은 `configure_logging()`으로 교체.
+- ContextVar 기반 request-scoped 컨텍스트(`request_id`, `user_id`, `thread_id`)는 SSE 핸들러 진입에서 `set` → 자식 태스크/노드에서 자동 inherit (anyio TaskGroup 호환).
+- promtail은 이미 stdout 수집 중 — 포맷만 JSON으로 바뀌면 Loki LogQL에서 `{app="localbiz-api"} | json | trace_id="..."` 가능.
+
+### 3.3 Metrics 계층
+
+신규 모듈 `src/observability/metrics.py` (Prometheus client 직접 사용):
+
+| 메트릭 | 타입 | 라벨 | 측정 위치 |
+|---|---|---|---|
+| `langgraph_intent_total` | Counter | `intent` | intent_router 종료 |
+| `langgraph_node_latency_seconds` | Histogram | `node`, `intent`, `status` | `traced_node` 데코레이터 내부 (span end 시점) |
+| `langgraph_llm_calls_total` | Counter | `model`, `purpose`, `status` | 공통 LLM 래퍼 (`utils/llm_parsing.py`에 카운터 hook) |
+| `langgraph_llm_tokens_total` | Counter | `model`, `purpose`, `direction` | 동상, `response.usage_metadata`에서 추출 |
+| `langgraph_llm_latency_seconds` | Histogram | `model`, `purpose` | 동상 |
+| `langgraph_os_query_latency_seconds` | Histogram | `index`, `op` | `db/opensearch.py` 진입/종료 |
+| `langgraph_fallback_total` | Counter | `path` (e.g., `event.naver`, `places.os_empty`) | 각 fallback 분기 |
+| `langgraph_sse_sessions` | Gauge | — | SSE handler enter/exit |
+| `langgraph_pg_pool_in_use` | Gauge | — | 주기적 task로 `pool.get_size() - pool.get_idle_size()` |
+
+- 기존 `prometheus_fastapi_instrumentator` 노출(`/metrics`)에 자동 합류. 별도 endpoint 분리 안 함.
+
+## 4. Components & Files
+
+| 파일 | 변경 유형 | 비고 |
+|---|---|---|
+| `backend/src/observability/__init__.py` | NEW | 패키지 진입 |
+| `backend/src/observability/logging.py` | NEW | JSON 포맷 + trace 컨텍스트 필터 |
+| `backend/src/observability/metrics.py` | NEW | Prometheus client metrics 정의·헬퍼 |
+| `backend/src/observability/context.py` | NEW | ContextVar (`request_id`, `user_id`, `thread_id`) |
+| `backend/src/graph/_tracing.py` | NEW | `traced_node` 데코레이터 + `traced_call` 컨텍스트 |
+| `backend/src/telemetry.py` | EDIT | `setup_tracing`은 유지. `configure_logging` 호출은 `main.py`로 이동. |
+| `backend/src/main.py` | EDIT | `basicConfig` → `configure_logging()`. metrics 초기화 추가. SSE 라우터 미들웨어에서 ContextVar 세팅. |
+| `backend/src/api/sse.py` | EDIT | request 진입 시 `request_id` 생성, `thread_id`·`user_id` 컨텍스트 주입, `langgraph_sse_sessions` enter/exit |
+| `backend/src/graph/*_node.py` (17개) | EDIT | `@traced_node("name")` 데코레이터 부착. 무거운 노드(course_plan/place_search/place_recommend/analysis/booking/calendar/cost_estimate/review_compare)는 외부 호출 sub-span 추가 |
+| `backend/src/graph/event_search_node.py` | EDIT | 기존 span 호출을 `traced_call` 헬퍼로 리팩토링 (의미·계층 동일, DRY 통일) |
+| `backend/src/utils/llm_parsing.py` | EDIT | Gemini 호출 래퍼에서 metrics counter/histogram·sub-span 발급 |
+| `backend/src/db/postgres.py` | EDIT | pool 게이지 백그라운드 갱신 task (lifespan) |
+| `backend/src/db/opensearch.py` | EDIT | 쿼리 헬퍼에 metrics + span |
+| `backend/requirements.txt` | EDIT | `python-json-logger==2.0.7` 추가 (필요 시) |
+| `backend/monitoring/grafana/dashboards/langgraph-overview.json` | NEW | 노드 latency p50/p95/p99, intent 분포, LLM 토큰, fallback rate 패널 |
+| `backend/monitoring/grafana/provisioning/dashboards/*.yaml` | EDIT | 위 대시보드 등록 |
+| `backend/tests/test_observability_logging.py` | NEW | JSON 포맷 + trace_id 주입 검증 |
+| `backend/tests/test_observability_metrics.py` | NEW | counter/histogram 라벨 회귀 |
+| `backend/tests/test_graph_tracing.py` | NEW | `traced_node` no-op·span 발급·에러 status 검증 |
+
+## 5. Phased Rollout (3 PRs)
+
+각 페이즈는 별도 PR. 검증·롤백 독립.
+
+### Phase 1 — Tracing 전 노드 확장 (`feat/observability-tracing`)
+1. `src/graph/_tracing.py` + 테스트.
+2. 17개 노드에 `@traced_node` 부착.
+3. 무거운 노드(8개)에 외부 호출 `traced_call` sub-span 추가.
+4. `event_search_node` 기존 span을 `traced_call`로 리팩토링.
+5. **Verify**: `JAEGER_HOST` 세팅한 staging에서 각 intent 호출 → Jaeger에 `node.*` span 트리 + 외부 호출 sub-span 보이는지 확인. `validate.sh` 통과.
+
+### Phase 2 — 구조화 로깅 + 트레이스 상관 (`feat/observability-logging`)
+1. `python-json-logger` 의존성 추가, `requirements.txt`·`validate.sh` 통과.
+2. `src/observability/{__init__,logging,context}.py` 작성·테스트.
+3. `main.py`에서 `configure_logging()` 적용, `sse.py`에서 ContextVar 세팅.
+4. **Verify**: 로컬 backend → `curl /sse?... | head`. stdout이 JSON 1줄당 1로그, `trace_id`/`thread_id` 필드 존재. dev 배포 후 Loki에서 `{app="localbiz-api"} | json | trace_id != ""` 매칭. Grafana 로그 패널에서 Jaeger 점프 링크(`derived field`) 동작.
+
+### Phase 3 — 비즈니스 메트릭 + Grafana 대시보드 (`feat/observability-metrics`)
+1. `src/observability/metrics.py` 작성·테스트.
+2. `_tracing.py`의 데코레이터 안에 latency 히스토그램 hook.
+3. `llm_parsing.py`/`opensearch.py`/`postgres.py`/`sse.py`에 메트릭 hook.
+4. fallback 분기 카운터 부착(event Naver, places OS empty 등 — 코드 grep 후 확정).
+5. Grafana 대시보드 JSON·provisioning 추가.
+6. **Verify**: `/metrics` curl → `langgraph_*` 메트릭 노출. Prometheus Status→Targets UP. Grafana "LangGraph Overview" 대시보드 패널 데이터 흐름. 5분 부하 후 p95 latency 그래프 채워짐.
+
+## 6. Data Flow (한 요청 기준)
+
+```
+브라우저 EventSource POST /sse
+  ↓
+sse.py 진입:
+  - ContextVar 세팅: request_id(uuid4), user_id(jwt), thread_id(body)
+  - SSE 세션 게이지 +1
+  ↓
+intent_router_node:
+  - @traced_node("intent.classify") span 시작 (trace_id 발급 → log 자동 포함)
+  - LLM 래퍼: traced_call("gemini.classify") + llm_calls_total/+tokens_total/+latency
+  - intent_total{intent="PLACE_RECOMMEND"} +1
+  ↓
+query_preprocessor_node: 동일 패턴
+  ↓
+place_recommend_node:
+  - @traced_node("place_recommend") + node_latency_seconds histogram
+  - traced_call("os.places_vector.knn") + os_query_latency_seconds
+  - traced_call("gemini.rerank") + llm_*
+  - 결과 없으면 fallback_total{path="places.os_empty"} +1
+  ↓
+response_builder_node: traced_node + 마지막 SSE write
+  ↓
+sse.py 종료: 세션 게이지 -1, request_id 컨텍스트 해제
+```
+
+로그 한 줄 예시:
+```json
+{"ts":"2026-06-01T12:00:00Z","level":"INFO","logger":"src.graph.place_recommend_node","message":"OS knn hit","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","request_id":"...","thread_id":"42","user_id":7,"hits":12}
+```
+
+## 7. Error Handling
+
+- `traced_node` 내부 예외는 `span.record_exception` + `StatusCode.ERROR` → 로그에 stacktrace 자동(JSON formatter `exc_info`) → 메트릭은 `status="error"` 라벨로 카운트.
+- OTel/JSON 로거 초기화 실패는 기존 `telemetry.py` 패턴대로 ImportError·RuntimeError 분리 warning, **앱 기동은 계속.** 관측 인프라 부재가 서비스 장애로 이어지지 않아야 함.
+- ContextVar는 진입 시 `set` 후 finally에서 `reset` — async-leak 회피.
+
+## 8. Testing
+
+| 테스트 | 위치 | 핵심 케이스 |
+|---|---|---|
+| `test_observability_logging.py` | tests/ | JSON 1줄 1레코드, `trace_id` 주입, 없을 때 `null`, `exc_info` 직렬화 |
+| `test_observability_metrics.py` | tests/ | counter inc, histogram observe, label cardinality 회귀 |
+| `test_graph_tracing.py` | tests/ | `traced_node` no-op(tracer 미설정), span attribute 세팅, 예외 시 status=ERROR |
+| `test_sse_context.py` | tests/ | SSE 진입 시 ContextVar 세팅·해제, async task 간 inherit |
+| `validate.sh` | 루트 | ruff/format/pyright/pytest/기획·plan 무결성 |
+| 수동(staging) | — | Jaeger 트리 / Loki json 매칭 / Grafana 대시보드 패널 |
+
+## 9. Risks & Rollback
+
+| 리스크 | 완화 |
+|---|---|
+| JSON 로그가 로컬 가독성 저해 | `LOG_FORMAT=plain` env로 fallback 옵션 제공 (개발용) |
+| 메트릭 라벨 카디널리티 폭증 | 라벨에 `user_id`/`thread_id` **포함 금지** (오직 trace/log에). intent enum 13종, node 18종, model 2~3종으로 상한 고정 |
+| 데코레이터 부착으로 노드 시그니처 변경 | `@wraps` + `async def` 유지 — LangGraph는 함수 객체만 보므로 호환 |
+| OTel SDK 버전 충돌 | requirements.txt 현재 핀과 비교 후 별도 commit으로 분리 |
+| 롤백 | 각 PR이 독립 → 문제 PR만 revert. metrics만 끄려면 `/metrics` 라우트 차단으로 즉시 격리 가능. |
+
+## 10. Verification (PR 머지 전 공통)
+
+- [ ] `./validate.sh` 통과
+- [ ] 신규 모듈 단위 테스트 추가 (logging/metrics/tracing)
+- [ ] dev 배포 후 Jaeger에 `node.*` span 트리 확인 (Phase 1)
+- [ ] Loki LogQL `{app="localbiz-api"} | json | trace_id != ""` 매칭 (Phase 2)
+- [ ] Prometheus targets UP + `langgraph_*` 메트릭 노출 + 대시보드 패널 (Phase 3)
+- [ ] 19 데이터 모델 불변식 무관 (관측성은 데이터 모델 변경 없음)
+
+## 11. Open Questions / Follow-ups
+
+- LLM 토큰 카운트 추출 경로: `google.genai` 응답의 `usage_metadata` 정확한 키 확인 필요(Phase 3 착수 시 1회 spike).
+- promtail이 stdout만 보는데, multiprocess uvicorn 워커일 때 JSON 1라인 보장되는지 — Phase 2 staging에서 검증.
+- Grafana 대시보드는 JSON으로 git에 두는 게 맞는지, provisioning 디렉터리 권한 — `backend/monitoring/` 기존 패턴 따라감.
+
+---
+
+## APPROVED
+
+APPROVED — 2026-06-01 이정
+
+**정정사항 반영:** 본 plan의 일부 가정(특히 §3.3 `utils/llm_parsing.py` LLM 후크 위치)은 코드 실측에서 오류로 확인됨. 정정·실행 순서는 `~/.claude/plans/polymorphic-questing-biscuit.md`(execution plan) 참조. 충돌 시 execution plan 우선.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #202

## #️⃣ 작업 내용

> Observability Overhaul Phase 1 — 전 LangGraph 노드(18개)에 OpenTelemetry tracing 확장.

- **신규 `backend/src/graph/_tracing.py`** — `traced_node` 데코레이터 + `traced_call` async 컨텍스트 매니저
  - JAEGER_HOST 미설정 환경에서도 NoOp tracer로 동작 (로컬·테스트 영향 0)
  - state에서 intent/thread_id/user_id 추출해 span attribute 부착
  - response_blocks 길이를 `response_blocks.added` 속성으로 기록
  - 예외 시 `record_exception` + status=ERROR

- **신규 `backend/src/observability/` 패키지** — `context.py`에 ContextVar(`request_id`/`user_id`/`thread_id`) 정의 (Phase 2 로깅에서 사용 예정)

- **17개 노드에 `@traced_node` 부착**: analysis, booking, calendar, cost_estimate, course_plan, crowdedness, detail_inquiry, event_recommend, general, image_search, intent_router, place_recommend, place_search, query_preprocessor, refine, response_builder, review_compare

- **`event_search_node` 리팩토링**: 기존 6개 수동 `tracer.start_as_current_span(...)` → `async with traced_call(...)` 통일 (의미 동일, DRY) + `@traced_node("event_search")` 부착

- **`booking_node.py:100` google-genai 호출**: `traced_call("gemini.booking_grounding")` 부착 (Phase 3에서 토큰 metric 추가 예정)

- **단위 테스트 `tests/test_graph_tracing.py`** — InMemorySpanExporter 기반 7개 케이스 (no-op·attribute·error status·None attr skip 등)

- **`docs/2026-06-01-observability-overhaul-plan.md`** — 아키텍처 계층 설계 (APPROVED). 실행 정정사항은 `~/.claude/plans/polymorphic-questing-biscuit.md`.

## #️⃣ 테스트 결과

> 로컬:
- `ruff check .` — All checks passed
- `ruff format --check .` — 118 files already formatted
- `pyright src/graph src/observability` — 0 errors (1 pre-existing warning)
- `python -m pytest tests/test_graph_tracing.py tests/test_event_search.py tests/test_event_recommend.py tests/test_metrics_endpoint.py` — 47 passed (1 ERROR는 pytest-asyncio 0.24.0 + conftest event_loop 호환성 문제로 dev 전반에서 동일 — test_calendar_node.py도 동일 패턴)
- `from src.graph.real_builder import build_graph; build_graph()` — 19 nodes 정상 구성 확인

> 통합 (dev 배포 후 별도 확인 예정):
- Jaeger UI에서 각 intent 호출 → `node.*` span 트리 + `event.search.*` sub-span 표시 확인
- staging trace 1개 캡처 후 본 PR 코멘트에 첨부

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우) — `docs/2026-06-01-observability-overhaul-plan.md`
- [x] 코드 컨벤션에 따라 코드를 작성했나요? (불변식 #9 Optional 문법, 19 데이터 모델 무관)
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요? (opentelemetry-sdk 1.28.1 기존 핀 사용)

## 📎 참고 자료

- 아키텍처 설계: `docs/2026-06-01-observability-overhaul-plan.md`
- 실행 정정사항: `~/.claude/plans/polymorphic-questing-biscuit.md`
- 후속 PR: Phase 2 (구조화 로깅), Phase 3 (비즈니스 메트릭 + Grafana 대시보드)
- 선행: #173 (모니터링 인프라), #174 (CD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive observability infrastructure including distributed tracing and span tracking across all graph processing nodes.
  * Implemented request-scoped context tracking for correlation of requests, users, and sessions across system operations.

* **Tests**
  * Added test suite for tracing functionality and span behavior validation.

* **Documentation**
  * Added observability roadmap documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->