### PR TITLE
[Feat] Observability fallback 카운터 inc() 부착 — 4 사이트 (#208)

### DIFF
--- a/backend/src/graph/event_recommend_node.py
+++ b/backend/src/graph/event_recommend_node.py
@@ -44,6 +44,7 @@ from typing import Any, Optional
 
 from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.event_filters import is_real_event  # pyright: ignore[reportMissingImports]
+from src.observability.metrics import langgraph_fallback_total  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -810,6 +811,7 @@ async def event_recommend_node(state: dict[str, Any]) -> dict[str, Any]:
     # 4) PG∪OS 병합 부족 시 Naver fallback
     naver_events: list[dict[str, Any]] = []
     if merged_count < _MIN_MERGED_RESULTS:
+        langgraph_fallback_total.labels(path="event_recommend.naver_sparse").inc()
         naver_query = " ".join(keywords) if keywords else query[:100]
         naver_items = await _search_naver(
             naver_query,

--- a/backend/src/graph/event_search_node.py
+++ b/backend/src/graph/event_search_node.py
@@ -36,6 +36,7 @@ from typing import Any, Optional
 
 from src.graph._tracing import traced_call, traced_node  # pyright: ignore[reportMissingImports]
 from src.graph.event_filters import is_real_event  # pyright: ignore[reportMissingImports]
+from src.observability.metrics import langgraph_fallback_total  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -838,6 +839,7 @@ async def event_search_node(state: dict[str, Any]) -> dict[str, Any]:
     # 4) PG∪OS 병합 부족 시 Naver fallback
     naver_events: list[dict[str, Any]] = []
     if merged_count < _MIN_MERGED_RESULTS:
+        langgraph_fallback_total.labels(path="event.naver_sparse").inc()
         # 검색어 조합: keywords 우선, 없으면 query 자체 (앞 100자)
         naver_query = " ".join(keywords) if keywords else query[:100]
         naver_items = await _search_naver(

--- a/backend/src/graph/image_search_node.py
+++ b/backend/src/graph/image_search_node.py
@@ -33,6 +33,7 @@ import re
 from typing import Any, Optional
 
 from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+from src.observability.metrics import langgraph_fallback_total  # pyright: ignore[reportMissingImports]
 
 _URL_RE = re.compile(r"https?://\S+")
 # "여기 어딘지" 류 — 특정 장소 식별 의도
@@ -656,6 +657,7 @@ async def _fallback_knn_with_message(
     place_type: Optional[str],
 ) -> list[dict[str, Any]]:
     """못 찾은 경우 커스텀 메시지 + k-NN 결과 반환. scene_description 없으면 메시지만."""
+    langgraph_fallback_total.labels(path="image.knn_scene_fallback").inc()
     if not scene_description:
         return [_text_stream_block(msg_prompt)]
     knn_blocks = await _run_knn(scene_description, api_key, pool, os_client, place_type=place_type)

--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -11,6 +11,7 @@ from enum import StrEnum  # pyright: ignore[reportAttributeAccessIssue]
 from typing import Any, Optional
 
 from src.graph._tracing import traced_node  # pyright: ignore[reportMissingImports]
+from src.observability.metrics import langgraph_fallback_total  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +207,7 @@ async def classify_intents(
     settings = get_settings()
     if not settings.gemini_llm_api_key:
         logger.warning("classify_intents: GEMINI_LLM_API_KEY 미설정 → GENERAL fallback")
+        langgraph_fallback_total.labels(path="intent.no_llm_key").inc()
         return [(_GENERAL_FALLBACK, 0.0, query)]
 
     try:
@@ -298,6 +300,7 @@ async def classify_intent(
     settings = get_settings()
     if not settings.gemini_llm_api_key:
         logger.warning("classify_intent: GEMINI_LLM_API_KEY 미설정 → GENERAL fallback")
+        langgraph_fallback_total.labels(path="intent.no_llm_key").inc()
         return (_GENERAL_FALLBACK, 0.0)
 
     try:


### PR DESCRIPTION
Phase 3(#207)에서 langgraph_fallback_total{path} 카운터는 정의됐으나 .inc() 호출 미부착으로 Grafana 'Fallback rate' 패널이 No data 였던 문제 해결.

## 변경
- event_search_node.py: PG∪OS<3 분기 → `event.naver_sparse`
- event_recommend_node.py: 동상 → `event_recommend.naver_sparse`
- intent_router_node.py: 2 사이트 (classify_intents/classify_intent) → `intent.no_llm_key`
- image_search_node.py: _fallback_knn_with_message 진입 → `image.knn_scene_fallback`
- 각 파일에 from src.observability.metrics import langgraph_fallback_total 추가

## 검증
- ruff/format/pyright 통과
- build_graph() smoke OK
- 9줄 추가, 데이터 모델 무관, SSE 블록 변경 없음

Refs: #208 (선행 #207 머지 완료)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added fallback event tracking metrics to improve system observability and monitoring across search and recommendation services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->