### PR TITLE
[Fix] REVIEW_COMPARE chart 누락 + 후속 위치 질문 오분류 (#214)

### DIFF
--- a/backend/src/graph/intent_router_node.py
+++ b/backend/src/graph/intent_router_node.py
@@ -102,7 +102,15 @@ Phase 1 (active):
 - BOOKING: requesting a reservation or booking link
 - CALENDAR: adding an event to calendar
 - FAVORITE: bookmarking or favoriting something
-- REVIEW_COMPARE: comparing two or more places by 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise)
+- REVIEW_COMPARE: comparing two or more places by 6 metrics (satisfaction/accessibility/cleanliness/value/atmosphere/expertise).
+  Trigger keywords REQUIRED: "비교", "리뷰 비교", "어디가 더", "어느 쪽이", "어느 게 더", "더 좋아".
+  Without these explicit comparison keywords, classify as DETAIL_INQUIRY or GENERAL even if
+  multiple places are mentioned (Korean connectors like "이랑", "와", "과", "vs" alone are NOT enough).
+  NOT REVIEW_COMPARE (classify accordingly):
+    - "A랑 B 어디야?" / "A와 B 어디냐?" → GENERAL or DETAIL_INQUIRY (location query)
+    - "A 그리고 B 가격" → COST_ESTIMATE (price query)
+    - "A하고 B 영업시간" → DETAIL_INQUIRY (info query)
+  Example REVIEW_COMPARE: "물포곤 청담점이랑 광화문점 리뷰 비교해줘" / "강남역과 홍대 카페 어느 게 더 좋아?"
 - CROWDEDNESS: asking about current crowdedness, busyness, or population density of an area.
   Accept noun-phrase queries without verbs (e.g. "홍대 혼잡도", "강남 사람 많아?", "지금 이태원").
   Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구", "지금 ~ 어때".
@@ -142,7 +150,11 @@ Phase 1 (active):
 - BOOKING: requesting a reservation or booking link
 - CALENDAR: adding an event to calendar
 - FAVORITE: bookmarking or favoriting something
-- REVIEW_COMPARE: comparing two or more places by 6 metrics
+- REVIEW_COMPARE: comparing two or more places by 6 metrics.
+  Trigger keywords REQUIRED: "비교", "리뷰 비교", "어디가 더", "어느 쪽이", "어느 게 더", "더 좋아".
+  Without these explicit comparison keywords, classify as DETAIL_INQUIRY or GENERAL even if
+  multiple places are mentioned (Korean connectors like "이랑", "와", "과", "vs" alone are NOT enough).
+  NOT REVIEW_COMPARE: "A랑 B 어디야?" → GENERAL/DETAIL_INQUIRY, "A 그리고 B 가격" → COST_ESTIMATE.
 - CROWDEDNESS: asking about current crowdedness, busyness, or population density of an area.
   Accept noun-phrase queries without verbs (e.g. "홍대 혼잡도", "강남 사람 많아?", "지금 이태원").
   Trigger keywords: "혼잡", "혼잡도", "붐비", "사람 많", "사람 적", "한산", "유동인구", "생활인구", "지금 ~ 어때".

--- a/backend/src/graph/response_builder_node.py
+++ b/backend/src/graph/response_builder_node.py
@@ -32,6 +32,8 @@ _EXPECTED_BLOCK_ORDER: dict[str, list[str]] = {
     "EVENT_RECOMMEND": ["intent", "events", "text_stream", "done"],
     "COURSE_PLAN": ["intent", "text_stream", "course", "done"],
     "DETAIL_INQUIRY": ["intent", "text_stream", "done"],
+    # 기획서 §4.5: chart 누락 silent 회귀 방지 — 신규 ChartBlock 의존 패널 추적용.
+    "REVIEW_COMPARE": ["intent", "text_stream", "chart", "analysis_sources", "done"],
 }
 
 # 선택적 블록 — 있어도 되고 없어도 되는 블록 (순서 검증에서 제외)

