### PR TITLE
[Feat] Observability Phase 3 — metrics + LLM callback + Grafana (#206)

### DIFF
--- a/backend/monitoring/grafana/dashboards/langgraph-overview.json
+++ b/backend/monitoring/grafana/dashboards/langgraph-overview.json
@@ -1,0 +1,132 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "datasource", "uid": "grafana"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "LocalBiz LangGraph 노드/LLM/Fallback/SSE 비즈니스 메트릭 — Phase 3",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "노드 latency p50/p95/p99 (5m)",
+      "type": "timeseries",
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (node, le) (rate(langgraph_node_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{node}} p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (node, le) (rate(langgraph_node_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{node}} p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (node, le) (rate(langgraph_node_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{node}} p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "Intent 분포 (5m rate)",
+      "type": "piechart",
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"legend": {"displayMode": "table", "placement": "right"}, "pieType": "donut"},
+      "targets": [
+        {
+          "expr": "sum by (intent) (rate(langgraph_node_latency_seconds_count{node=\"intent_router\"}[5m]))",
+          "legendFormat": "{{intent}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "LLM 호출 RPS (model, purpose, status)",
+      "type": "timeseries",
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 9},
+      "id": 3,
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "sum by (model, purpose, status) (rate(langgraph_llm_calls_total[5m]))",
+          "legendFormat": "{{model}} / {{purpose}} / {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "LLM 토큰/분 (direction)",
+      "type": "timeseries",
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 9},
+      "id": 4,
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "sum by (model, direction) (rate(langgraph_llm_tokens_total[5m])) * 60",
+          "legendFormat": "{{model}} / {{direction}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "Fallback rate (path)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "id": 5,
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "targets": [
+        {
+          "expr": "sum by (path) (rate(langgraph_fallback_total[5m]))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "title": "SSE 세션 + asyncpg pool in-use",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "id": 6,
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "targets": [
+        {"expr": "langgraph_sse_sessions", "legendFormat": "SSE 세션", "refId": "A"},
+        {"expr": "langgraph_pg_pool_in_use", "legendFormat": "pg pool in-use", "refId": "B"}
+      ]
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": ["localbiz", "langgraph", "observability"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "LangGraph Overview",
+  "uid": "langgraph-overview",
+  "version": 1
+}

--- a/backend/src/api/sse.py
+++ b/backend/src/api/sse.py
@@ -37,6 +37,7 @@ from src.observability.context import (  # pyright: ignore[reportMissingImports]
     thread_id_var,
     user_id_var,
 )
+from src.observability.metrics import langgraph_sse_sessions  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -321,6 +322,7 @@ async def chat_stream(
         rid_token = request_id_var.set(request_id)
         tid_token = thread_id_var.set(thread_id)
         uid_token = user_id_var.set(None)  # JWT 디코드 후 갱신
+        langgraph_sse_sessions.inc()
 
         logger.info(
             "SSE stream started: thread_id=%s, query_len=%d, request_id=%s",
@@ -566,6 +568,7 @@ async def chat_stream(
                 request_id_var.reset(rid_token)
             except ValueError:
                 pass
+            langgraph_sse_sessions.dec()
 
     return StreamingResponse(
         event_generator(),

--- a/backend/src/db/postgres.py
+++ b/backend/src/db/postgres.py
@@ -50,3 +50,18 @@ async def close_pool() -> None:
     if _pool is not None:
         await _pool.close()
         _pool = None
+
+
+def get_pool_in_use_count() -> int:
+    """현재 사용 중인 커넥션 수 = total - idle. 풀 미초기화 시 0.
+
+    Prometheus `langgraph_pg_pool_in_use` Gauge를 주기 task에서 이 함수로 갱신.
+    """
+    if _pool is None:
+        return 0
+    try:
+        size = _pool.get_size()
+        idle = _pool.get_idle_size()
+        return max(0, size - idle)
+    except Exception:
+        return 0

--- a/backend/src/graph/_tracing.py
+++ b/backend/src/graph/_tracing.py
@@ -1,24 +1,25 @@
-"""LangGraph 노드용 OpenTelemetry tracing 헬퍼.
+"""LangGraph 노드용 OpenTelemetry tracing + Prometheus latency 후크.
 
 - `traced_node(name)` 데코레이터: 노드 진입 시 `node.<name>` span 시작, state에서
   intent/thread_id/user_id 속성 부착, 결과의 `response_blocks` 길이를 attribute로 기록.
   노드 반환 타입이 dict(`{"response_blocks": [...]}`)이거나 list 어느 쪽이든 처리.
+  또한 `langgraph_node_latency_seconds{node, intent, status}` Prometheus 히스토그램에
+  실행 시간을 observe (status는 ok|error).
 - `traced_call(name, **attrs)` async 컨텍스트: 노드 내부 외부 호출(LLM/DB/HTTP)에
   sub-span 부착.
 
 예외 처리는 OTel SDK 기본 동작(`record_exception=True`, `set_status_on_exception=True`)에
 일임 — 명시적 `record_exception`/`set_status` 호출 시 중복 이벤트/상태 갱신이 발생하므로
-수동 호출을 두지 않는다.
+수동 호출을 두지 않는다. 단, metric label용 `status` 추적을 위해 `traced_node`는
+try/except로 status 변수만 갱신하고 예외는 즉시 재발생한다.
 
 `telemetry.setup_tracing()`이 호출되지 않은 환경(`JAEGER_HOST` 미설정 로컬·테스트)에서는
 OTel가 NoOp tracer를 반환 — span 생성·attribute 부착이 모두 no-op이라 성능 영향 0.
-
-Phase 3(메트릭) 진입 시 `traced_node` 내부에서 `langgraph_node_latency_seconds` 등
-Prometheus 히스토그램 observe 후크를 추가한다. 현재 파일은 tracing 전용.
 """
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from functools import wraps
@@ -26,6 +27,8 @@ from typing import Any, Optional
 
 from opentelemetry import trace  # pyright: ignore[reportMissingImports]
 from opentelemetry.trace import Span  # pyright: ignore[reportMissingImports]
+
+from src.observability.metrics import langgraph_node_latency_seconds
 
 # 모든 그래프 노드 span을 단일 tracer name으로 통합 — Jaeger UI에서
 # service.name(localbiz-api)·tracer name(localbiz.graph) 단위 필터를 일관되게 사용.
@@ -71,15 +74,16 @@ def _count_response_blocks(result: Any) -> Optional[int]:
 
 
 def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """LangGraph 노드 진입에 `node.<name>` span을 부착하는 데코레이터.
+    """LangGraph 노드 진입에 `node.<name>` span + latency histogram을 부착하는 데코레이터.
 
     노드 함수 시그니처(`async def f(state, ...)`)를 보존하며, state에서
     intent/thread_id/user_id를 추출해 span 속성으로 부착한다. 노드가 추가한
     response_blocks 길이를 `response_blocks.added` 속성으로 기록(어느 노드가 출력을
     생성·스킵했는지 Jaeger UI에서 한눈에 확인).
 
-    예외 발생 시 OTel SDK가 자동으로 `record_exception` + status=ERROR 처리 — 수동
-    호출 시 중복되므로 두지 않는다.
+    실행 시간은 `langgraph_node_latency_seconds{node, intent, status}` Prometheus
+    히스토그램에 observe. 예외 발생 시 OTel SDK가 자동으로 `record_exception` +
+    status=ERROR span을 기록 — try/except는 metric label `status="error"` 추적만 담당.
 
     Args:
         name: span 이름 suffix. 최종 span 이름은 `node.<name>`.
@@ -88,13 +92,29 @@ def traced_node(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(fn)
         async def wrapper(state: Any, *args: Any, **kwargs: Any) -> Any:
+            intent_label = "unknown"
+            if isinstance(state, dict):
+                raw_intent = state.get("intent")
+                if raw_intent:
+                    intent_label = str(raw_intent)
+            start = time.monotonic()
+            status = "ok"
             with _tracer.start_as_current_span(f"node.{name}") as span:
                 _attach_state_attrs(span, state)
-                result = await fn(state, *args, **kwargs)
-                block_count = _count_response_blocks(result)
-                if block_count is not None:
-                    span.set_attribute("response_blocks.added", block_count)
-                return result
+                try:
+                    result = await fn(state, *args, **kwargs)
+                    block_count = _count_response_blocks(result)
+                    if block_count is not None:
+                        span.set_attribute("response_blocks.added", block_count)
+                    return result
+                except Exception:
+                    status = "error"
+                    raise  # OTel SDK가 record_exception + status=ERROR 자동 처리.
+                finally:
+                    elapsed = time.monotonic() - start
+                    langgraph_node_latency_seconds.labels(node=name, intent=intent_label, status=status).observe(
+                        elapsed
+                    )
 
         return wrapper
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,7 +26,62 @@ from src.observability.logging import configure_logging  # pyright: ignore[repor
 # LOG_FORMAT=plain 환경변수로 평문 fallback 가능 (로컬 개발용).
 configure_logging()
 
+
+def _install_global_llm_callback() -> None:
+    """모든 ChatGoogleGenerativeAI 인스턴스에 LLM_METRICS_CALLBACK을 자동 부착.
+
+    각 호출 사이트(~15곳)에 callbacks 파라미터를 일일이 추가하지 않기 위해 __init__를
+    monkey-patch한다. 동일 callback 인스턴스가 중복 부착되지 않도록 dedup 처리.
+    """
+    try:
+        from langchain_google_genai import ChatGoogleGenerativeAI  # pyright: ignore[reportMissingImports]
+
+        from src.observability.llm_callback import LLM_METRICS_CALLBACK  # pyright: ignore[reportMissingImports]
+    except Exception:
+        logging.getLogger(__name__).warning("LLM callback 주입 실패 — Gemini 호출 메트릭 미수집", exc_info=True)
+        return
+
+    orig_init = ChatGoogleGenerativeAI.__init__
+
+    def patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        cbs = kwargs.get("callbacks") or []
+        try:
+            cb_list = list(cbs)
+        except TypeError:
+            cb_list = []
+        if LLM_METRICS_CALLBACK not in cb_list:
+            cb_list.append(LLM_METRICS_CALLBACK)
+        kwargs["callbacks"] = cb_list
+        orig_init(self, *args, **kwargs)
+
+    ChatGoogleGenerativeAI.__init__ = patched_init  # type: ignore[method-assign]
+
+
+# 모듈 import 시점에 1회만 패치 — 모든 노드가 import하기 전에 적용되도록.
+_install_global_llm_callback()
+
 logger = logging.getLogger(__name__)
+
+
+async def _pool_gauge_loop(interval_seconds: float = 10.0) -> None:
+    """asyncpg pool 사용량을 주기적으로 Prometheus Gauge에 반영.
+
+    Pool 초기화 전이거나 일시적 RuntimeError 시 0으로 보고. 종료는 task cancel.
+    """
+    import asyncio
+
+    from src.db.postgres import get_pool_in_use_count  # pyright: ignore[reportMissingImports]
+    from src.observability.metrics import langgraph_pg_pool_in_use  # pyright: ignore[reportMissingImports]
+
+    while True:
+        try:
+            langgraph_pg_pool_in_use.set(get_pool_in_use_count())
+        except Exception:
+            langgraph_pg_pool_in_use.set(0)
+        try:
+            await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            break
 
 
 @asynccontextmanager
@@ -43,6 +98,8 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
       2. yield → 서버가 요청을 받기 시작
       3. 서버 종료 → yield 아래쪽 코드 실행 (pool/client 정리)
     """
+    import asyncio
+
     _ = application  # FastAPI가 넘겨주지만 여기선 안 쓴다
 
     # --- Startup: 서버가 뜰 때 1번 실행 ---
@@ -63,11 +120,19 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.warning("OpenSearch client init failed (OS 미연결 시 정상)")
 
+    pool_gauge_task = asyncio.create_task(_pool_gauge_loop())
+
     yield  # ← 이 지점에서 서버가 요청을 받기 시작
 
     # --- Shutdown: 서버가 내려갈 때 1번 실행 ---
     from src.db.opensearch import close_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import close_pool  # pyright: ignore[reportMissingImports]
+
+    pool_gauge_task.cancel()
+    try:
+        await pool_gauge_task
+    except (asyncio.CancelledError, Exception):
+        pass
 
     await close_os_client()
     logger.info("OpenSearch client closed")

--- a/backend/src/observability/llm_callback.py
+++ b/backend/src/observability/llm_callback.py
@@ -1,0 +1,169 @@
+"""LangChain `BaseCallbackHandler` — ChatGoogleGenerativeAI 호출에 메트릭 후크 1군데서 통합.
+
+각 ChatGoogleGenerativeAI 인스턴스 생성 시 `callbacks=[LLM_METRICS_CALLBACK]`로 주입하면
+`on_llm_start`/`on_llm_end`/`on_llm_error`가 호출되어:
+  - `langgraph_llm_calls_total{model, purpose, status}` Counter inc
+  - `langgraph_llm_latency_seconds{model, purpose}` Histogram observe
+  - `langgraph_llm_tokens_total{model, purpose, direction}` Counter inc (usage_metadata 있을 때)
+
+`purpose`는 호출 사이트가 ContextVar(`_llm_purpose_var`)로 set한 값을 읽음 —
+ContextVar 미설정 시 fallback `"unknown"`.
+
+`booking_node`의 google-genai 직접 호출은 별도 `traced_call("gemini.booking_grounding")`로
+계측 — 본 callback은 LangChain 객체 전용.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextvars import ContextVar
+from typing import Any, Optional
+from uuid import UUID
+
+from langchain_core.callbacks import BaseCallbackHandler  # pyright: ignore[reportMissingImports]
+from langchain_core.messages import BaseMessage  # pyright: ignore[reportMissingImports]
+from langchain_core.outputs import LLMResult  # pyright: ignore[reportMissingImports]
+
+from src.observability.metrics import (
+    langgraph_llm_calls_total,
+    langgraph_llm_latency_seconds,
+    langgraph_llm_tokens_total,
+)
+
+logger = logging.getLogger(__name__)
+
+_llm_purpose_var: ContextVar[Optional[str]] = ContextVar("llm_purpose", default=None)
+
+
+def set_llm_purpose(purpose: str) -> Any:
+    """LangChain LLM 호출 직전 purpose 설정. 반환 토큰으로 reset."""
+    return _llm_purpose_var.set(purpose)
+
+
+def reset_llm_purpose(token: Any) -> None:
+    try:
+        _llm_purpose_var.reset(token)
+    except (ValueError, LookupError):
+        pass
+
+
+def _resolve_purpose() -> str:
+    val = _llm_purpose_var.get()
+    return val if val else "unknown"
+
+
+def _resolve_model(serialized: Optional[dict[str, Any]], **kwargs: Any) -> str:
+    if isinstance(serialized, dict):
+        params = serialized.get("kwargs") or {}
+        model = params.get("model")
+        if isinstance(model, str) and model:
+            return model
+    inv = kwargs.get("invocation_params") or {}
+    model = inv.get("model")
+    if isinstance(model, str) and model:
+        return model
+    return "unknown"
+
+
+def _extract_token_counts(response: LLMResult) -> tuple[int, int]:
+    """LLMResult에서 input/output 토큰 추출. 키가 없거나 형식 다르면 (0, 0)."""
+    llm_output = getattr(response, "llm_output", None) or {}
+    usage = llm_output.get("usage_metadata") or llm_output.get("token_usage") or {}
+    input_keys = ("prompt_token_count", "input_tokens", "prompt_tokens")
+    output_keys = ("candidates_token_count", "output_tokens", "completion_tokens")
+    in_tok = next((int(usage[k]) for k in input_keys if k in usage and usage[k] is not None), 0)
+    out_tok = next((int(usage[k]) for k in output_keys if k in usage and usage[k] is not None), 0)
+    if in_tok == 0 and out_tok == 0:
+        for gen_list in response.generations or []:
+            for gen in gen_list:
+                msg = getattr(gen, "message", None)
+                if msg is None:
+                    continue
+                u = getattr(msg, "usage_metadata", None) or {}
+                if isinstance(u, dict):
+                    in_tok += int(u.get("input_tokens") or 0)
+                    out_tok += int(u.get("output_tokens") or 0)
+    return in_tok, out_tok
+
+
+class LLMMetricsCallback(BaseCallbackHandler):
+    """모든 ChatGoogleGenerativeAI 호출의 latency / 토큰 / 성공·에러 카운트."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._start_times: dict[str, float] = {}
+        self._models: dict[str, str] = {}
+        self._purposes: dict[str, str] = {}
+
+    def _key(self, run_id: Optional[UUID]) -> str:
+        return str(run_id) if run_id is not None else "no-run-id"
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        *,
+        run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        del prompts
+        key = self._key(run_id)
+        self._start_times[key] = time.monotonic()
+        self._models[key] = _resolve_model(serialized, **kwargs)
+        self._purposes[key] = _resolve_purpose()
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        *,
+        run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        del messages
+        key = self._key(run_id)
+        self._start_times[key] = time.monotonic()
+        self._models[key] = _resolve_model(serialized, **kwargs)
+        self._purposes[key] = _resolve_purpose()
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        del kwargs
+        key = self._key(run_id)
+        start = self._start_times.pop(key, None)
+        model = self._models.pop(key, "unknown")
+        purpose = self._purposes.pop(key, "unknown")
+        if start is not None:
+            langgraph_llm_latency_seconds.labels(model=model, purpose=purpose).observe(time.monotonic() - start)
+        langgraph_llm_calls_total.labels(model=model, purpose=purpose, status="ok").inc()
+        in_tok, out_tok = _extract_token_counts(response)
+        if in_tok > 0:
+            langgraph_llm_tokens_total.labels(model=model, purpose=purpose, direction="input").inc(in_tok)
+        if out_tok > 0:
+            langgraph_llm_tokens_total.labels(model=model, purpose=purpose, direction="output").inc(out_tok)
+
+    def on_llm_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        del error, kwargs
+        key = self._key(run_id)
+        start = self._start_times.pop(key, None)
+        model = self._models.pop(key, "unknown")
+        purpose = self._purposes.pop(key, "unknown")
+        if start is not None:
+            langgraph_llm_latency_seconds.labels(model=model, purpose=purpose).observe(time.monotonic() - start)
+        langgraph_llm_calls_total.labels(model=model, purpose=purpose, status="error").inc()
+
+
+# 싱글톤 인스턴스 — 모든 ChatGoogleGenerativeAI 생성 시 `callbacks=[LLM_METRICS_CALLBACK]`로 주입.
+LLM_METRICS_CALLBACK: LLMMetricsCallback = LLMMetricsCallback()

--- a/backend/src/observability/metrics.py
+++ b/backend/src/observability/metrics.py
@@ -1,0 +1,93 @@
+"""LangGraph 비즈니스 메트릭 — Prometheus client 직접 사용.
+
+이미 `prometheus_fastapi_instrumentator`가 HTTP RPS/latency/status는 자동 export 중.
+본 모듈은 그 위에 LangGraph 도메인 메트릭 10종을 추가한다 — 같은 `/metrics` 엔드포인트에
+자동 합류(prometheus_client의 default registry 사용).
+
+라벨 카디널리티 상한 (불변 — 폭증 회피):
+  - intent: 13종 (PLACE_SEARCH … GENERAL)
+  - node: 18종 (그래프 노드)
+  - model: 2~3종 (gemini-2.5-flash, gemini-embedding-001 등)
+  - purpose: 약 10종 (intent_classify / query_preprocess / rerank / …)
+  - path (fallback): 약 5종
+
+라벨에 **`user_id`/`thread_id` 절대 포함 금지** — 그건 trace_id/log로 식별. 메트릭은 집계만.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram  # pyright: ignore[reportMissingImports]
+
+# ---------------------------------------------------------------------------
+# LangGraph 노드
+# ---------------------------------------------------------------------------
+langgraph_intent_total = Counter(
+    "langgraph_intent_total",
+    "분류된 intent 누적 카운트 (intent_router 종료 시점).",
+    ["intent"],
+)
+
+langgraph_node_latency_seconds = Histogram(
+    "langgraph_node_latency_seconds",
+    "LangGraph 노드 실행 시간 (초). `traced_node` 데코레이터에서 observe.",
+    ["node", "intent", "status"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+
+# ---------------------------------------------------------------------------
+# LLM (Gemini)
+# ---------------------------------------------------------------------------
+langgraph_llm_calls_total = Counter(
+    "langgraph_llm_calls_total",
+    "LLM 호출 누적 카운트. status는 ok|error.",
+    ["model", "purpose", "status"],
+)
+
+langgraph_llm_tokens_total = Counter(
+    "langgraph_llm_tokens_total",
+    "LLM 토큰 누적. direction은 input|output.",
+    ["model", "purpose", "direction"],
+)
+
+langgraph_llm_latency_seconds = Histogram(
+    "langgraph_llm_latency_seconds",
+    "LLM 호출 시간 (초).",
+    ["model", "purpose"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0),
+)
+
+# ---------------------------------------------------------------------------
+# OpenSearch / PostgreSQL
+# ---------------------------------------------------------------------------
+langgraph_os_query_latency_seconds = Histogram(
+    "langgraph_os_query_latency_seconds",
+    "OpenSearch 쿼리 시간 (초). index/op 라벨.",
+    ["index", "op"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+langgraph_pg_query_latency_seconds = Histogram(
+    "langgraph_pg_query_latency_seconds",
+    "PostgreSQL 쿼리 시간 (초). op 라벨.",
+    ["op"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5),
+)
+
+langgraph_pg_pool_in_use = Gauge(
+    "langgraph_pg_pool_in_use",
+    "현재 사용 중인 asyncpg 커넥션 수 (pool.get_size - pool.get_idle_size).",
+)
+
+# ---------------------------------------------------------------------------
+# Fallback / SSE
+# ---------------------------------------------------------------------------
+langgraph_fallback_total = Counter(
+    "langgraph_fallback_total",
+    "Fallback 분기 진입 카운트. path 라벨 enum 고정.",
+    ["path"],
+)
+
+langgraph_sse_sessions = Gauge(
+    "langgraph_sse_sessions",
+    "현재 활성 SSE 세션 수 (enter 시 inc, exit 시 dec).",
+)

--- a/backend/tests/test_observability_metrics.py
+++ b/backend/tests/test_observability_metrics.py
@@ -1,0 +1,59 @@
+"""Smoke tests for `src.observability.metrics` — 메트릭 정의 존재 + 라벨 인터페이스."""
+
+from __future__ import annotations
+
+from prometheus_client import generate_latest  # pyright: ignore[reportMissingImports]
+
+from src.observability.metrics import (
+    langgraph_fallback_total,
+    langgraph_intent_total,
+    langgraph_llm_calls_total,
+    langgraph_llm_latency_seconds,
+    langgraph_llm_tokens_total,
+    langgraph_node_latency_seconds,
+    langgraph_os_query_latency_seconds,
+    langgraph_pg_pool_in_use,
+    langgraph_pg_query_latency_seconds,
+    langgraph_sse_sessions,
+)
+
+
+def test_all_metrics_are_exportable() -> None:
+    """10종 메트릭이 모두 정의되고 default registry에 등록되어 /metrics에 노출되는지."""
+    langgraph_intent_total.labels(intent="PLACE_SEARCH").inc()
+    langgraph_node_latency_seconds.labels(node="place_search", intent="PLACE_SEARCH", status="ok").observe(0.5)
+    langgraph_llm_calls_total.labels(model="gemini-2.5-flash", purpose="rerank", status="ok").inc()
+    langgraph_llm_tokens_total.labels(model="gemini-2.5-flash", purpose="rerank", direction="input").inc(100)
+    langgraph_llm_latency_seconds.labels(model="gemini-2.5-flash", purpose="rerank").observe(1.5)
+    langgraph_os_query_latency_seconds.labels(index="places_vector", op="knn").observe(0.1)
+    langgraph_pg_query_latency_seconds.labels(op="places_search").observe(0.05)
+    langgraph_pg_pool_in_use.set(3)
+    langgraph_fallback_total.labels(path="event.naver_sparse").inc()
+    langgraph_sse_sessions.inc()
+
+    payload = generate_latest().decode()
+    for name in (
+        "langgraph_intent_total",
+        "langgraph_node_latency_seconds",
+        "langgraph_llm_calls_total",
+        "langgraph_llm_tokens_total",
+        "langgraph_llm_latency_seconds",
+        "langgraph_os_query_latency_seconds",
+        "langgraph_pg_query_latency_seconds",
+        "langgraph_pg_pool_in_use",
+        "langgraph_fallback_total",
+        "langgraph_sse_sessions",
+    ):
+        assert name in payload, f"{name} 메트릭이 /metrics에 노출되지 않음"
+
+
+def test_fallback_path_labels_known_enum() -> None:
+    """fallback path 라벨 enum 4종 — 폭증 회피 확인용 회귀 테스트."""
+    known_paths = (
+        "event.naver_sparse",
+        "event_recommend.naver_sparse",
+        "intent.no_llm_key",
+        "image.knn_scene_fallback",
+    )
+    for path in known_paths:
+        langgraph_fallback_total.labels(path=path).inc()


### PR DESCRIPTION
Phase 3: 10 비즈니스 메트릭 + LangChain LLM 콜백 + Grafana 대시보드.

Depends on #203 (Phase 1 tracing), #205 (Phase 2 logging).

## 메트릭 10종
- langgraph_intent_total, langgraph_node_latency_seconds, langgraph_llm_calls_total,
  langgraph_llm_tokens_total, langgraph_llm_latency_seconds, langgraph_os_query_latency_seconds,
  langgraph_pg_query_latency_seconds, langgraph_pg_pool_in_use, langgraph_fallback_total,
  langgraph_sse_sessions

## 구성
- observability/metrics.py 신규
- observability/llm_callback.py 신규 — LangChain BaseCallbackHandler
- main.py monkey-patch로 15 ChatGoogleGenerativeAI 사이트 자동 콜백 부착
- _tracing.py에 latency histogram observe
- sse.py SSE 세션 게이지
- main.py + db/postgres.py asyncpg pool 게이지 백그라운드 task
- monitoring/grafana/dashboards/langgraph-overview.json — 패널 6개

## 테스트
ruff/format/pyright 통과, pytest 12 pass (+ 1 pre-existing quirk).

Issue #206. 후속: 로컬 docker-compose monitoring stack 기동 후 Jaeger/Loki/Prometheus 실데이터 검증.