### PR TITLE
[Perf] P0-2: query_preprocessor 정규식 prefilter (정확도 우선판) (#218)

### DIFF
--- a/backend/src/graph/query_preprocessor_node.py
+++ b/backend/src/graph/query_preprocessor_node.py
@@ -164,6 +164,18 @@ async def _extract_query_fields(
         result.setdefault("expanded_query", query)
         result.setdefault("keywords", [])
 
+        # P0-2: 정규식 prefilter로 LLM 빈 필드를 보완 (정확도 우선 — overwrite 안 함)
+        try:
+            from src.utils.query_regex import extract_regex_fields  # pyright: ignore[reportMissingImports]
+
+            today_date = date.fromisoformat(today_str)
+            regex_result = extract_regex_fields(query, today_date)
+            for k, v in regex_result.items():
+                if result.get(k) is None:
+                    result[k] = v
+        except Exception:
+            logger.exception("query_regex 보완 실패 — LLM 결과만 사용")
+
         # date_*_resolved 보장 + ISO "YYYY-MM-DD" 형식 검증 (Gemini 응답 후처리)
         # Gemini가 잘못된 형식("2026/05/16", "다음 주" 등) 반환 시 None으로 정정
         result.setdefault("date_start_resolved", None)

--- a/backend/src/utils/query_regex.py
+++ b/backend/src/utils/query_regex.py
@@ -1,0 +1,204 @@
+"""쿼리에서 구조화 필드를 정규식으로 추출 (LLM 호출 없이 명확 매칭).
+
+`query_preprocessor` 노드가 LLM 응답 후 이 결과로 district/category/date/time을
+보완한다. 모호 케이스는 비워두고 LLM 응답을 그대로 유지한다 — 정확도 우선.
+
+재사용: 향후 P1-2(course_plan 카테고리 정규식), P1-4(calendar 시간 정규식)에서
+같은 모듈 import.
+"""
+
+from __future__ import annotations
+
+import re
+from calendar import monthrange
+from datetime import date, timedelta
+from typing import Any, Optional
+
+from src.utils.geo_mapping import NEIGHBORHOOD_TO_DISTRICT  # pyright: ignore[reportMissingImports]
+
+# 서울 25개 자치구 — 직접 매칭 (예: "강남구 카페")
+SEOUL_DISTRICTS: frozenset[str] = frozenset(
+    {
+        "강남구",
+        "강동구",
+        "강북구",
+        "강서구",
+        "관악구",
+        "광진구",
+        "구로구",
+        "금천구",
+        "노원구",
+        "도봉구",
+        "동대문구",
+        "동작구",
+        "마포구",
+        "서대문구",
+        "서초구",
+        "성동구",
+        "성북구",
+        "송파구",
+        "양천구",
+        "영등포구",
+        "용산구",
+        "은평구",
+        "종로구",
+        "중구",
+        "중랑구",
+    }
+)
+
+_DISTRICT_PATTERN = re.compile("(" + "|".join(SEOUL_DISTRICTS) + ")")
+
+# 카테고리 정규식 — 명확 키워드만. value는 정규화된 카테고리명.
+_CATEGORY_KEYWORDS: dict[str, str] = {
+    "카페": "카페",
+    "커피": "카페",
+    "디저트": "카페",
+    "음식점": "음식점",
+    "맛집": "음식점",
+    "식당": "음식점",
+    "레스토랑": "음식점",
+    "전시": "전시회",
+    "전시회": "전시회",
+    "축제": "축제",
+    "페스티벌": "축제",
+    "호텔": "호텔",
+    "모텔": "모텔",
+    "숙박": "숙박",
+    "게스트하우스": "숙박",
+    "펜션": "숙박",
+}
+
+# 긴 키워드 우선 매칭 — "전시회"가 "전시"보다 먼저 매치되게
+_CATEGORY_PATTERN = re.compile("(" + "|".join(sorted(_CATEGORY_KEYWORDS.keys(), key=len, reverse=True)) + ")")
+
+# 날짜 — 명확 패턴만. "다음 주", "주말" 등 모호 표현은 LLM 위임.
+_DATE_KEYWORDS_RELATIVE: dict[str, int] = {
+    "오늘": 0,
+    "내일": 1,
+    "모레": 2,
+    "글피": 3,
+}
+
+_DATE_ISO_PATTERN = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+_DATE_MONTH_DAY_PATTERN = re.compile(r"(\d{1,2})\s*월\s*(\d{1,2})\s*일")
+_DATE_MONTH_ONLY_PATTERN = re.compile(r"(?<!\d)(\d{1,2})\s*월(?!\s*\d)")
+
+_TIME_HH_PATTERN = re.compile(r"(오전|오후)?\s*(\d{1,2})\s*시")
+_TIME_KEYWORD_PATTERN = re.compile(r"(새벽|아침|점심|저녁|밤)")
+
+
+def extract_regex_fields(query: str, today: Optional[date] = None) -> dict[str, Any]:
+    """쿼리에서 정규식으로 추출 가능한 필드만 반환.
+
+    매치되지 않은 필드는 dict에 포함되지 않아 LLM 결과를 보존한다.
+
+    Args:
+        query: 사용자 원본 쿼리.
+        today: 기준 날짜. None이면 ``date.today()``.
+
+    Returns:
+        매치된 필드만 포함하는 dict (district/neighborhood/category/date_*/time_reference).
+    """
+    if not query:
+        return {}
+    # 입력 길이 가드 — 동네명 substring 루프가 O(k×n)이므로 비정상 입력으로부터 보호
+    query = query[:500]
+    result: dict[str, Any] = {}
+    today_resolved = today or date.today()
+
+    district_match = _DISTRICT_PATTERN.search(query)
+    if district_match:
+        result["district"] = district_match.group(1)
+    else:
+        # 가장 긴 동네명 우선 매칭 (부분매칭 폭주 방지)
+        for key in sorted(NEIGHBORHOOD_TO_DISTRICT.keys(), key=len, reverse=True):
+            if key in query:
+                result["neighborhood"] = key
+                result["district"] = NEIGHBORHOOD_TO_DISTRICT[key]
+                break
+
+    category_match = _CATEGORY_PATTERN.search(query)
+    if category_match:
+        result["category"] = _CATEGORY_KEYWORDS[category_match.group(1)]
+
+    date_start, date_end, date_ref = _extract_date(query, today_resolved)
+    if date_ref:
+        result["date_reference"] = date_ref
+    if date_start:
+        result["date_start_resolved"] = date_start.isoformat()
+    if date_end:
+        result["date_end_resolved"] = date_end.isoformat()
+
+    time_ref = _extract_time(query)
+    if time_ref:
+        result["time_reference"] = time_ref
+
+    return result
+
+
+def _extract_date(query: str, today: date) -> tuple[Optional[date], Optional[date], Optional[str]]:
+    """명확 날짜 패턴만 추출. 모호 표현은 None 반환 → LLM 위임."""
+    iso_match = _DATE_ISO_PATTERN.search(query)
+    if iso_match:
+        try:
+            d = date(
+                int(iso_match.group(1)),
+                int(iso_match.group(2)),
+                int(iso_match.group(3)),
+            )
+            return d, d, f"{iso_match.group(1)}-{iso_match.group(2)}-{iso_match.group(3)}"
+        except ValueError:
+            pass
+
+    md_match = _DATE_MONTH_DAY_PATTERN.search(query)
+    if md_match:
+        try:
+            month = int(md_match.group(1))
+            day = int(md_match.group(2))
+            year = today.year
+            d = date(year, month, day)
+            if d < today:
+                d = date(year + 1, month, day)
+            return d, d, f"{month}월 {day}일"
+        except ValueError:
+            pass
+
+    for keyword, offset in _DATE_KEYWORDS_RELATIVE.items():
+        if keyword in query:
+            d = today + timedelta(days=offset)
+            return d, d, keyword
+
+    m_only_match = _DATE_MONTH_ONLY_PATTERN.search(query)
+    if m_only_match:
+        try:
+            month = int(m_only_match.group(1))
+            if 1 <= month <= 12:
+                year = today.year if month >= today.month else today.year + 1
+                start = date(year, month, 1)
+                end = date(year, month, monthrange(year, month)[1])
+                return start, end, f"{month}월"
+        except ValueError:
+            pass
+
+    return None, None, None
+
+
+def _extract_time(query: str) -> Optional[str]:
+    """시간 표현 추출."""
+    hh_match = _TIME_HH_PATTERN.search(query)
+    if hh_match:
+        prefix = hh_match.group(1) or ""
+        hour = hh_match.group(2)
+        try:
+            h = int(hour)
+            if 0 <= h <= 24:
+                return (prefix + f" {h}시").strip()
+        except ValueError:
+            pass
+
+    kw_match = _TIME_KEYWORD_PATTERN.search(query)
+    if kw_match:
+        return kw_match.group(1)
+
+    return None

--- a/backend/tests/test_query_regex.py
+++ b/backend/tests/test_query_regex.py
@@ -1,0 +1,177 @@
+"""query_regex 단위 테스트.
+
+LLM 호출 없이 정규식 단독 동작을 검증.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from src.utils.query_regex import extract_regex_fields  # pyright: ignore[reportMissingImports]
+
+_TODAY = date(2026, 5, 14)  # 목요일
+
+
+@pytest.mark.parametrize(
+    "query, expected_district",
+    [
+        ("강남구 분위기 좋은 카페", "강남구"),
+        ("마포구 전시회", "마포구"),
+        ("종로구 한식 맛집", "종로구"),
+        ("서초구 호텔", "서초구"),
+        ("중구 명동 추천", "중구"),
+    ],
+)
+def test_district_direct_match(query: str, expected_district: str) -> None:
+    result = extract_regex_fields(query, today=_TODAY)
+    assert result.get("district") == expected_district
+
+
+@pytest.mark.parametrize(
+    "query, expected_district, expected_neighborhood",
+    [
+        ("홍대 카페 추천", "마포구", "홍대"),
+        ("이태원 맛집", "용산구", "이태원"),
+        ("성수동 전시", "성동구", "성수동"),
+        ("강남역 근처", "강남구", "강남역"),
+    ],
+)
+def test_neighborhood_to_district(query: str, expected_district: str, expected_neighborhood: str) -> None:
+    result = extract_regex_fields(query, today=_TODAY)
+    assert result.get("district") == expected_district
+    assert result.get("neighborhood") == expected_neighborhood
+
+
+@pytest.mark.parametrize(
+    "query, expected_category",
+    [
+        ("강남 카페", "카페"),
+        ("홍대 디저트", "카페"),
+        ("종로 맛집", "음식점"),
+        ("이태원 레스토랑", "음식점"),
+        ("DDP 전시회", "전시회"),
+        ("한강 축제", "축제"),
+        ("강남 호텔", "호텔"),
+        ("종로 게스트하우스", "숙박"),
+    ],
+)
+def test_category(query: str, expected_category: str) -> None:
+    result = extract_regex_fields(query, today=_TODAY)
+    assert result.get("category") == expected_category
+
+
+def test_category_long_first() -> None:
+    """'전시회'가 '전시'보다 우선 매치되어야 한다."""
+    result = extract_regex_fields("이번 전시회", today=_TODAY)
+    assert result.get("category") == "전시회"
+
+
+def test_date_iso() -> None:
+    result = extract_regex_fields("2026-12-25 행사", today=_TODAY)
+    assert result.get("date_start_resolved") == "2026-12-25"
+    assert result.get("date_end_resolved") == "2026-12-25"
+
+
+def test_date_month_day_future() -> None:
+    """미래 N월 N일 — 같은 해."""
+    result = extract_regex_fields("8월 15일 행사", today=_TODAY)
+    assert result.get("date_start_resolved") == "2026-08-15"
+
+
+def test_date_month_day_past_rolls_to_next_year() -> None:
+    """과거 N월 N일은 내년으로 보정."""
+    result = extract_regex_fields("3월 1일 일정", today=_TODAY)
+    assert result.get("date_start_resolved") == "2027-03-01"
+
+
+@pytest.mark.parametrize(
+    "query, expected_offset, expected_ref",
+    [
+        ("오늘 카페", 0, "오늘"),
+        ("내일 전시", 1, "내일"),
+        ("모레 약속", 2, "모레"),
+    ],
+)
+def test_date_relative(query: str, expected_offset: int, expected_ref: str) -> None:
+    result = extract_regex_fields(query, today=_TODAY)
+    expected = (_TODAY + timedelta(days=expected_offset)).isoformat()
+    assert result.get("date_reference") == expected_ref
+    assert result.get("date_start_resolved") == expected
+
+
+def test_date_month_only() -> None:
+    """'3월' 단독 — 해당 월 전체."""
+    result = extract_regex_fields("3월 축제", today=_TODAY)
+    assert result.get("date_start_resolved") == "2027-03-01"
+    assert result.get("date_end_resolved") == "2027-03-31"
+
+
+def test_date_ambiguous_returns_nothing() -> None:
+    """'다음 주' '주말' 같은 모호 표현은 정규식이 채우지 않음 (LLM 위임)."""
+    result = extract_regex_fields("다음 주 카페", today=_TODAY)
+    assert "date_start_resolved" not in result
+    assert "date_reference" not in result
+
+
+@pytest.mark.parametrize(
+    "query, expected_time",
+    [
+        ("오후 2시 약속", "오후 2시"),
+        ("오전 9시 회의", "오전 9시"),
+        ("3시에 만나자", "3시"),
+        ("저녁에 보자", "저녁"),
+        ("아침 일찍", "아침"),
+    ],
+)
+def test_time(query: str, expected_time: str) -> None:
+    result = extract_regex_fields(query, today=_TODAY)
+    assert result.get("time_reference") == expected_time
+
+
+def test_combined_fields() -> None:
+    result = extract_regex_fields("내일 오후 2시 홍대 카페", today=_TODAY)
+    assert result.get("district") == "마포구"
+    assert result.get("neighborhood") == "홍대"
+    assert result.get("category") == "카페"
+    assert result.get("date_reference") == "내일"
+    assert result.get("date_start_resolved") == "2026-05-15"
+    assert result.get("time_reference") == "오후 2시"
+
+
+def test_empty_query() -> None:
+    assert extract_regex_fields("", today=_TODAY) == {}
+
+
+def test_no_match_returns_empty() -> None:
+    """매치되지 않는 쿼리는 빈 dict — LLM 응답을 전부 보존."""
+    result = extract_regex_fields("그냥 추천해줘", today=_TODAY)
+    assert result == {}
+
+
+def test_invalid_month_day() -> None:
+    """잘못된 월일은 매치되지 않음 (예외 처리)."""
+    result = extract_regex_fields("13월 32일", today=_TODAY)
+    assert "date_start_resolved" not in result
+
+
+def test_explicit_date_wins_over_relative_keyword() -> None:
+    """'오늘 8월 15일' 같은 충돌 케이스 — 명시 N월 N일이 우선."""
+    result = extract_regex_fields("오늘 8월 15일 축제", today=_TODAY)
+    assert result.get("date_reference") == "8월 15일"
+    assert result.get("date_start_resolved") == "2026-08-15"
+
+
+def test_iso_date_wins_over_relative_keyword() -> None:
+    """ISO 날짜가 상대 키워드보다 우선."""
+    result = extract_regex_fields("내일 2026-08-15 행사", today=_TODAY)
+    assert result.get("date_start_resolved") == "2026-08-15"
+
+
+def test_long_input_truncated_safely() -> None:
+    """500자 초과 입력에서도 정상 동작."""
+    long_query = "강남 카페 " + "x" * 1000
+    result = extract_regex_fields(long_query, today=_TODAY)
+    assert result.get("district") == "강남구"
+    assert result.get("category") == "카페"


### PR DESCRIPTION
closes #218. 자세한 변경 내용·트레이드오프는 이슈 #218 참조. 38 단위 테스트 PASS. LLM 호출 빈도 동일, district/category/date/time 정확도 향상.