--- a/backend/src/graph/review_compare_node.py
+++ b/backend/src/graph/review_compare_node.py
@@ -92,68 +92,105 @@ async def _fetch_places_pg(
     return results
 
 
+# 6지표 키 고정 (analysis_node._VALID_SCORE_KEYS와 동일 — DRY 위해 별도 정의보다 import도 가능하지만
+# 본 노드 단독에서 chart axis fill에만 사용되므로 분리. analysis_node와 일치 유지 필수 — 불변식 #6).
+_VALID_SCORE_KEYS: frozenset[str] = frozenset(
+    {"satisfaction", "accessibility", "cleanliness", "value", "atmosphere", "expertise"}
+)
+
+# 비교 키워드 self-check — intent_router 오분류 backstop.
+# "비교" 동사·명사 / "어느"·"어디가 더" 선택 의문 / "리뷰"(스코어 비교 전제) 셋 중 하나는 있어야 비교 의도로 인정.
+_COMPARE_KEYWORDS: frozenset[str] = frozenset({"비교", "어느", "어디가 더", "리뷰"})
+
+
+def _fill_score_keys(scores: dict[str, float]) -> dict[str, float]:
+    """6 지표 키 중 누락된 것은 0.0으로 fill. 차트 axis 누락 방지 — 불변식 #6.
+
+    원본 점수가 빈 dict이면 6 키 모두 0.0 — FE가 'no data' 차트를 명시적으로 그릴 수 있음.
+    """
+    return {k: float(scores.get(k, 0.0)) for k in _VALID_SCORE_KEYS}
+
+
 async def _fetch_scores_os(
     os_client: Any,
     place_ids: list[str],
-) -> dict[str, dict[str, float]]:
-    """place_ids → OS place_reviews._raw_scores mget 1회 조회."""
+) -> tuple[dict[str, dict[str, float]], dict[str, int]]:
+    """place_ids → OS place_reviews._raw_scores + review_count mget 1회 조회.
+
+    Returns:
+        (scores_map, review_count_map). 둘 다 place_id → 값 dict. 실패 시 빈 dict 짝.
+        review_count_map은 analysis_sources.review_count 합산용 (analysis_node 패턴).
+    """
     from src.utils.resilience import retry_call  # pyright: ignore[reportMissingImports]
 
     if not place_ids:
-        return {}
+        return {}, {}
     doc_ids = [f"review_{pid}" for pid in place_ids]
     try:
         mget_resp = await retry_call(
             lambda: os_client.mget(
                 body={"ids": doc_ids},
                 index="place_reviews",
-                _source=["_raw_scores", "place_id"],
+                _source=["_raw_scores", "review_count", "place_id"],
             ),
             attempts=3,
         )
         scores_map: dict[str, dict[str, float]] = {}
+        review_count_map: dict[str, int] = {}
         for hit in mget_resp.get("docs", []):
             if hit.get("found"):
                 src = hit.get("_source", {})
                 pid = src.get("place_id", "")
+                if not pid:
+                    continue
                 raw = src.get("_raw_scores", {})
-                if pid and isinstance(raw, dict):
+                if isinstance(raw, dict):
                     scores_map[pid] = {k: float(v) for k, v in raw.items() if isinstance(v, (int, float))}
-        return scores_map
+                rc = src.get("review_count", 0)
+                review_count_map[pid] = int(rc) if rc is not None else 0
+        return scores_map, review_count_map
     except Exception:
         logger.exception("_fetch_scores_os: OS mget 실패")
-        return {}
+        return {}, {}
 
 
 def _build_compare_blocks(
     query: str,
     places: list[dict[str, Any]],
     scores_map: dict[str, dict[str, float]],
+    review_count_map: dict[str, int],
 ) -> list[dict[str, Any]]:
-    """text_stream + chart + analysis_sources raw dict 블록 생성."""
-    compare_lines = []
-    for p in places:
-        pid = p["place_id"]
-        scores = scores_map.get(pid, {})
-        score_str = ", ".join(f"{k}: {v:.1f}" for k, v in scores.items()) if scores else "데이터 없음"
-        compare_lines.append(f"- {p['name']} ({p.get('category', '')}): {score_str}")
+    """text_stream + chart + analysis_sources raw dict 블록 생성.
 
-    compare_text = "\n".join(compare_lines)
+    text_stream prompt에는 raw 점수를 포함하지 않는다 — 수치는 chart 블록 단독 책임.
+    Gemini가 점수를 prose로 풀어 출력하면 차트가 무의미해지고 화면이 줄글로 덮임.
+    """
+    place_names = ", ".join(p["name"] for p in places)
+    place_lines = "\n".join(f"- {p['name']} ({p.get('category', '')})" for p in places)
 
     return [
         {
             "type": "text_stream",
             "system": _COMPARE_SYSTEM_PROMPT,
-            "prompt": f"사용자 질문: {query}\n\n장소 비교:\n{compare_text}",
+            "prompt": (
+                f"사용자 질문: {query}\n\n"
+                f"비교 장소:\n{place_lines}\n\n"
+                "(6지표 점수는 레이더 차트로 별도 시각화됩니다. "
+                f"{place_names} 각 장소의 강점·약점·추천 상황을 한국어 1-2 문장으로만 요약하세요. "
+                "구체적인 점수 수치는 절대 언급하지 마세요.)"
+            ),
         },
         {
             "type": "chart",
             "chart_type": "radar",
-            "places": [{"name": p["name"], "scores": scores_map.get(p["place_id"], {})} for p in places],
+            "places": [
+                {"name": p["name"], "scores": _fill_score_keys(scores_map.get(p["place_id"], {}))} for p in places
+            ],
         },
         {
             "type": "analysis_sources",
-            "review_count": len([p for p in places if scores_map.get(p["place_id"])]),
+            # 비교 장소 전체의 리뷰 합산 — analysis_node 패턴.
+            "review_count": sum(review_count_map.get(p["place_id"], 0) for p in places),
         },
     ]
 
