### PR TITLE
chore(deploy): GEMINI_LLM_API_KEY 를 GitHub secret 으로 통합 + 빈값 가드

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -57,6 +57,7 @@ jobs:
           GOOGLE_CALENDAR_CLIENT_SECRET=${GOOGLE_CALENDAR_CLIENT_SECRET}
           GOOGLE_CALENDAR_REDIRECT_URI=${GOOGLE_CALENDAR_REDIRECT_URI}
           GCS_BUCKET_NAME=${GCS_BUCKET_NAME}
+          GEMINI_LLM_API_KEY=${GEMINI_LLM_API_KEY}
           LOKI_HOST=10.178.0.4
           PROMTAIL_ENV=production
           EOF
@@ -71,12 +72,15 @@ jobs:
           cd backend
 
           # 시크릿 .env에 병합 — 시크릿 파일 경로는 $1 (없으면 레거시 경로)
+          # value 빈 라인은 skip — GitHub secret 미설정 시 .env의 기존 키를
+          # 빈값으로 덮어쓰는 사고 방지 (2026-06-05 GEMINI_LLM_API_KEY 갱신 사고 재발 방지).
           SECRETS_FILE="${1:-/tmp/secrets.env}"
           if [ -f "$SECRETS_FILE" ]; then
             while IFS= read -r line; do
               [ -z "$line" ] && continue
               key="${line%%=*}"
               value="${line#*=}"
+              [ -z "$value" ] && continue
               if grep -q "^${key}=" .env 2>/dev/null; then
                 grep -v "^${key}=" .env > .env.tmp
                 echo "${key}=${value}" >> .env.tmp
@@ -132,6 +136,7 @@ jobs:
           GOOGLE_CALENDAR_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}
           GOOGLE_CALENDAR_REDIRECT_URI: ${{ secrets.GOOGLE_CALENDAR_REDIRECT_URI }}
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
+          GEMINI_LLM_API_KEY: ${{ secrets.GEMINI_LLM_API_KEY }}
 
       # ②-c scp 전 선제 디스크 정리 — 디스크 풀 시 scp "write remote Failure" 방지(자가 치유).
       #     기존 정리는 deploy 스크립트 내부(scp 이후 실행)라, 디스크가 이미 차면 업로드 자체가


### PR DESCRIPTION
## Summary

- 2026-06-05 사고 재발 방지: `GEMINI_LLM_API_KEY` 를 deploy-dev.yml 의 시크릿 주입 경로에 추가
- 머지 루프에 **빈값 가드** 추가 — GitHub secret 미설정 시 GCE `.env` 의 기존 키를 빈값으로 덮어쓰는 사고 방지
- 변경: `.github/workflows/deploy-dev.yml` +5 / -0

## 사고 맥락

배포 BE 의 `GEMINI_LLM_API_KEY` 가 무효화 (`API key not valid` × 30회 / 1시간) → 모든 LLM 호출 실패 → SSE 가 응답 없이 hang → 사용자는 "코스 쿼리 응답 없음" 으로 인지. 임시 회복은 GCE `.env` 를 hand-patch 한 뒤 컨테이너 재생성으로 마무리했지만 (1Password / GitHub / GCE 3중 sync 깨짐), 다음 dev push 시 deploy-dev.yml 이 옛 키로 되돌릴 위험은 없어도 **신규 PC / 팀원 셋업 시 옛 키 받아서 동일 사고 재발** 가능.

이 PR 은 구조적으로 `GEMINI_LLM_API_KEY` 를 GitHub secret → runner → 시크릿 파일 → GCE `.env` 머지 경로에 포함시켜 단일 진실 공급원 (GitHub secret) 으로 통합.

## 변경 상세

1. **env 블록** — runner 가 `secrets.GEMINI_LLM_API_KEY` 를 환경변수로 노출
2. **시크릿 heredoc** — `GEMINI_LLM_API_KEY=${GEMINI_LLM_API_KEY}` 라인 추가 (unquoted heredoc → runner 치환)
3. **머지 루프 빈값 가드** — `[ -z \"\$value\" ] && continue` 추가. 시크릿 값이 빈 경우 (secret 미설정) `.env` 의 기존 라인을 건드리지 않음 → 사고 직후처럼 hand-patch 한 키 보존

## 사용자 직접 수행 필요 (머지 전 또는 머지 후 즉시)

- [ ] GitHub secret 등록: \`gh secret set GEMINI_LLM_API_KEY -R Techeer-2026-1/LocalBiz-Seoul\` (또는 Settings → Secrets and variables → Actions)
- [ ] 1Password \`AnyWay-Dev-Shared\` 의 \`GEMINI_LLM_API_KEY\` 새 키로 갱신
- [ ] 옛 키 (\`AIzaSyA-CbJ...\` 시작) Google AI Studio 에서 폐기

> secret 등록 전에 머지·배포되어도 빈값 가드 덕분에 GCE `.env` 의 hand-patch 한 키는 보존됨 (안전).

## Test plan

- [ ] PR 머지 → deploy-dev.yml 실행 → 헬스체크 통과
- [ ] 배포 후 코스 쿼리 / 일반 쿼리 둘 다 SSE done 이벤트까지 도달 확인 (검증 명령: docker logs api | grep -E "API key|Gemini streaming")
- [ ] secret 일시 unset 후 재배포 시 GCE `.env` 의 기존 키가 보존되는지 dry-run (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions deployment workflow to support new API key configuration in development environments.
  * Enhanced secrets merge logic in deployment scripts to properly handle blank lines and prevent existing environment variables from being accidentally overwritten with empty values when secrets are unset, improving deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->