### PR TITLE
[Feat] uvicorn /health·/metrics 액세스 로그 필터 (#210)

### DIFF
--- a/backend/src/observability/logging.py
+++ b/backend/src/observability/logging.py
@@ -41,6 +41,31 @@ _NOISY_LOGGERS: tuple[str, ...] = (
 )
 
 
+class UvicornAccessFilter(logging.Filter):
+    """uvicorn.access 로거에서 /health, /metrics 요청 로그를 drop.
+
+    헬스체크/메트릭 스크랩이 초당 호출돼 비즈니스 로그가 묻히고 Loki 적재 비용도
+    증가하는 문제 회피. uvicorn.access 표준 args 위치는
+    (client_addr, method, full_path, http_version, status_code) — 3번째가 path.
+    형식이 다르면 getMessage() fallback.
+    """
+
+    _EXCLUDED_PATHS: tuple[str, ...] = ("/health", "/metrics")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        path = ""
+        if isinstance(record.args, tuple) and len(record.args) >= 3:
+            third = record.args[2]
+            if isinstance(third, str):
+                path = third
+        if not path:
+            path = record.getMessage()
+        for excluded in self._EXCLUDED_PATHS:
+            if excluded in path:
+                return False
+        return True
+
+
 class TraceContextFilter(logging.Filter):
     """모든 로그 레코드에 trace/request 컨텍스트 필드를 주입.
 
@@ -105,4 +130,6 @@ def configure_logging(format_: Optional[LogFormat] = None, level: int = logging.
     root.setLevel(level)
     for noisy in _NOISY_LOGGERS:
         logging.getLogger(noisy).setLevel(logging.WARNING)
+    # uvicorn.access는 INFO로 두되 /health·/metrics만 drop — 비즈니스 API 호출 로그는 유지.
+    logging.getLogger("uvicorn.access").addFilter(UvicornAccessFilter())
     root.info("logging configured: format=%s level=%s", fmt, logging.getLevelName(level))

--- a/backend/tests/test_observability_logging.py
+++ b/backend/tests/test_observability_logging.py
@@ -10,7 +10,7 @@ from opentelemetry import trace  # pyright: ignore[reportMissingImports]
 from opentelemetry.sdk.trace import TracerProvider  # pyright: ignore[reportMissingImports]
 
 from src.observability.context import request_id_var, thread_id_var, user_id_var
-from src.observability.logging import TraceContextFilter, configure_logging
+from src.observability.logging import TraceContextFilter, UvicornAccessFilter, configure_logging
 
 
 def _last_log_line(capsys: Any) -> dict[str, Any]:
@@ -73,6 +73,57 @@ def test_trace_context_filter_injects_request_user_thread() -> None:
         request_id_var.reset(rid_token)
         user_id_var.reset(uid_token)
         thread_id_var.reset(tid_token)
+
+
+def test_uvicorn_access_filter_drops_health_and_metrics() -> None:
+    """UvicornAccessFilter가 /health·/metrics 요청 record를 drop, 그 외는 유지."""
+    f = UvicornAccessFilter()
+
+    def make_record(request_line: str) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=10,
+            msg='%s:%s - "%s %s %s" %s',
+            args=("127.0.0.1", "45144", "GET", request_line, "HTTP/1.1", 200),
+            exc_info=None,
+        )
+
+    # uvicorn args의 path는 인자 3번 위치 (full_path) — getMessage fallback도 확인.
+    health_rec = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg='%s - "%s %s %s" %s',
+        args=("127.0.0.1:45144", "GET", "/health", "HTTP/1.1", 200),
+        exc_info=None,
+    )
+    metrics_rec = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg='%s - "%s %s %s" %s',
+        args=("10.178.0.4:60908", "GET", "/metrics", "HTTP/1.1", 200),
+        exc_info=None,
+    )
+    api_rec = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg='%s - "%s %s %s" %s',
+        args=("127.0.0.1:45144", "GET", "/api/v1/chat/stream", "HTTP/1.1", 200),
+        exc_info=None,
+    )
+
+    assert f.filter(health_rec) is False
+    assert f.filter(metrics_rec) is False
+    assert f.filter(api_rec) is True
+    # make_record는 사용하지 않지만 사인쳐 시그니처 회귀 보장.
+    _ = make_record
 
 
 def test_trace_context_filter_attaches_trace_id_when_span_active() -> None:


### PR DESCRIPTION
Grafana Logs 패널이 /health·/metrics 액세스 로그로 도배되어 비즈니스 로그가 묻히는 문제 해결.

## 변경
- observability/logging.py: UvicornAccessFilter 신규 — path가 /health·/metrics인 record만 drop
- configure_logging()에서 uvicorn.access 로거에 자동 부착
- 테스트 1건 추가 (5 pass)

소스 단계 drop이라 Loki 적재 비용도 감소.

Refs: #210