@@ -197,6 +234,28 @@ async def review_compare_node(state: dict[str, Any]) -> dict[str, Any]:
             ]
         }
 
+    # 비교 키워드 self-check — intent_router 오분류 backstop.
+    # 2 장소가 추출돼도 사용자가 "비교/리뷰/어디가 더" 같은 비교 의도를 명시하지 않으면 안내로 빠진다.
+    # 예) "A랑 B 어디냐?" 는 위치 질문(DETAIL_INQUIRY 영역)이지 비교가 아님.
+    if not any(kw in query for kw in _COMPARE_KEYWORDS):
+        logger.info(
+            "review_compare_node: 비교 키워드 없음 query_len=%d places=%d → disambiguation",
+            len(query),
+            len(place_names),
+        )
+        return {
+            "response_blocks": [
+                {
+                    "type": "disambiguation",
+                    "message": (
+                        "두 장소를 비교하시려는 거라면 '리뷰 비교해줘'라고 말씀해 주세요. "
+                        "위치나 정보가 궁금하시면 한 장소씩 물어봐 주세요."
+                    ),
+                    "candidates": [],
+                }
+            ]
+        }
+
     from src.db.opensearch import get_os_client  # pyright: ignore[reportMissingImports]
     from src.db.postgres import get_pool  # pyright: ignore[reportMissingImports]
 
@@ -229,7 +288,7 @@ async def review_compare_node(state: dict[str, Any]) -> dict[str, Any]:
             ]
         }
 
-    scores_map = await _fetch_scores_os(os_client, [p["place_id"] for p in places])
-    blocks = _build_compare_blocks(query, places, scores_map)
+    scores_map, review_count_map = await _fetch_scores_os(os_client, [p["place_id"] for p in places])
+    blocks = _build_compare_blocks(query, places, scores_map, review_count_map)
 
     return {"response_blocks": blocks}

--- a/backend/tests/test_review_compare_node.py
+++ b/backend/tests/test_review_compare_node.py
@@ -114,7 +114,8 @@ async def test_build_compare_blocks_success() -> None:
         },
     }
 
-    blocks = _build_compare_blocks("스타벅스 vs 블루보틀 비교", places, scores_map)
+    review_count_map = {"uuid-1": 12, "uuid-2": 30}
+    blocks = _build_compare_blocks("스타벅스 vs 블루보틀 비교", places, scores_map, review_count_map)
 
     assert len(blocks) == 3
 
@@ -135,14 +136,15 @@ async def test_build_compare_blocks_success() -> None:
         "atmosphere",
         "expertise",
     }
+    assert set(chart["places"][1]["scores"].keys()) == set(chart["places"][0]["scores"].keys())
 
     src = blocks[2]
     assert src["type"] == "analysis_sources"
-    assert src["review_count"] == 2
+    assert src["review_count"] == 42
 
 
 async def test_build_compare_blocks_no_scores() -> None:
-    """OS 문서 없는 장소 → scores={} → 에러 없이 chart.places에 포함."""
+    """OS 문서 없는 장소 → scores 빈 dict → 6 키 0.0 fill (#214)."""
     from src.graph.review_compare_node import _build_compare_blocks  # pyright: ignore[reportMissingImports]
 
     places: list[dict[str, Any]] = [
@@ -150,13 +152,90 @@ async def test_build_compare_blocks_no_scores() -> None:
         {"place_id": "uuid-2", "name": "장소B", "category": "카페"},
     ]
 
-    blocks = _build_compare_blocks("장소A vs 장소B", places, {})
+    blocks = _build_compare_blocks("장소A vs 장소B 비교", places, {}, {})
 
     chart = blocks[1]
     assert len(chart["places"]) == 2
