### PR TITLE
[Perf] P1-3: refine _parse_refinement 정규식 prefilter (#224)

### DIFF
--- a/backend/src/graph/refine_node.py
+++ b/backend/src/graph/refine_node.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Optional
 
 from pydantic import BaseModel
@@ -44,6 +45,40 @@ class RefinementInstruction(BaseModel):
 
 
 _VALID_ACTIONS = frozenset({"replace", "remove", "add", "change_condition", "regenerate"})
+
+# P1-3: 정규식 prefilter — 명확 수정 지시는 LLM 호출 skip
+_REGEX_REMOVE = re.compile(r"(?P<idx>[1-9]\d?)\s*번\s*(빼|삭제|제거|지워)")
+_REGEX_REPLACE = re.compile(r"(?P<idx>[1-9]\d?)\s*번\s*(바꿔|교체|변경)")
+_REGEX_ADD = re.compile(r"(하나\s*더|한\s*개\s*더|추가해)")
+_REGEX_REGENERATE = re.compile(r"(다시\s*(해|만들)|마음에\s*안|별로|싫어|새로)")
+
+
+def _try_regex_parse(query: str) -> Optional[RefinementInstruction]:
+    """명확 수정 패턴을 정규식으로 직접 파싱. 매치 안 되면 None → LLM 위임."""
+    m = _REGEX_REMOVE.search(query)
+    if m:
+        return RefinementInstruction(
+            action="remove",
+            target_index=int(m.group("idx")),
+            full_instruction=query,
+        )
+
+    m = _REGEX_REPLACE.search(query)
+    if m:
+        return RefinementInstruction(
+            action="replace",
+            target_index=int(m.group("idx")),
+            full_instruction=query,
+        )
+
+    if _REGEX_ADD.search(query):
+        return RefinementInstruction(action="add", full_instruction=query)
+
+    if _REGEX_REGENERATE.search(query):
+        return RefinementInstruction(action="regenerate", full_instruction=query)
+
+    return None
+
 
 # 구조화 블록 → 원본 intent 매핑
 _BLOCK_TYPE_TO_INTENT: dict[str, str] = {
@@ -285,8 +320,19 @@ async def _parse_refinement(
 ) -> RefinementInstruction:
     """Gemini JSON mode로 수정 지시 파싱.
 
+    P1-3: 명확 패턴은 정규식으로 직접 파싱 (LLM 호출 skip).
     실패 시 regenerate fallback.
     """
+    # P1-3: 정규식 prefilter
+    regex_result = _try_regex_parse(query)
+    if regex_result is not None:
+        logger.info(
+            "refine_node: regex parsed action=%s target_index=%s (LLM skip)",
+            regex_result.action,
+            regex_result.target_index,
+        )
+        return regex_result
+
     try:
         from langchain_google_genai import ChatGoogleGenerativeAI  # pyright: ignore[reportMissingImports]
 

--- a/backend/tests/test_refine_node.py
+++ b/backend/tests/test_refine_node.py
@@ -239,3 +239,48 @@ async def test_identify_target_skips_refine_self_response_for_course() -> None:
     # (명시적 참조 없으니 가장 최근 refineable = CALENDAR가 target.)
     assert intent == "CALENDAR"
     assert target is calendar_resp
+
+
+# ---------------------------------------------------------------------------
+# P1-3: _try_regex_parse — 정규식 prefilter
+# ---------------------------------------------------------------------------
+def test_regex_parse_remove() -> None:
+    from src.graph.refine_node import _try_regex_parse  # pyright: ignore[reportMissingImports]
+
+    r = _try_regex_parse("3번 빼줘")
+    assert r is not None
+    assert r.action == "remove"
+    assert r.target_index == 3
+
+
+def test_regex_parse_replace() -> None:
+    from src.graph.refine_node import _try_regex_parse  # pyright: ignore[reportMissingImports]
+
+    r = _try_regex_parse("2번 바꿔줘")
+    assert r is not None
+    assert r.action == "replace"
+    assert r.target_index == 2
+
+
+def test_regex_parse_regenerate() -> None:
+    from src.graph.refine_node import _try_regex_parse  # pyright: ignore[reportMissingImports]
+
+    r = _try_regex_parse("다시 해줘")
+    assert r is not None
+    assert r.action == "regenerate"
+
+
+def test_regex_parse_add() -> None:
+    from src.graph.refine_node import _try_regex_parse  # pyright: ignore[reportMissingImports]
+
+    r = _try_regex_parse("하나 더 추가해줘")
+    assert r is not None
+    assert r.action == "add"
+
+
+def test_regex_parse_no_match() -> None:
+    """모호 패턴은 None → LLM 위임."""
+    from src.graph.refine_node import _try_regex_parse  # pyright: ignore[reportMissingImports]
+
+    assert _try_regex_parse("강남 말고 홍대로 바꿔") is None  # 'N번' 없음
+    assert _try_regex_parse("좀 다른 거 보여줘") is None


### PR DESCRIPTION
closes #224. 명확 수정 패턴(N번 빼/바꿔, 다시, 추가)은 LLM 호출 없이 정규식만으로 RefinementInstruction 채움. 5 단위 테스트 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Refinement request processing optimized—standard refinement commands (remove, replace, add, regenerate) now execute faster by streamlining request handling and eliminating unnecessary processing steps.

* **Tests**
  * Added comprehensive regression tests validating refinement request parsing behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->