### PR TITLE
[Fix] REFINE 자기응답 필터 + fallthrough 로깅 (#212)

### DIFF
--- a/backend/src/graph/refine_node.py
+++ b/backend/src/graph/refine_node.py
@@ -179,6 +179,28 @@ def _has_explicit_reference(query: str) -> bool:
 # ---------------------------------------------------------------------------
 # 수정 대상 특정
 # ---------------------------------------------------------------------------
+def _filter_refineable(
+    all_assistant_blocks: list[list[dict[str, Any]]],
+) -> tuple[list[list[dict[str, Any]]], list[Optional[str]]]:
+    """REFINE 자기 응답(target 후보로 부적격)을 걸러내고, 각 블록의 원본 intent도 함께 반환.
+
+    REFINE 노드가 "이전 응답이 없어요" / 실패 안내로 응답한 경우, 그 응답을 다음 turn의
+    수정 대상으로 잡으면 self-loop가 되며 _detect_original_intent도 None을 반환한다.
+    원본 intent가 None이거나 'REFINE'인 응답은 후보에서 제외.
+
+    Returns:
+        (refineable_blocks, refineable_intents) — 같은 길이, 최신순 유지.
+    """
+    refineable_blocks: list[list[dict[str, Any]]] = []
+    refineable_intents: list[Optional[str]] = []
+    for blocks in all_assistant_blocks:
+        intent = _detect_original_intent(blocks)
+        if intent and intent != "REFINE":
+            refineable_blocks.append(blocks)
+            refineable_intents.append(intent)
+    return refineable_blocks, refineable_intents
+
+
 async def _identify_target(
     query: str,
     all_assistant_blocks: list[list[dict[str, Any]]],
@@ -186,18 +208,26 @@ async def _identify_target(
 ) -> tuple[list[dict[str, Any]], Optional[str]]:
     """수정 대상 응답 블록과 원본 intent를 특정.
 
-    기본: 직전 응답. 명시적 참조 시 Gemini 추론.
+    REFINE 자기 응답은 후보에서 제외 후 최신 refineable 응답을 기본으로 잡는다.
+    명시적 참조(아까/이전/그때 등)가 있을 때만 Gemini로 더 거슬러 올라가 추론.
 
     Returns:
-        (target_blocks, original_intent). 실패 시 ([], None).
+        (target_blocks, original_intent). 후보가 0건이거나 실패 시 ([], None).
     """
     if not all_assistant_blocks:
         return [], None
 
-    # 기본: 직전 응답
-    if not _has_explicit_reference(query) or len(all_assistant_blocks) == 1:
-        target = all_assistant_blocks[0]
-        return target, _detect_original_intent(target)
+    refineable_blocks, refineable_intents = _filter_refineable(all_assistant_blocks)
+    if not refineable_blocks:
+        logger.info(
+            "refine_node._identify_target: refineable 응답 0건 — 전체 %d건 모두 REFINE 자기응답 또는 intent 추론 실패",
+            len(all_assistant_blocks),
+        )
+        return [], None
+
+    # 기본: 가장 최근 refineable 응답
+    if not _has_explicit_reference(query) or len(refineable_blocks) == 1:
+        return refineable_blocks[0], refineable_intents[0]
 
     # 명시적 참조 → Gemini 추론
     try:
@@ -207,13 +237,12 @@ async def _identify_target(
 
         settings = get_settings()
         if not settings.gemini_llm_api_key:
-            target = all_assistant_blocks[0]
-            return target, _detect_original_intent(target)
+            return refineable_blocks[0], refineable_intents[0]
 
-        # 응답 요약 생성
+        # 응답 요약 생성 — refineable 후보만 (전체 인덱스가 아닌 refineable 인덱스 기준)
         summaries: list[str] = []
-        for i, blocks in enumerate(all_assistant_blocks):
-            intent = _detect_original_intent(blocks)
+        for i, blocks in enumerate(refineable_blocks):
+            intent = refineable_intents[i]
             block_types = [b.get("type", "") for b in blocks if isinstance(b, dict)]
             summaries.append(f"[{i}] intent={intent}, blocks={block_types}")
 
@@ -238,15 +267,13 @@ async def _identify_target(
 
         result = json.loads(text)
         idx = int(result.get("target_message_index", 0))
-        idx = max(0, min(idx, len(all_assistant_blocks) - 1))
+        idx = max(0, min(idx, len(refineable_blocks) - 1))
 
-        target = all_assistant_blocks[idx]
-        return target, _detect_original_intent(target)
+        return refineable_blocks[idx], refineable_intents[idx]
 
     except Exception:
-        logger.exception("refine_node: target 추론 실패 → 직전 응답 fallback")
-        target = all_assistant_blocks[0]
-        return target, _detect_original_intent(target)
+        logger.exception("refine_node: target 추론 실패 → 직전 refineable 응답 fallback")
+        return refineable_blocks[0], refineable_intents[0]
 
 
 # ---------------------------------------------------------------------------
@@ -421,12 +448,24 @@ async def refine_node(state: dict[str, Any]) -> dict[str, Any]:
     # 1. 이전 응답 블록 로드
     all_blocks = await _load_previous_assistant_blocks(thread_id)
     if not all_blocks:
+        logger.info(
+            "refine_node: 이전 assistant 응답 0건 thread_id=%s → 안내 메시지",
+            thread_id,
+        )
         return {"response_blocks": _no_previous_response_blocks()}
 
     # 2. 수정 대상 특정
     target_blocks, original_intent = await _identify_target(query, all_blocks, conversation_history)
 
     if not target_blocks or not original_intent:
+        logger.info(
+            "refine_node: target 추정 실패 thread_id=%s, all_blocks_count=%d, "
+            "target_blocks_empty=%s, original_intent=%s → 안내 메시지",
+            thread_id,
+            len(all_blocks),
+            not target_blocks,
+            original_intent,
+        )
         return {"response_blocks": _no_previous_response_blocks()}
 
     # 3. 수정 지시 파싱

--- a/backend/tests/test_refine_node.py
+++ b/backend/tests/test_refine_node.py
@@ -138,3 +138,105 @@ def test_classify_prompts_contain_not_refine_guidance() -> None:
     for prompt in [_CLASSIFY_SYSTEM_PROMPT, _CLASSIFY_MULTI_SYSTEM_PROMPT]:
         assert "NOT REFINE" in prompt, "프롬프트에 NOT REFINE 부정 예시가 없음"
         assert "questions about previous results" in prompt or "questions about a previous response" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _filter_refineable / _identify_target 회귀 (#212)
+# ---------------------------------------------------------------------------
+def test_filter_refineable_excludes_refine_self_response() -> None:
+    """REFINE 자기 실패 응답은 후보에서 제외.
+
+    실제 DB 관측 케이스 (thread session-1780290718671):
+      msg 832: [intent(REFINE), intent(REFINE), text_stream, done]  ← REFINE 자기응답
+      msg 824: [intent(COURSE_PLAN), course, text_stream, map_route]  ← 실제 코스 응답
+    """
+    from src.graph.refine_node import _filter_refineable
+
+    refine_failure = [
+        {"type": "intent", "intent": "REFINE", "confidence": 1.0},
+        {"type": "intent", "intent": "REFINE", "confidence": 1.0},
+        {"type": "text_stream", "system": "...", "prompt": "..."},
+        {"type": "done", "status": "done"},
+    ]
+    course_response = [
+        {"type": "intent", "intent": "COURSE_PLAN", "confidence": 0.95},
+        {"type": "course", "stops": [{"order": 1, "place": {"name": "홍대씨앤", "place_id": "p1"}}]},
+        {"type": "text_stream", "system": "...", "prompt": "..."},
+        {"type": "map_route", "polyline": "..."},
+    ]
+
+    refineable, intents = _filter_refineable([refine_failure, course_response])
+
+    assert len(refineable) == 1
+    assert intents == ["COURSE_PLAN"]
+    assert refineable[0] is course_response
+
+
+def test_filter_refineable_keeps_order() -> None:
+    """refineable 응답 순서가 입력 순서(최신순)와 일치."""
+    from src.graph.refine_node import _filter_refineable
+
+    course_resp = [{"type": "intent", "intent": "COURSE_PLAN"}, {"type": "course", "stops": []}]
+    places_resp = [{"type": "intent", "intent": "PLACE_SEARCH"}, {"type": "places", "items": []}]
+    refine_resp = [{"type": "intent", "intent": "REFINE"}, {"type": "text_stream"}]
+
+    refineable, intents = _filter_refineable([refine_resp, course_resp, refine_resp, places_resp])
+
+    # refine_resp 2건은 모두 제거되고 course → places 순서 유지
+    assert intents == ["COURSE_PLAN", "PLACE_SEARCH"]
+    assert refineable[0] is course_resp
+    assert refineable[1] is places_resp
+
+
+def test_filter_refineable_all_refine_returns_empty() -> None:
+    """모든 응답이 REFINE 자기응답이면 빈 결과 + 호출부가 안내 메시지로 fallthrough."""
+    from src.graph.refine_node import _filter_refineable
+
+    refine_resp = [{"type": "intent", "intent": "REFINE"}, {"type": "text_stream"}]
+    refineable, intents = _filter_refineable([refine_resp, refine_resp])
+
+    assert refineable == []
+    assert intents == []
+
+
+def test_identify_target_skips_refine_self_response_for_course() -> None:
+    """가장 최근 응답이 REFINE 자기응답이어도 그 다음 course 응답을 target으로 잡음.
+
+    #212 핵심 회귀 — DB 관측 사례 그대로 재현.
+    """
+    import asyncio
+
+    from src.graph.refine_node import _identify_target
+
+    refine_failure = [
+        {"type": "intent", "intent": "REFINE"},
+        {"type": "intent", "intent": "REFINE"},
+        {"type": "text_stream"},
+        {"type": "done"},
+    ]
+    calendar_resp = [
+        {"type": "intent", "intent": "CALENDAR"},
+        {"type": "text_stream"},
+        {"type": "calendar", "event_id": "..."},
+        {"type": "done"},
+    ]
+    course_resp = [
+        {"type": "intent", "intent": "COURSE_PLAN"},
+        {"type": "course", "stops": [{"order": 1, "place": {"name": "홍대씨앤"}}]},
+        {"type": "text_stream"},
+        {"type": "map_route"},
+    ]
+
+    target, intent = asyncio.run(
+        _identify_target(
+            query="홍대씨앤이 마음에 들지 않아, 다른 팝업 스토어로 바꿔줘",
+            all_assistant_blocks=[refine_failure, calendar_resp, course_resp],
+            conversation_history=[],
+        )
+    )
+
+    # CALENDAR가 가장 최근 refineable이지만 plan 의도가 course 쪽이라 caller의 _parse_refinement가
+    # 결정하므로 여기선 단순히 _identify_target이 self-REFINE을 skip하는지만 검증.
+    # (명시적 참조 없으니 가장 최근 refineable = CALENDAR가 target.)
+    assert intent == "CALENDAR"
+    assert target is calendar_resp

--- a/backend/tests/test_refine_node.py
+++ b/backend/tests/test_refine_node.py
@@ -199,13 +199,14 @@ def test_filter_refineable_all_refine_returns_empty() -> None:
     assert intents == []
 
 
-def test_identify_target_skips_refine_self_response_for_course() -> None:
-    """가장 최근 응답이 REFINE 자기응답이어도 그 다음 course 응답을 target으로 잡음.
+async def test_identify_target_skips_refine_self_response_for_course() -> None:
+    """가장 최근 응답이 REFINE 자기응답이어도 그 다음 refineable 응답을 target으로 잡음.
 
     #212 핵심 회귀 — DB 관측 사례 그대로 재현.
-    """
-    import asyncio
 
+    asyncio.run()을 쓰면 세션 event_loop fixture를 닫아 후속 sync 테스트가
+    'no current event loop'으로 깨지므로 async test로 작성 — pytest-asyncio auto mode가 처리.
+    """
     from src.graph.refine_node import _identify_target
 
     refine_failure = [
@@ -227,12 +228,10 @@ def test_identify_target_skips_refine_self_response_for_course() -> None:
         {"type": "map_route"},
     ]
 
-    target, intent = asyncio.run(
-        _identify_target(
-            query="홍대씨앤이 마음에 들지 않아, 다른 팝업 스토어로 바꿔줘",
-            all_assistant_blocks=[refine_failure, calendar_resp, course_resp],
-            conversation_history=[],
-        )
+    target, intent = await _identify_target(
+        query="홍대씨앤이 마음에 들지 않아, 다른 팝업 스토어로 바꿔줘",
+        all_assistant_blocks=[refine_failure, calendar_resp, course_resp],
+        conversation_history=[],
     )
 
     # CALENDAR가 가장 최근 refineable이지만 plan 의도가 course 쪽이라 caller의 _parse_refinement가


### PR DESCRIPTION
REFINE 노드가 자기 자신 실패 응답을 target으로 잡아 'No previous response' 안내가 반복되던 버그 수정.

## 원인
- _identify_target가 가장 최근 assistant 응답을 default target으로 잡는데, 그게 REFINE 자기 실패 응답일 때 _detect_original_intent가 None 반환
- silent fallthrough라 디버깅 불가

## 수정
- _filter_refineable 추가 — REFINE 자기응답·intent 추론 실패 응답 제외
- _identify_target가 refineable 후보만 사용
- fallthrough 2분기에 logger.info 추가

## 검증
- ruff/format/pyright 통과
- 19 tests pass (기존 15 + 회귀 4)
- DB 관측 사례 그대로 재현하는 테스트 포함

Refs: #212