-    assert chart["places"][0]["scores"] == {}
-    assert chart["places"][1]["scores"] == {}
+    for place_chart in chart["places"]:
+        assert set(place_chart["scores"].keys()) == {
+            "satisfaction",
+            "accessibility",
+            "cleanliness",
+            "value",
+            "atmosphere",
+            "expertise",
+        }
+        assert all(v == 0.0 for v in place_chart["scores"].values())
     assert blocks[2]["review_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# #214 회귀 — text_stream prompt에 raw 점수 leak 금지 + 비교 키워드 self-check
+# ---------------------------------------------------------------------------
+def test_build_compare_blocks_text_stream_does_not_leak_scores() -> None:
+    """text_stream prompt에 점수 수치/지표명이 leak되면 안 됨 (#214 C1)."""
+    from src.graph.review_compare_node import _build_compare_blocks  # pyright: ignore[reportMissingImports]
+
+    places: list[dict[str, Any]] = [
+        {"place_id": "p1", "name": "A", "category": "카페"},
+        {"place_id": "p2", "name": "B", "category": "카페"},
+    ]
+    scores_map: dict[str, dict[str, float]] = {
+        "p1": {"satisfaction": 4.9, "value": 2.5, "cleanliness": 4.9},
+        "p2": {"satisfaction": 4.5, "value": 3.0, "cleanliness": 4.7},
+    }
+
+    blocks = _build_compare_blocks("A vs B 비교", places, scores_map, {"p1": 5, "p2": 5})
+
+    prompt: str = blocks[0]["prompt"]
+    forbidden_score_tokens = ("4.9", "2.5", "4.5", "3.0", "4.7", "5.0", "/5", "/5.0")
+    for tok in forbidden_score_tokens:
+        assert tok not in prompt, f"prompt에 점수 leak: {tok!r}"
+    for key in ("satisfaction", "accessibility", "cleanliness", "value", "atmosphere", "expertise"):
+        assert key not in prompt, f"prompt에 지표 키 leak: {key!r}"
+
+
+def test_build_compare_blocks_chart_has_six_metric_keys() -> None:
+    """chart.places[].scores는 항상 6 키 모두 보유 (#214 M2)."""
+    from src.graph.review_compare_node import _build_compare_blocks  # pyright: ignore[reportMissingImports]
+
+    places: list[dict[str, Any]] = [
+        {"place_id": "p1", "name": "A", "category": "카페"},
+        {"place_id": "p2", "name": "B", "category": "카페"},
+    ]
+    scores_map = {"p1": {"satisfaction": 4.0}, "p2": {}}
+
+    blocks = _build_compare_blocks("A 비교 B", places, scores_map, {})
+
+    expected_keys = {"satisfaction", "accessibility", "cleanliness", "value", "atmosphere", "expertise"}
+    for place_chart in blocks[1]["places"]:
+        assert set(place_chart["scores"].keys()) == expected_keys
+
+
+async def test_review_compare_node_no_compare_keyword_returns_disambiguation() -> None:
+    """비교 키워드 없는 쿼리("A랑 B 어디냐?")는 intent_router 오분류 backstop으로 안내로 빠짐 (#214 H3)."""
+    from src.graph.review_compare_node import review_compare_node  # pyright: ignore[reportMissingImports]
+
+    state: dict[str, Any] = {
+        "query": "물포곤 청담점이랑 광화문점 어디냐?",
+        "processed_query": {"keywords": ["물포곤 청담점", "광화문점"]},
+    }
+
+    result = await review_compare_node(state)
+    blocks = result["response_blocks"]
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "disambiguation"
+    msg = blocks[0]["message"]
+    assert "비교" in msg or "리뷰 비교" in msg
+
+
+def test_intent_router_review_compare_requires_trigger_keyword() -> None:
+    """intent_router 분류 프롬프트 양쪽에 REVIEW_COMPARE trigger keyword 필수 명시 (#214 H2)."""
+    from src.graph.intent_router_node import _CLASSIFY_MULTI_SYSTEM_PROMPT, _CLASSIFY_SYSTEM_PROMPT
+
+    for prompt in (_CLASSIFY_SYSTEM_PROMPT, _CLASSIFY_MULTI_SYSTEM_PROMPT):
+        assert "Trigger keywords REQUIRED" in prompt, "REVIEW_COMPARE trigger keyword 명시 누락"
+        assert "NOT REVIEW_COMPARE" in prompt, "REVIEW_COMPARE 부정 예시 누락"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Plan: ~/.claude/plans/polymorphic-questing-biscuit.md

## 수정
- text_stream prompt에서 raw 6지표 점수 제거 (chart 단독 책임)
- response_builder _EXPECTED_BLOCK_ORDER에 REVIEW_COMPARE 추가
- intent_router 분류 프롬프트 양쪽 trigger keyword 필수 명시
- review_compare_node 진입부 비교 키워드 self-check
- _fetch_scores_os가 review_count_map도 반환, analysis_sources 의미 정정
- chart.places[].scores 6 키 fill 가드
- 회귀 테스트 4건

## 검증
- ruff/format/pyright 통과
- 13 tests pass (기존 9 + 신규 4)

## 운영 통합 테스트 (dev 머지 후)
- '물포곤 청담점이랑 광화문점 리뷰 비교해줘' → chart + 짧은 텍스트 요약
- '물포곤 청담점이랑 광화문점 어디냐?' → GENERAL/DETAIL_INQUIRY (비교 안 됨)
- '물포곤 청담점 리뷰' → disambiguation

Refs: #214